### PR TITLE
fix: prevent editor data loss and UTF-8 corruption

### DIFF
--- a/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationKeyframeEditorViewModel.cs
+++ b/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationKeyframeEditorViewModel.cs
@@ -53,6 +53,7 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
         public CommandExecutor CommandExecutor { get => _commandExecutor; private set { _commandExecutor = value; } }
         private CommandExecutor _commandExecutor;
         private readonly IFileSaveService _packFileSaveService;
+        private readonly IStandardDialogs _standardDialogs;
         private SceneObject _newAnimation;
 
         public SceneObject Mount { get => _mount; private set { _mount = value; } }
@@ -169,7 +170,8 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
             SelectionManager selectionManager,
             GizmoComponent gizmoComponent,
             CommandExecutor commandExecutor,
-            IFileSaveService packFileSaveService)
+            IFileSaveService packFileSaveService,
+            IStandardDialogs standardDialogs)
         {
             _sceneObjectViewModelBuilder = sceneObjectViewModelBuilder;
             _animationPlayerViewModel = animationPlayerViewModel;
@@ -185,6 +187,7 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
             _gizmoComponent = gizmoComponent;
             _commandExecutor = commandExecutor;
             _packFileSaveService = packFileSaveService;
+            _standardDialogs = standardDialogs;
 
             SelectedRiderBone = new FilterCollection<SkeletonBoneNode>(null, (x) => UpdateCanSaveAndPreviewStates());
 
@@ -702,9 +705,10 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
 
             var animFile = _rider.AnimationClip.ConvertToFileFormat(_rider.Skeleton);
             var path = _rider.AnimationName.Value;
-            MessageBox.Show(LocalizationManager.Instance.GetFormat("Msg.SaveWithVersionAndPath", animFile.Header.Version, path), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButtons.OK, MessageBoxIcon.Information);
-            _packFileSaveService.Save(path, AnimationFile.ConvertToBytes(animFile), true);
-            IsDirty.Value = false;
+            _standardDialogs.ShowDialogBox(LocalizationManager.Instance.GetFormat("Msg.SaveWithVersionAndPath", animFile.Header.Version, path), LocalizationManager.Instance.Get("Msg.GeneralError"));
+            var savedFile = _packFileSaveService.Save(path, AnimationFile.ConvertToBytes(animFile), true);
+            if (savedFile != null)
+                IsDirty.Value = false;
         }
         public void SaveAs()
         {
@@ -716,10 +720,11 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
 
             var animFile = _rider.AnimationClip.ConvertToFileFormat(_rider.Skeleton);
 
-            MessageBox.Show(LocalizationManager.Instance.GetFormat("Msg.SaveWithVersion", animFile.Header.Version), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButtons.OK, MessageBoxIcon.Information);
+            _standardDialogs.ShowDialogBox(LocalizationManager.Instance.GetFormat("Msg.SaveWithVersion", animFile.Header.Version), LocalizationManager.Instance.Get("Msg.GeneralError"));
             var bytes = AnimationFile.ConvertToBytes(animFile);
-            _packFileSaveService.SaveAs(".anim", bytes);
-            IsDirty.Value = false;
+            var savedFile = _packFileSaveService.SaveAs(".anim", bytes);
+            if (savedFile != null)
+                IsDirty.Value = false;
         }
     }
 }

--- a/Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/AnimPackViewModel.cs
+++ b/Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/AnimPackViewModel.cs
@@ -78,7 +78,7 @@ namespace CommonControls.Editors.AnimationPack
 
         bool BeforeItemSelected(IAnimationPackFile item)
         {
-            if (SelectedItemViewModel != null && SelectedItemViewModel.HasUnsavedChanges())
+            if (HasUnsavedChildChanges())
             {
                 if (MessageBox.Show(LocalizationManager.Instance.Get("Msg.UnsavedChangesLost"), "", MessageBoxButton.YesNo) == MessageBoxResult.No)
                     return false;
@@ -129,11 +129,21 @@ namespace CommonControls.Editors.AnimationPack
         }
         public void Close() { }
         private bool _hasUnsavedChanges;
-        public bool HasUnsavedChanges { get => _hasUnsavedChanges; set => SetAndNotify(ref _hasUnsavedChanges, value); }
+        public bool HasUnsavedChanges
+        {
+            get => _hasUnsavedChanges || HasUnsavedChildChanges();
+            set => SetAndNotify(ref _hasUnsavedChanges, value);
+        }
 
         public PackFile CurrentFile => _packFile;
 
- 
+        private bool HasUnsavedChildChanges()
+        {
+            return TableEditorVM?.IsDirty == true ||
+                SelectedItemViewModel?.HasUnsavedChanges() == true;
+        }
+
+
         public bool SaveActiveFile()
         {
             if (_packFile == null)
@@ -142,13 +152,21 @@ namespace CommonControls.Editors.AnimationPack
                 return false;
             }
 
+            var tableDirty = TableEditorVM?.IsDirty == true;
+            var xmlDirty = SelectedItemViewModel?.HasUnsavedChanges() == true;
+            if (tableDirty && xmlDirty)
+                return false;
+
             var fileName = AnimationPackItems.SelectedItem.FileName;
             byte[] bytes;
             ITextConverter.SaveError? error;
+            var saveTable = (tableDirty && !xmlDirty) ||
+                (tableDirty == xmlDirty && IsTableView);
+            var tableEditorToSave = saveTable ? TableEditorVM : null;
 
-            if (IsTableView && TableEditorVM != null)
+            if (tableEditorToSave != null)
             {
-                bytes = TableEditorVM.SaveToBinary(fileName, out error);
+                bytes = tableEditorToSave.SaveToBinary(fileName, out error);
             }
             else
             {
@@ -167,7 +185,17 @@ namespace CommonControls.Editors.AnimationPack
             seletedFile.CreateFromBytes(bytes);
             seletedFile.IsChanged.Value = true;
 
-            SelectedItemViewModel.ResetChangeLog();
+            if (tableEditorToSave != null)
+            {
+                tableEditorToSave.IsDirty = false;
+                SelectedItemViewModel.Text = _activeConverter.GetText(bytes);
+                SelectedItemViewModel.ResetChangeLog();
+            }
+            else
+            {
+                SelectedItemViewModel.ResetChangeLog();
+                TableEditorVM?.LoadFromBinary(bytes, fileName);
+            }
             HasUnsavedChanges = true;
 
             return true;
@@ -182,9 +210,14 @@ namespace CommonControls.Editors.AnimationPack
                 return false;
             }
 
-            if (SelectedItemViewModel != null && SelectedItemViewModel.HasUnsavedChanges())
+            var tableDirty = TableEditorVM?.IsDirty == true;
+            var xmlDirty = SelectedItemViewModel?.HasUnsavedChanges() == true;
+            if (tableDirty && xmlDirty)
+                return false;
+
+            if (tableDirty || xmlDirty)
             {
-                if (MessageBox.Show(LocalizationManager.Instance.Get("Msg.SaveAnyway"), "", MessageBoxButton.YesNo) == MessageBoxResult.No)
+                if (!SaveActiveFile() || HasUnsavedChildChanges())
                     return false;
             }
 
@@ -196,13 +229,12 @@ namespace CommonControls.Editors.AnimationPack
             var savePath = _pfs.GetFullPath(_packFile);
 
             var result = _packFileSaveService.Save(savePath, AnimationPackSerializer.ConvertToBytes(newAnimPack), false);
-            if (result != null)
-            {
-                HasUnsavedChanges = false;
-                foreach (var file in AnimationPackItems.PossibleValues)
-                    file.IsChanged.Value = false;
-            }
+            if (result == null)
+                return false;
 
+            HasUnsavedChanges = false;
+            foreach (var file in AnimationPackItems.PossibleValues)
+                file.IsChanged.Value = false;
             return true;
         }
 

--- a/Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/Commands/CreateEmptyWarhammer3AnimSetFileCommand.cs
+++ b/Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/Commands/CreateEmptyWarhammer3AnimSetFileCommand.cs
@@ -20,9 +20,10 @@ namespace Editors.AnimationFragmentEditor.AnimationPack.Commands
             var animSet = CreateExampleWarhammer3AnimSet(fileName);
             editor.AnimationPackItems.PossibleValues.Add(animSet);
             editor.AnimationPackItems.UpdatePossibleValues(editor.AnimationPackItems.PossibleValues);
+            editor.HasUnsavedChanges = true;
         }
 
-        string? GetAnimSetFileName()
+        protected virtual string? GetAnimSetFileName()
         {
             var window = new TextInputWindow("Fragment name", "");
             if (window.ShowDialog() == true)

--- a/Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/Commands/RemoveSelectedFileCommand.cs
+++ b/Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/Commands/RemoveSelectedFileCommand.cs
@@ -7,7 +7,10 @@ namespace Editors.AnimationFragmentEditor.AnimationPack.Commands
     {
         public void Execute(AnimPackViewModel editor)
         {
-            editor.AnimationPackItems.PossibleValues.Remove(editor.AnimationPackItems.SelectedItem);
+            var selectedItem = editor.AnimationPackItems.SelectedItem;
+            if (selectedItem != null && editor.AnimationPackItems.PossibleValues.Remove(selectedItem))
+                editor.HasUnsavedChanges = true;
+
             editor.AnimationPackItems.RefreshFilter();
         }
 

--- a/Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/Commands/RenameSelectedFileCommand.cs
+++ b/Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/Commands/RenameSelectedFileCommand.cs
@@ -12,12 +12,24 @@ namespace Editors.AnimationFragmentEditor.AnimationPack.Commands
             if (animFile == null)
                 return;
 
-            var window = new TextInputWindow("Rename Anim File", animFile.FileName);
-            if (window.ShowDialog() == true)
-                animFile.FileName = window.TextValue;
+            var newFileName = GetNewFileName(animFile.FileName);
+            if (newFileName != null && newFileName != animFile.FileName)
+            {
+                animFile.FileName = newFileName;
+                editor.HasUnsavedChanges = true;
+            }
 
             // way to refresh the view
             editor.AnimationPackItems.RefreshFilter();
+        }
+
+        protected virtual string? GetNewFileName(string currentFileName)
+        {
+            var window = new TextInputWindow("Rename Anim File", currentFileName);
+            if (window.ShowDialog() == true)
+                return window.TextValue;
+
+            return null;
         }
     }
 

--- a/Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/ViewModels/AnimSetTableEditorViewModel.cs
+++ b/Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/ViewModels/AnimSetTableEditorViewModel.cs
@@ -1,7 +1,10 @@
 using System.Collections;
+using System.Collections.Specialized;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Input;
@@ -54,6 +57,8 @@ namespace Editors.AnimationFragmentEditor.AnimationPack.ViewModels
         private AnimationEntryRowViewModel? _selectedRow;
         private IList _multiSelectedRows = new List<AnimationEntryRowViewModel>();
         private ITextConverter? _activeConverter;
+        private bool _suppressDirtyTracking;
+        private readonly HashSet<AnimationEntryRowViewModel> _trackedRows = new();
 
         // Undo system - snapshot based (includes header metadata)
         private readonly Stack<TableSnapshot> _undoSnapshots = new();
@@ -123,20 +128,20 @@ namespace Editors.AnimationFragmentEditor.AnimationPack.ViewModels
         public ICommand? SaveCommand { get; set; }
 
         // WH3 header properties
-        public string Name { get => _name; set => SetAndNotify(ref _name, value); }
-        public string SkeletonName { get => _skeletonName; set => SetAndNotify(ref _skeletonName, value); }
-        public string MountBin { get => _mountBin; set => SetAndNotify(ref _mountBin, value); }
-        public string LocomotionGraph { get => _locomotionGraph; set => SetAndNotify(ref _locomotionGraph, value); }
-        public uint TableVersion { get => _tableVersion; set => SetAndNotify(ref _tableVersion, value); }
-        public uint TableSubVersion { get => _tableSubVersion; set => SetAndNotify(ref _tableSubVersion, value); }
-        public short UnknownValue1 { get => _unknownValue1; set => SetAndNotify(ref _unknownValue1, value); }
+        public string Name { get => _name; set => SetAndMarkDirty(ref _name, value); }
+        public string SkeletonName { get => _skeletonName; set => SetAndMarkDirty(ref _skeletonName, value); }
+        public string MountBin { get => _mountBin; set => SetAndMarkDirty(ref _mountBin, value); }
+        public string LocomotionGraph { get => _locomotionGraph; set => SetAndMarkDirty(ref _locomotionGraph, value); }
+        public uint TableVersion { get => _tableVersion; set => SetAndMarkDirty(ref _tableVersion, value); }
+        public uint TableSubVersion { get => _tableSubVersion; set => SetAndMarkDirty(ref _tableSubVersion, value); }
+        public short UnknownValue1 { get => _unknownValue1; set => SetAndMarkDirty(ref _unknownValue1, value); }
 
         // Fragment header
-        public string Skeleton { get => _skeleton; set => SetAndNotify(ref _skeleton, value); }
+        public string Skeleton { get => _skeleton; set => SetAndMarkDirty(ref _skeleton, value); }
 
         // State
         public bool IsWh3 { get => _isWh3; set => SetAndNotify(ref _isWh3, value); }
-        public bool IsDirty { get => _isDirty; set => SetAndNotify(ref _isDirty, value); }
+        public bool IsDirty { get => _isDirty; set => SetAndNotifyWhenChanged(ref _isDirty, value); }
         public AnimationEntryRowViewModel? SelectedRow { get => _selectedRow; set => SetAndNotify(ref _selectedRow, value); }
         public IList MultiSelectedRows { get => _multiSelectedRows; set => SetAndNotify(ref _multiSelectedRows, value); }
 
@@ -152,8 +157,67 @@ namespace Editors.AnimationFragmentEditor.AnimationPack.ViewModels
             _metaDataFileParser = metaDataFileParser;
             _animPackFile = animPackFile;
             _gameType = gameType;
+            Rows.CollectionChanged += Rows_CollectionChanged;
             LoadFileLists();
         }
+
+        private void SetAndMarkDirty<T>(ref T field, T value, [CallerMemberName] string propertyName = "")
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+                return;
+
+            SetAndNotifyWhenChanged(ref field, value, propertyName: propertyName);
+            MarkDirty();
+        }
+
+        private void MarkDirty()
+        {
+            if (!_suppressDirtyTracking)
+                IsDirty = true;
+        }
+
+        private void Rows_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                foreach (var row in _trackedRows)
+                    row.PropertyChanged -= Row_PropertyChanged;
+                _trackedRows.Clear();
+
+                foreach (var row in Rows)
+                    TrackRow(row);
+            }
+            else
+            {
+                if (e.OldItems != null)
+                {
+                    foreach (AnimationEntryRowViewModel row in e.OldItems)
+                        UntrackRow(row);
+                }
+
+                if (e.NewItems != null)
+                {
+                    foreach (AnimationEntryRowViewModel row in e.NewItems)
+                        TrackRow(row);
+                }
+            }
+
+            MarkDirty();
+        }
+
+        private void TrackRow(AnimationEntryRowViewModel row)
+        {
+            if (_trackedRows.Add(row))
+                row.PropertyChanged += Row_PropertyChanged;
+        }
+
+        private void UntrackRow(AnimationEntryRowViewModel row)
+        {
+            if (_trackedRows.Remove(row))
+                row.PropertyChanged -= Row_PropertyChanged;
+        }
+
+        private void Row_PropertyChanged(object? sender, PropertyChangedEventArgs e) => MarkDirty();
 
         private void LoadFileLists()
         {
@@ -179,27 +243,35 @@ namespace Editors.AnimationFragmentEditor.AnimationPack.ViewModels
 
         public void LoadFromBinary(byte[] bytes, string fileName)
         {
-            Rows.Clear();
-            _undoSnapshots.Clear();
-            IsDirty = false;
-
+            _suppressDirtyTracking = true;
             try
             {
-                var bin = new AnimationBinWh3("", bytes);
-                LoadFromWh3Bin(bin);
-                return;
-            }
-            catch { }
+                Rows.Clear();
+                _undoSnapshots.Clear();
 
-            try
+                try
+                {
+                    var bin = new AnimationBinWh3("", bytes);
+                    LoadFromWh3Bin(bin);
+                    return;
+                }
+                catch { }
+
+                try
+                {
+                    var frag = new AnimationFragmentFile("", bytes, _gameType);
+                    LoadFromFragment(frag);
+                    return;
+                }
+                catch { }
+
+                IsWh3 = true;
+            }
+            finally
             {
-                var frag = new AnimationFragmentFile("", bytes, _gameType);
-                LoadFromFragment(frag);
-                return;
+                _suppressDirtyTracking = false;
+                IsDirty = false;
             }
-            catch { }
-
-            IsWh3 = true;
         }
 
         private void LoadFromWh3Bin(AnimationBinWh3 bin)

--- a/Shared/ByteParsing/Shared.ByteParsing/Parsers/StringParser.cs
+++ b/Shared/ByteParsing/Shared.ByteParsing/Parsers/StringParser.cs
@@ -140,8 +140,9 @@ namespace Shared.ByteParsing.Parsers
 
 
 
-            var byteLength = BitConverter.GetBytes((short)value.Length);
             var byteStr = StringEncoding.GetBytes(value);
+            var length = StringEncoding == Encoding.Unicode ? value.Length : byteStr.Length;
+            var byteLength = BitConverter.GetBytes((short)length);
 
             var stringWithCountAtFront = byteLength.Concat(byteStr).ToArray();
 

--- a/Shared/ByteParsing/Shared.ByteParsingTest/Parsers/StringParserTest.cs
+++ b/Shared/ByteParsing/Shared.ByteParsingTest/Parsers/StringParserTest.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using Shared.ByteParsing.Parsers;
+using System.Text;
 
 namespace Shared.ByteParsingTest.Parsers
 {
@@ -20,6 +21,68 @@ namespace Shared.ByteParsingTest.Parsers
             Assert.That(ok, Is.True);
             Assert.That(error, Is.Null);
             Assert.That(value, Is.EqualTo(input));
+        }
+
+        [Test]
+        public void Utf8Chinese_UsesByteLengthPrefixAndRoundTrips()
+        {
+            var parser = new StringParser();
+            var input = "中文";
+
+            var bytes = parser.WriteCaString(input);
+
+            Assert.That(BitConverter.ToInt16(bytes, 0), Is.EqualTo(6));
+            Assert.That(parser.TryDecodeValue(bytes, 0, out var value, out var bytesRead, out var error), Is.True);
+            Assert.That(error, Is.Null);
+            Assert.That(value, Is.EqualTo(input));
+            Assert.That(bytesRead, Is.EqualTo(8));
+        }
+
+        [Test]
+        public void Utf8Emoji_UsesByteLengthPrefixAndRoundTrips()
+        {
+            var parser = new StringParser();
+            var input = "😀";
+
+            var bytes = parser.WriteCaString(input);
+
+            Assert.That(BitConverter.ToInt16(bytes, 0), Is.EqualTo(4));
+            Assert.That(parser.TryDecodeValue(bytes, 0, out var value, out var bytesRead, out var error), Is.True);
+            Assert.That(error, Is.Null);
+            Assert.That(value, Is.EqualTo(input));
+            Assert.That(bytesRead, Is.EqualTo(6));
+        }
+
+        [Test]
+        public void OptionalUtf8_UsesByteLengthPrefixAndRoundTrips()
+        {
+            var parser = new OptionalStringParser();
+            var input = "中文";
+
+            var bytes = parser.WriteCaString(input);
+
+            Assert.That(bytes[0], Is.EqualTo(1));
+            Assert.That(BitConverter.ToInt16(bytes, 1), Is.EqualTo(6));
+            Assert.That(parser.TryDecodeValue(bytes, 0, out var value, out var bytesRead, out var error), Is.True);
+            Assert.That(error, Is.Null);
+            Assert.That(value, Is.EqualTo(input));
+            Assert.That(bytesRead, Is.EqualTo(9));
+        }
+
+        [Test]
+        public void Utf16_UsesCodeUnitLengthPrefixAndRoundTrips()
+        {
+            var parser = new StringAsciiParser();
+            var input = "😀";
+
+            var bytes = parser.WriteCaString(input);
+
+            Assert.That(BitConverter.ToInt16(bytes, 0), Is.EqualTo(2));
+            Assert.That(bytes.Length, Is.EqualTo(2 + Encoding.Unicode.GetByteCount(input)));
+            Assert.That(parser.TryDecodeValue(bytes, 0, out var value, out var bytesRead, out var error), Is.True);
+            Assert.That(error, Is.Null);
+            Assert.That(value, Is.EqualTo(input));
+            Assert.That(bytesRead, Is.EqualTo(bytes.Length));
         }
     }
 }

--- a/Shared/GameFiles/Dat/DatFileParser.cs
+++ b/Shared/GameFiles/Dat/DatFileParser.cs
@@ -134,8 +134,8 @@ namespace Shared.GameFormats.Dat
 
         static byte[] WriteStr32(string str)
         {
-            var buffer = ByteParsers.Int32.EncodeValue(str.Length, out _).ToList();
             var strBytes = Encoding.UTF8.GetBytes(str);
+            var buffer = ByteParsers.Int32.EncodeValue(strBytes.Length, out _).ToList();
             buffer.AddRange(strBytes);
             return buffer.ToArray();
         }

--- a/Shared/SharedCore/Services/FileSaveService.cs
+++ b/Shared/SharedCore/Services/FileSaveService.cs
@@ -27,18 +27,22 @@ namespace Shared.Core.Services
                 throw new Exception($"Unable to save file. No Editable PackFile selected");
 
             var saveDialogResult = _packFileUiProvider.DisplaySaveDialog(_packFileService, [extention]);
-            if (saveDialogResult.Result)
+            if (saveDialogResult.Result == false)
                 return null;
 
-            var fileName = Path.GetFileName(saveDialogResult.SelectedFilePath);
+            var selectedFilePath = saveDialogResult.SelectedFilePath;
+            if (string.IsNullOrWhiteSpace(selectedFilePath))
+                return null;
+
+            var fileName = Path.GetFileName(selectedFilePath);
             if (string.IsNullOrWhiteSpace(fileName))
                 return null;
 
-            var isExistingFile = _packFileService.FindFile(saveDialogResult.SelectedFilePath!, editablePack);
+            var isExistingFile = _packFileService.FindFile(selectedFilePath, editablePack);
             if (isExistingFile == null)
             {
                 var newPackFile = new PackFile(fileName, new MemorySource(content));
-                var directoryPath = Path.GetDirectoryName(saveDialogResult.SelectedFilePath);
+                var directoryPath = Path.GetDirectoryName(selectedFilePath);
                 var item = new NewPackFileEntry(directoryPath!, newPackFile);
                 _packFileService.AddFilesToPack(editablePack, [item]);
 

--- a/Testing/AssetEditorTests/AnimPackDirtyStateTests.cs
+++ b/Testing/AssetEditorTests/AnimPackDirtyStateTests.cs
@@ -1,0 +1,339 @@
+using CommonControls.Editors.AnimationPack;
+using Editors.AnimationFragmentEditor.AnimationPack.ViewModels;
+using GameWorld.Core.Services;
+using Moq;
+using Shared.Core.Events;
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Services;
+using Shared.Core.Settings;
+using Shared.GameFormats.Animation;
+using Shared.GameFormats.AnimationMeta.Parsing;
+using Shared.GameFormats.AnimationPack;
+using Shared.GameFormats.AnimationPack.AnimPackFileTypes.Wh3;
+using Shared.Ui.Editors.TextEditor;
+using System.Xml.Linq;
+
+namespace AssetEditorTests
+{
+    [TestClass]
+    public class AnimPackDirtyStateTests
+    {
+        [TestMethod]
+        public void HeaderEdit_MarksTableDirty()
+        {
+            var editor = CreateTableEditor();
+
+            editor.Name = "changed";
+
+            Assert.IsTrue(editor.IsDirty);
+        }
+
+        [TestMethod]
+        public void RowCollectionEdit_MarksTableDirty()
+        {
+            var editor = CreateTableEditor();
+
+            editor.Rows.Add(new AnimationEntryRowViewModel());
+
+            Assert.IsTrue(editor.IsDirty);
+        }
+
+        [TestMethod]
+        public void RowPropertyEdit_MarksTableDirty()
+        {
+            var editor = CreateTableEditor();
+            var row = new AnimationEntryRowViewModel();
+            editor.Rows.Add(row);
+            editor.IsDirty = false;
+
+            row.AnimationFile = "animations/test.anim";
+
+            Assert.IsTrue(editor.IsDirty);
+        }
+
+        [TestMethod]
+        public void LoadFromBinary_LeavesTableClean()
+        {
+            var editor = CreateTableEditor();
+            var bin = CreateAnimationBin();
+
+            editor.LoadFromBinary(bin.ToByteArray(), bin.FileName);
+
+            Assert.IsFalse(editor.IsDirty);
+            Assert.AreEqual(bin.Name, editor.Name);
+        }
+
+        [TestMethod]
+        public void HasUnsavedChanges_IncludesDirtyTable()
+        {
+            var editor = CreateOuterEditor();
+            editor.TableEditorVM = CreateTableEditor();
+            editor.TableEditorVM.IsDirty = true;
+
+            Assert.IsTrue(editor.HasUnsavedChanges);
+        }
+
+        [TestMethod]
+        public void HasUnsavedChanges_IncludesDirtyXml()
+        {
+            var editor = CreateOuterEditor();
+            editor.SelectedItemViewModel = new SimpleTextEditorViewModel();
+            editor.SelectedItemViewModel.Text = "<changed/>";
+
+            Assert.IsTrue(editor.HasUnsavedChanges);
+        }
+
+        [TestMethod]
+        public void Save_CommitsDirtyChildBeforeSavingParent()
+        {
+            var harness = CreateLoadedOuterEditor(parentSaveSucceeds: true);
+            harness.Editor.TableEditorVM.MountBin = "changed_mount";
+
+            var result = harness.Editor.Save();
+
+            Assert.IsTrue(result);
+            Assert.IsFalse(harness.Editor.TableEditorVM.IsDirty);
+            Assert.IsFalse(harness.Editor.HasUnsavedChanges);
+
+            var savedPack = PackFile.CreateFromBytes("saved.animpack", harness.SavedBytes!);
+            var savedDatabase = AnimationPackSerializer.Load(savedPack, harness.PackFileService.Object);
+            var savedBin = (AnimationBinWh3)savedDatabase.Files.Single();
+            Assert.AreEqual("changed_mount", savedBin.MountBin);
+        }
+
+        [TestMethod]
+        public void Save_TableDirtyWhileXmlViewActive_CommitsTable()
+        {
+            var harness = CreateLoadedOuterEditor(parentSaveSucceeds: true);
+            harness.Editor.TableEditorVM.MountBin = "changed_mount";
+            harness.Editor.IsTableView = false;
+
+            var result = harness.Editor.Save();
+
+            Assert.IsTrue(result);
+            Assert.IsFalse(harness.Editor.TableEditorVM.IsDirty);
+            Assert.IsFalse(harness.Editor.HasUnsavedChanges);
+
+            var savedPack = PackFile.CreateFromBytes("saved.animpack", harness.SavedBytes!);
+            var savedDatabase = AnimationPackSerializer.Load(savedPack, harness.PackFileService.Object);
+            var savedBin = (AnimationBinWh3)savedDatabase.Files.Single();
+            Assert.AreEqual("changed_mount", savedBin.MountBin);
+        }
+
+        [TestMethod]
+        public void SaveActiveFile_TableDirty_SynchronizesXmlSnapshot()
+        {
+            var harness = CreateLoadedOuterEditor(parentSaveSucceeds: true);
+            harness.Editor.TableEditorVM.MountBin = "changed_mount";
+
+            var result = harness.Editor.SaveActiveFile();
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("changed_mount", GetXmlMountBin(harness.Editor));
+            Assert.IsFalse(harness.Editor.TableEditorVM.IsDirty);
+            Assert.IsFalse(harness.Editor.SelectedItemViewModel.HasUnsavedChanges());
+            Assert.IsTrue(harness.Editor.HasUnsavedChanges);
+        }
+
+        [TestMethod]
+        public void SaveActiveFile_XmlDirty_SynchronizesTableSnapshot()
+        {
+            var harness = CreateLoadedOuterEditor(parentSaveSucceeds: true);
+            SetXmlMountBin(harness.Editor, "changed_mount");
+
+            var result = harness.Editor.SaveActiveFile();
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("changed_mount", harness.Editor.TableEditorVM.MountBin);
+            Assert.IsFalse(harness.Editor.TableEditorVM.IsDirty);
+            Assert.IsFalse(harness.Editor.SelectedItemViewModel.HasUnsavedChanges());
+            Assert.IsTrue(harness.Editor.HasUnsavedChanges);
+        }
+
+        [TestMethod]
+        public void SaveActiveFile_WhenBothChildrenDirty_DoesNotModifyEitherRepresentation()
+        {
+            var harness = CreateLoadedOuterEditor(parentSaveSucceeds: true);
+            var selectedFile = harness.Editor.AnimationPackItems.SelectedItem!;
+            var originalBytes = selectedFile.ToByteArray().ToArray();
+            harness.Editor.TableEditorVM.MountBin = "table_mount";
+            SetXmlMountBin(harness.Editor, "xml_mount");
+
+            var result = harness.Editor.SaveActiveFile();
+
+            Assert.IsFalse(result);
+            Assert.IsTrue(harness.Editor.TableEditorVM.IsDirty);
+            Assert.IsTrue(harness.Editor.SelectedItemViewModel.HasUnsavedChanges());
+            CollectionAssert.AreEqual(originalBytes, selectedFile.ToByteArray());
+        }
+
+        [TestMethod]
+        public void Save_WhenBothChildrenDirty_DoesNotWriteParentAndKeepsUncommittedChildDirty()
+        {
+            var harness = CreateLoadedOuterEditor(parentSaveSucceeds: true);
+            harness.Editor.TableEditorVM.MountBin = "changed_mount";
+            harness.Editor.SelectedItemViewModel.Text += Environment.NewLine;
+            harness.Editor.IsTableView = true;
+            var selectedFile = harness.Editor.AnimationPackItems.SelectedItem!;
+            var originalBytes = selectedFile.ToByteArray().ToArray();
+
+            var result = harness.Editor.Save();
+
+            Assert.IsFalse(result);
+            Assert.IsTrue(harness.Editor.TableEditorVM.IsDirty);
+            Assert.IsTrue(harness.Editor.SelectedItemViewModel.HasUnsavedChanges());
+            Assert.IsTrue(harness.Editor.HasUnsavedChanges);
+            CollectionAssert.AreEqual(originalBytes, selectedFile.ToByteArray());
+            harness.FileSaveService.Verify(
+                x => x.Save(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>()),
+                Times.Never);
+        }
+
+        [TestMethod]
+        public void Save_WhenParentSaveFails_KeepsEditorDirty()
+        {
+            var harness = CreateLoadedOuterEditor(parentSaveSucceeds: false);
+            harness.Editor.TableEditorVM.MountBin = "changed_mount";
+
+            var result = harness.Editor.Save();
+
+            Assert.IsFalse(result);
+            Assert.IsFalse(harness.Editor.TableEditorVM.IsDirty);
+            Assert.IsTrue(harness.Editor.HasUnsavedChanges);
+        }
+
+        private static string GetXmlMountBin(AnimPackViewModel editor)
+        {
+            var document = XDocument.Parse(editor.SelectedItemViewModel.Text);
+            var mountBin = document.Root?
+                .Element("GeneralBinData")?
+                .Element("MountBin");
+            Assert.IsNotNull(mountBin);
+            return mountBin.Value;
+        }
+
+        private static void SetXmlMountBin(AnimPackViewModel editor, string value)
+        {
+            var document = XDocument.Parse(editor.SelectedItemViewModel.Text);
+            var mountBin = document.Root?
+                .Element("GeneralBinData")?
+                .Element("MountBin");
+            Assert.IsNotNull(mountBin);
+            mountBin.Value = value;
+            editor.SelectedItemViewModel.Text = document.ToString();
+        }
+
+        private static AnimSetTableEditorViewModel CreateTableEditor(
+            Mock<IPackFileService>? packFileService = null,
+            Mock<ISkeletonAnimationLookUpHelper>? skeletonLookup = null,
+            PackFile? animPack = null)
+        {
+            packFileService ??= CreatePackFileService();
+            skeletonLookup ??= new Mock<ISkeletonAnimationLookUpHelper>();
+            var metadataParser = new MetaDataFileParser(new Mock<IMetaDataDatabase>().Object);
+
+            return new AnimSetTableEditorViewModel(
+                packFileService.Object,
+                skeletonLookup.Object,
+                metadataParser,
+                animPack!,
+                GameTypeEnum.Warhammer3);
+        }
+
+        private static AnimPackViewModel CreateOuterEditor(
+            Mock<IPackFileService>? packFileService = null,
+            Mock<ISkeletonAnimationLookUpHelper>? skeletonLookup = null,
+            Mock<IFileSaveService>? fileSaveService = null)
+        {
+            packFileService ??= CreatePackFileService();
+            skeletonLookup ??= new Mock<ISkeletonAnimationLookUpHelper>();
+            fileSaveService ??= new Mock<IFileSaveService>();
+
+            return new AnimPackViewModel(
+                new Mock<IUiCommandFactory>().Object,
+                packFileService.Object,
+                skeletonLookup.Object,
+                new ApplicationSettingsService(GameTypeEnum.Warhammer3),
+                fileSaveService.Object,
+                new MetaDataFileParser(new Mock<IMetaDataDatabase>().Object));
+        }
+
+        private static LoadedEditorHarness CreateLoadedOuterEditor(bool parentSaveSucceeds)
+        {
+            var packFileService = CreatePackFileService();
+            var skeletonLookup = new Mock<ISkeletonAnimationLookUpHelper>();
+            skeletonLookup
+                .Setup(x => x.GetSkeletonFileFromName("skeleton"))
+                .Returns(new AnimationFile());
+
+            var database = new AnimationPackFileDatabase("test.animpack");
+            database.AddFile(CreateAnimationBin());
+            var parentPack = PackFile.CreateFromBytes(
+                "test.animpack",
+                AnimationPackSerializer.ConvertToBytes(database));
+
+            byte[]? savedBytes = null;
+            var fileSaveService = new Mock<IFileSaveService>();
+            fileSaveService
+                .Setup(x => x.Save("test.animpack", It.IsAny<byte[]>(), false))
+                .Callback<string, byte[], bool>((_, bytes, _) => savedBytes = bytes)
+                .Returns(parentSaveSucceeds ? parentPack : null);
+
+            var editor = CreateOuterEditor(packFileService, skeletonLookup, fileSaveService);
+            editor.LoadFile(parentPack);
+            editor.AnimationPackItems.SelectedItem = editor.AnimationPackItems.PossibleValues.Single();
+
+            return new LoadedEditorHarness(editor, packFileService, fileSaveService, () => savedBytes);
+        }
+
+        private static Mock<IPackFileService> CreatePackFileService()
+        {
+            var packFileService = new Mock<IPackFileService>();
+            packFileService
+                .Setup(x => x.GetAllPackfileContainers())
+                .Returns(new List<PackFileContainer>());
+            packFileService
+                .Setup(x => x.GetFullPath(It.IsAny<PackFile>(), It.IsAny<PackFileContainer?>()))
+                .Returns("test.animpack");
+            packFileService
+                .Setup(x => x.FindFile("graph.xml", It.IsAny<PackFileContainer?>()))
+                .Returns(PackFile.CreateFromBytes("graph.xml", [1]));
+            return packFileService;
+        }
+
+        private static AnimationBinWh3 CreateAnimationBin()
+        {
+            return new AnimationBinWh3("animations/database/battle/bin/test_bin.bin")
+            {
+                Name = "test_bin",
+                SkeletonName = "skeleton",
+                LocomotionGraph = "graph.xml",
+                TableVersion = 4,
+                TableSubVersion = 3,
+            };
+        }
+
+        private sealed class LoadedEditorHarness
+        {
+            private readonly Func<byte[]?> _getSavedBytes;
+
+            public LoadedEditorHarness(
+                AnimPackViewModel editor,
+                Mock<IPackFileService> packFileService,
+                Mock<IFileSaveService> fileSaveService,
+                Func<byte[]?> getSavedBytes)
+            {
+                Editor = editor;
+                PackFileService = packFileService;
+                FileSaveService = fileSaveService;
+                _getSavedBytes = getSavedBytes;
+            }
+
+            public AnimPackViewModel Editor { get; }
+            public Mock<IPackFileService> PackFileService { get; }
+            public Mock<IFileSaveService> FileSaveService { get; }
+            public byte[]? SavedBytes => _getSavedBytes();
+        }
+    }
+}

--- a/Testing/AssetEditorTests/AnimPackStructureCommandTests.cs
+++ b/Testing/AssetEditorTests/AnimPackStructureCommandTests.cs
@@ -1,0 +1,157 @@
+using CommonControls.Editors.AnimationPack;
+using Editors.AnimationFragmentEditor.AnimationPack.Commands;
+using GameWorld.Core.Services;
+using Moq;
+using Shared.Core.Events;
+using Shared.Core.PackFiles;
+using Shared.Core.Services;
+using Shared.Core.Settings;
+using Shared.GameFormats.AnimationMeta.Parsing;
+using Shared.GameFormats.AnimationPack.AnimPackFileTypes;
+
+namespace AssetEditorTests
+{
+    [TestClass]
+    public class AnimPackStructureCommandTests
+    {
+        [TestMethod]
+        public void Create_Success_AddsFileAndMarksDirty()
+        {
+            var editor = CreateEditor();
+            var command = new StubCreateCommand("new.frg");
+
+            command.Execute(editor);
+
+            Assert.AreEqual(1, editor.AnimationPackItems.PossibleValues.Count);
+            Assert.IsTrue(editor.HasUnsavedChanges);
+        }
+
+        [TestMethod]
+        public void Create_Cancel_DoesNotAddFileOrMarkDirty()
+        {
+            var editor = CreateEditor();
+            var command = new StubCreateCommand(null);
+
+            command.Execute(editor);
+
+            Assert.AreEqual(0, editor.AnimationPackItems.PossibleValues.Count);
+            Assert.IsFalse(editor.HasUnsavedChanges);
+        }
+
+        [TestMethod]
+        public void Rename_Success_ChangesFileNameAndMarksDirty()
+        {
+            var editor = CreateEditor();
+            var file = AddAndSelectFile(editor);
+            var command = new StubRenameCommand("renamed.bin");
+
+            command.Execute(editor);
+
+            Assert.AreEqual("renamed.bin", file.FileName);
+            Assert.IsTrue(editor.HasUnsavedChanges);
+        }
+
+        [TestMethod]
+        public void Rename_Cancel_DoesNotChangeFileNameOrMarkDirty()
+        {
+            var editor = CreateEditor();
+            var file = AddAndSelectFile(editor);
+            var command = new StubRenameCommand(null);
+
+            command.Execute(editor);
+
+            Assert.AreEqual("original.bin", file.FileName);
+            Assert.IsFalse(editor.HasUnsavedChanges);
+        }
+
+        [TestMethod]
+        public void Rename_NoSelection_DoesNotMarkDirty()
+        {
+            var editor = CreateEditor();
+            var command = new StubRenameCommand("renamed.bin");
+
+            command.Execute(editor);
+
+            Assert.IsFalse(editor.HasUnsavedChanges);
+        }
+
+        [TestMethod]
+        public void Remove_Success_RemovesFileAndMarksDirty()
+        {
+            var editor = CreateEditor();
+            AddAndSelectFile(editor);
+            var command = new RemoveSelectedFileCommand();
+
+            command.Execute(editor);
+
+            Assert.AreEqual(0, editor.AnimationPackItems.PossibleValues.Count);
+            Assert.IsTrue(editor.HasUnsavedChanges);
+        }
+
+        [TestMethod]
+        public void Remove_NoSelection_DoesNotMarkDirty()
+        {
+            var editor = CreateEditor();
+            var command = new RemoveSelectedFileCommand();
+
+            command.Execute(editor);
+
+            Assert.IsFalse(editor.HasUnsavedChanges);
+        }
+
+        [TestMethod]
+        public void Remove_SelectedFileNotInList_DoesNotMarkDirty()
+        {
+            var editor = CreateEditor();
+            editor.AnimationPackItems.SelectedItem = new UnknownAnimFile("missing.bin", [1]);
+            var command = new RemoveSelectedFileCommand();
+
+            command.Execute(editor);
+
+            Assert.IsFalse(editor.HasUnsavedChanges);
+        }
+
+        private static AnimPackViewModel CreateEditor()
+        {
+            return new AnimPackViewModel(
+                new Mock<IUiCommandFactory>().Object,
+                new Mock<IPackFileService>().Object,
+                new Mock<ISkeletonAnimationLookUpHelper>().Object,
+                new ApplicationSettingsService(GameTypeEnum.Warhammer3),
+                new Mock<IFileSaveService>().Object,
+                new MetaDataFileParser(new Mock<IMetaDataDatabase>().Object));
+        }
+
+        private static UnknownAnimFile AddAndSelectFile(AnimPackViewModel editor)
+        {
+            var file = new UnknownAnimFile("original.bin", [1]);
+            editor.AnimationPackItems.PossibleValues.Add(file);
+            editor.AnimationPackItems.SelectedItem = file;
+            return file;
+        }
+
+        private sealed class StubCreateCommand : CreateEmptyWarhammer3AnimSetFileCommand
+        {
+            private readonly string? _fileName;
+
+            public StubCreateCommand(string? fileName)
+            {
+                _fileName = fileName;
+            }
+
+            protected override string? GetAnimSetFileName() => _fileName;
+        }
+
+        private sealed class StubRenameCommand : RenameSelectedFileCommand
+        {
+            private readonly string? _fileName;
+
+            public StubRenameCommand(string? fileName)
+            {
+                _fileName = fileName;
+            }
+
+            protected override string? GetNewFileName(string currentFileName) => _fileName;
+        }
+    }
+}

--- a/Testing/AssetEditorTests/AnimationKeyframeEditorSaveTests.cs
+++ b/Testing/AssetEditorTests/AnimationKeyframeEditorSaveTests.cs
@@ -1,0 +1,159 @@
+using System.Reflection;
+using Editors.AnimationVisualEditors.AnimationKeyframeEditor;
+using Editors.Shared.Core.Common;
+using GameWorld.Core.Animation;
+using GameWorld.Core.Services;
+using Microsoft.Xna.Framework;
+using Moq;
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Services;
+using Shared.GameFormats.Animation;
+using Shared.GameFormats.RigidModel.Transforms;
+
+namespace AssetEditorTests
+{
+    [TestClass]
+    [DoNotParallelize]
+    public class AnimationKeyframeEditorSaveTests
+    {
+        [ClassInitialize]
+        public static void Initialize(TestContext _)
+        {
+            new LocalizationManager().LoadLanguage();
+        }
+
+        [TestMethod]
+        public void Save_WhenSaveIsCancelled_KeepsDirty()
+        {
+            var harness = CreateHarness();
+            harness.FileSaveService
+                .Setup(x => x.Save("animations/test.anim", It.IsAny<byte[]>(), true))
+                .Returns((PackFile?)null);
+
+            harness.Editor.Save();
+
+            Assert.IsTrue(harness.Editor.IsDirty.Value);
+        }
+
+        [TestMethod]
+        public void Save_WhenSaveSucceeds_ClearsDirty()
+        {
+            var harness = CreateHarness();
+            harness.FileSaveService
+                .Setup(x => x.Save("animations/test.anim", It.IsAny<byte[]>(), true))
+                .Returns(PackFile.CreateFromBytes("test.anim", [1]));
+
+            harness.Editor.Save();
+
+            Assert.IsFalse(harness.Editor.IsDirty.Value);
+        }
+
+        [TestMethod]
+        public void SaveAs_WhenSaveIsCancelled_KeepsDirty()
+        {
+            var harness = CreateHarness();
+            harness.FileSaveService
+                .Setup(x => x.SaveAs(".anim", It.IsAny<byte[]>()))
+                .Returns((PackFile?)null);
+
+            harness.Editor.SaveAs();
+
+            Assert.IsTrue(harness.Editor.IsDirty.Value);
+        }
+
+        [TestMethod]
+        public void SaveAs_WhenSaveSucceeds_ClearsDirty()
+        {
+            var harness = CreateHarness();
+            harness.FileSaveService
+                .Setup(x => x.SaveAs(".anim", It.IsAny<byte[]>()))
+                .Returns(PackFile.CreateFromBytes("test.anim", [1]));
+
+            harness.Editor.SaveAs();
+
+            Assert.IsFalse(harness.Editor.IsDirty.Value);
+        }
+
+        private static EditorHarness CreateHarness()
+        {
+            var fileSaveService = new Mock<IFileSaveService>();
+            var standardDialogs = new Mock<IStandardDialogs>();
+            var editor = new AnimationKeyframeEditorViewModel(
+                new Mock<IPackFileService>().Object,
+                new Mock<ISkeletonAnimationLookUpHelper>().Object,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                fileSaveService.Object,
+                standardDialogs.Object);
+
+            var rider = new SceneObject("rider")
+            {
+                AnimationClip = CreateAnimationClip(),
+                Skeleton = CreateSkeleton(),
+            };
+            rider.AnimationName.Value = "animations/test.anim";
+
+            var riderField = typeof(AnimationKeyframeEditorViewModel)
+                .GetField("_rider", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(riderField);
+            riderField.SetValue(editor, rider);
+
+            editor.IsDirty.Value = true;
+            return new EditorHarness(editor, fileSaveService);
+        }
+
+        private static AnimationClip CreateAnimationClip()
+        {
+            var frame = new AnimationClip.KeyFrame();
+            frame.Position.Add(Vector3.Zero);
+            frame.Rotation.Add(Quaternion.Identity);
+            frame.Scale.Add(Vector3.One);
+
+            var clip = new AnimationClip();
+            clip.DynamicFrames.Add(frame);
+            clip.PlayTimeInSec = 0.05f;
+            return clip;
+        }
+
+        private static GameSkeleton CreateSkeleton()
+        {
+            var skeletonFile = new AnimationFile
+            {
+                Header = new AnimationFile.AnimationHeader
+                {
+                    SkeletonName = "test_skeleton",
+                },
+                Bones =
+                [
+                    new AnimationFile.BoneInfo
+                    {
+                        Id = 0,
+                        Name = "root",
+                        ParentId = AnimationFile.BoneIndexNoParent,
+                    },
+                ],
+            };
+
+            var frame = new AnimationFile.Frame();
+            frame.Transforms.Add(new RmvVector3());
+            frame.Quaternion.Add(new RmvVector4(0, 0, 0, 1));
+
+            var part = new AnimationFile.AnimationPart();
+            part.DynamicFrames.Add(frame);
+            skeletonFile.AnimationParts.Add(part);
+
+            return new GameSkeleton(skeletonFile, new AnimationPlayer());
+        }
+
+        private sealed record EditorHarness(
+            AnimationKeyframeEditorViewModel Editor,
+            Mock<IFileSaveService> FileSaveService);
+    }
+}

--- a/Testing/AssetEditorTests/AssetEditorTests.csproj
+++ b/Testing/AssetEditorTests/AssetEditorTests.csproj
@@ -17,6 +17,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+		<PackageReference Include="Moq" Version="4.20.72" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Testing/AssetEditorTests/DatFileParserTests.cs
+++ b/Testing/AssetEditorTests/DatFileParserTests.cs
@@ -1,0 +1,26 @@
+using Shared.ByteParsing;
+using Shared.GameFormats.Dat;
+
+namespace AssetEditorTests
+{
+    [TestClass]
+    public class DatFileParserTests
+    {
+        [TestMethod]
+        public void WriteData_NonAsciiEventUsesUtf8ByteLengthAndRoundTrips()
+        {
+            var input = "中文";
+            var file = new SoundDatFile();
+            file.EventWithStateGroup.Add(new SoundDatFile.DatEventWithStateGroup
+            {
+                Event = input,
+                Value = 1.5f
+            });
+
+            var bytes = DatFileParser.WriteData(file);
+
+            Assert.AreEqual(6, BitConverter.ToInt32(bytes, sizeof(uint)));
+            Assert.AreEqual(input, DatFileParser.ReadStr32(new ByteChunk(bytes, sizeof(uint))));
+        }
+    }
+}

--- a/Testing/Shared.Core.Test/Services/FileSaveServiceTests.cs
+++ b/Testing/Shared.Core.Test/Services/FileSaveServiceTests.cs
@@ -154,6 +154,84 @@ namespace Test.Shared.Core.Services
             _uiProvider.Verify(x => x.DisplaySaveDialog(_pfs, It.IsAny<List<string>>()), Times.Once);
         }
 
-        // SaveAs
+        [Test]
+        public void SaveAs_ConfirmedNewPath_CreatesAndReturnsFile()
+        {
+            var saveService = new FileSaveService(_pfs, _uiProvider.Object);
+            _uiProvider
+                .Setup(x => x.DisplaySaveDialog(_pfs, It.IsAny<List<string>>()))
+                .Returns(new SaveDialogResult(true, null, "folder\\save-as\\Created.test"));
+
+            var result = saveService.SaveAs(".test", [3]);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.DataSource.ReadData(), Is.EqualTo(new byte[] { 3 }));
+            Assert.That(_pfs.FindFile("folder\\save-as\\Created.test"), Is.SameAs(result));
+            Assert.That(_container.FileList.Count, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void SaveAs_ConfirmedExistingPath_OverwritesAndReturnsFile()
+        {
+            var saveService = new FileSaveService(_pfs, _uiProvider.Object);
+            _uiProvider
+                .Setup(x => x.DisplaySaveDialog(_pfs, It.IsAny<List<string>>()))
+                .Returns(new SaveDialogResult(true, null, "folder\\subfolder\\File1.test"));
+
+            var result = saveService.SaveAs(".test", [3]);
+
+            Assert.That(result, Is.SameAs(_fileHandle));
+            Assert.That(result!.DataSource.ReadData(), Is.EqualTo(new byte[] { 3 }));
+            Assert.That(_container.FileList.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void SaveAs_Cancelled_DoesNotMutatePackAndReturnsNull()
+        {
+            var saveService = new FileSaveService(_pfs, _uiProvider.Object);
+            _uiProvider
+                .Setup(x => x.DisplaySaveDialog(_pfs, It.IsAny<List<string>>()))
+                .Returns(new SaveDialogResult(false, null, null));
+
+            var result = saveService.SaveAs(".test", [3]);
+
+            Assert.That(result, Is.Null);
+            Assert.That(_container.FileList.Count, Is.EqualTo(2));
+            Assert.That(_fileHandle.DataSource.ReadData(), Is.EqualTo(new byte[] { 1 }));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase("folder\\")]
+        public void SaveAs_ConfirmedInvalidPath_DoesNotMutatePackAndReturnsNull(string? selectedFilePath)
+        {
+            var saveService = new FileSaveService(_pfs, _uiProvider.Object);
+            _uiProvider
+                .Setup(x => x.DisplaySaveDialog(_pfs, It.IsAny<List<string>>()))
+                .Returns(new SaveDialogResult(true, null, selectedFilePath));
+
+            var result = saveService.SaveAs(".test", [3]);
+
+            Assert.That(result, Is.Null);
+            Assert.That(_container.FileList.Count, Is.EqualTo(2));
+            Assert.That(_fileHandle.DataSource.ReadData(), Is.EqualTo(new byte[] { 1 }));
+        }
+
+        [Test]
+        public void SaveAs_ConfirmedRootFileName_CreatesAndReturnsFile()
+        {
+            var saveService = new FileSaveService(_pfs, _uiProvider.Object);
+            _uiProvider
+                .Setup(x => x.DisplaySaveDialog(_pfs, It.IsAny<List<string>>()))
+                .Returns(new SaveDialogResult(true, null, "Root.test"));
+
+            var result = saveService.SaveAs(".test", [3]);
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result!.DataSource.ReadData(), Is.EqualTo(new byte[] { 3 }));
+            Assert.That(_pfs.FindFile("Root.test"), Is.SameAs(result));
+            Assert.That(_container.FileList.Count, Is.EqualTo(3));
+        }
     }
 }

--- a/docs/superpowers/plans/2026-07-26-p0-data-integrity-fixes.md
+++ b/docs/superpowers/plans/2026-07-26-p0-data-integrity-fixes.md
@@ -1,0 +1,233 @@
+# P0 Data Integrity Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the three confirmed P0 data-loss and data-corruption paths in AnimPack editing, Save/Save As handling, and UTF-8 length-prefixed serialization.
+
+**Architecture:** Keep each fix inside its current ownership boundary. View models remain responsible for dirty-state transitions, `FileSaveService` remains responsible for dialog result semantics, and format parsers remain responsible for byte-accurate prefixes. Add focused regression tests before each production change and avoid unrelated refactoring.
+
+**Tech Stack:** C#, .NET, WPF, ReactiveUI, NUnit/MSTest, existing test utilities
+
+## Global Constraints
+
+- Preserve the existing AnimPack binary and XML formats.
+- Preserve the existing UTF-16 CA string convention of storing UTF-16 code-unit counts.
+- Treat save dialog cancellation and serialization failure as unsuccessful saves.
+- Do not clear dirty state until the corresponding save operation returns a non-null file.
+- Keep changes scoped to the three approved P0 findings.
+- Observe every new regression test failing for the expected reason before changing production code.
+
+---
+
+## Task 1: Make AnimPack child edits part of the save lifecycle
+
+**Files:**
+
+- Modify: `Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/ViewModels/AnimSetTableEditorViewModel.cs`
+- Modify: `Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack/AnimPackViewModel.cs`
+- Add: `Testing/AssetEditorTests/AnimSetTableEditorViewModelTests.cs`
+- Add: `Testing/AssetEditorTests/AnimPackViewModelTests.cs`
+- Modify only if required for project references: `Testing/AssetEditorTests/AssetEditorTests.csproj`
+
+### Step 1: Add failing table dirty-state tests
+
+- [ ] Add tests showing a freshly loaded table is clean.
+- [ ] Add tests showing direct header edits set `IsDirty`.
+- [ ] Add tests showing direct row property edits set `IsDirty`.
+- [ ] Add tests showing row collection changes set `IsDirty`.
+- [ ] Run:
+
+```powershell
+dotnet test Testing/AssetEditorTests/AssetEditorTests.csproj -c Release --filter "FullyQualifiedName~AnimSetTableEditorViewModelTests"
+```
+
+- [ ] Confirm RED because direct header/row/collection edits are not all tracked.
+
+### Step 2: Implement precise table dirty tracking
+
+- [ ] Subscribe to `Rows.CollectionChanged` in the table view model.
+- [ ] Subscribe and unsubscribe row `PropertyChanged` handlers when rows enter or leave the collection.
+- [ ] Mark header and mode property changes dirty through the existing notification setters.
+- [ ] Suppress dirty notifications while `LoadFromBinary` rebuilds the model.
+- [ ] Finish every successful or failed load cleanup path with notification suppression disabled and the loaded model clean.
+- [ ] Re-run the targeted table tests and confirm GREEN.
+
+### Step 3: Add failing AnimPack lifecycle tests
+
+- [ ] Add a test showing pending table edits are considered by the selection-change guard.
+- [ ] Add a test showing the outer `Save()` commits the active table before serializing the parent.
+- [ ] Add a test showing failed child conversion aborts the parent save and preserves dirty state.
+- [ ] Add a test showing successful child commit clears the child dirty flag and leaves the parent dirty until parent persistence succeeds.
+- [ ] Run:
+
+```powershell
+dotnet test Testing/AssetEditorTests/AssetEditorTests.csproj -c Release --filter "FullyQualifiedName~AnimPackViewModelTests"
+```
+
+- [ ] Confirm RED because the current outer save only considers XML editor state.
+
+### Step 4: Implement the unified pending-change lifecycle
+
+- [ ] Add one pending-active-child check that selects table `IsDirty` or XML `HasUnsavedChanges()` according to the active mode.
+- [ ] Use it in entry switching, editor-level unsaved-state reporting, and outer save.
+- [ ] Make outer `Save()` call `SaveActiveFile()` before parent serialization when the active child is pending.
+- [ ] Abort parent serialization when the child commit fails.
+- [ ] Clear the committed child dirty marker only after successful conversion.
+- [ ] Treat a null parent save result as failure and keep the parent dirty.
+- [ ] Re-run both AnimPack test classes and confirm GREEN.
+
+### Step 5: Commit the isolated AnimPack fix
+
+```powershell
+git add Editors/AnimationFragmentEditor/Editor.AnimationFragmentEditor/AnimationPack Testing/AssetEditorTests
+git commit -m "fix: preserve pending AnimPack edits"
+```
+
+---
+
+## Task 2: Correct Save As results and animation dirty-state transitions
+
+**Files:**
+
+- Modify: `Shared/SharedCore/Services/FileSaveService.cs`
+- Modify: `Testing/Shared.Core.Test/Services/FileSaveServiceTests.cs`
+- Modify: `Editors/AnimationEditor/AnimationKeyframeEditor/AnimationKeyframeEditorViewModel.cs`
+- Add or modify: a focused animation keyframe view-model test under an existing editor test project
+
+### Step 1: Add failing FileSaveService tests
+
+- [ ] Add a confirmed-new-path test that expects a returned file and written data.
+- [ ] Add a confirmed-existing-path test that expects overwrite and a returned file.
+- [ ] Add a cancellation test that expects null and no pack mutation.
+- [ ] Run:
+
+```powershell
+dotnet test Testing/Shared.Core.Test/Test.Shared.Core.csproj -c Release --filter "FullyQualifiedName~FileSaveServiceTests"
+```
+
+- [ ] Confirm RED because confirmed Save As currently returns null.
+
+### Step 2: Fix `FileSaveService.SaveAs`
+
+- [ ] Return null only when the dialog is cancelled or the selected path is invalid.
+- [ ] Preserve the current create-or-overwrite behavior for confirmed paths.
+- [ ] Re-run the targeted service tests and confirm GREEN.
+
+### Step 3: Add failing animation save-state tests
+
+- [ ] Add a test showing cancelled ordinary Save keeps `IsDirty` true.
+- [ ] Add a test showing cancelled Save As keeps `IsDirty` true.
+- [ ] Add a test showing a successful save clears `IsDirty`.
+- [ ] Run the owning test project with a class-name filter.
+- [ ] Confirm RED because both animation callers currently clear dirty state unconditionally.
+
+### Step 4: Fix animation callers
+
+- [ ] Capture the result of `IFileSaveService.Save()` and `SaveAs()`.
+- [ ] Clear `IsDirty` only when the result is non-null.
+- [ ] Re-run the animation and service tests and confirm GREEN.
+
+### Step 5: Commit the isolated save fix
+
+```powershell
+git add Shared/SharedCore/Services/FileSaveService.cs Testing/Shared.Core.Test/Services/FileSaveServiceTests.cs Editors/AnimationEditor
+git commit -m "fix: retain dirty state when save is cancelled"
+```
+
+---
+
+## Task 3: Write byte-accurate UTF-8 string lengths
+
+**Files:**
+
+- Modify: `Shared/ByteParsing/Shared.ByteParsing/Parsers/StringParser.cs`
+- Modify: `Shared/ByteParsing/Shared.ByteParsingTest/Parsers/StringParserTest.cs`
+- Modify: `Shared/GameFiles/Dat/DatFileParser.cs`
+- Add: `Testing/FileTypesTests/DatFileParserTests.cs`
+
+### Step 1: Add failing CA string parser tests
+
+- [ ] Add UTF-8 round-trip and prefix assertions for Chinese text.
+- [ ] Add UTF-8 round-trip and prefix assertions for an emoji.
+- [ ] Add the same byte-count assertion for optional UTF-8 strings.
+- [ ] Add a UTF-16 assertion proving its prefix remains the UTF-16 code-unit count.
+- [ ] Run:
+
+```powershell
+dotnet test Shared/ByteParsing/Shared.ByteParsingTest/Shared.ByteParsingTest.csproj -c Release --filter "FullyQualifiedName~StringParserTest"
+```
+
+- [ ] Confirm RED because UTF-8 prefixes currently use `string.Length`.
+
+### Step 2: Fix CA string prefix calculation
+
+- [ ] Encode the value before writing its prefix.
+- [ ] Use encoded byte length for UTF-8 variants.
+- [ ] Use `string.Length` for UTF-16 variants to preserve reader compatibility.
+- [ ] Re-run the targeted parser tests and confirm GREEN.
+
+### Step 3: Add failing DAT serialization tests
+
+- [ ] Create a `SoundDatFile` containing a non-ASCII event string.
+- [ ] Assert `WriteData()` stores `Encoding.UTF8.GetByteCount(value)` in the first string prefix.
+- [ ] Read the produced string through `DatFileParser.ReadStr32` and assert an exact round trip.
+- [ ] Run:
+
+```powershell
+dotnet test Testing/FileTypesTests/FileTypesTests.csproj -c Release --filter "FullyQualifiedName~DatFileParserTests"
+```
+
+- [ ] Confirm RED because `WriteStr32()` currently stores `string.Length`.
+
+### Step 4: Fix DAT prefix calculation
+
+- [ ] Encode the string once.
+- [ ] Store the encoded byte array length.
+- [ ] Append the same encoded bytes.
+- [ ] Re-run DAT and CA parser tests and confirm GREEN.
+
+### Step 5: Commit the isolated serialization fix
+
+```powershell
+git add Shared/ByteParsing Shared/GameFiles/Dat/DatFileParser.cs Testing/FileTypesTests/DatFileParserTests.cs
+git commit -m "fix: write UTF-8 byte lengths"
+```
+
+---
+
+## Task 4: Cross-cutting verification and review
+
+### Step 1: Run all targeted regression tests together
+
+```powershell
+dotnet test Testing/AssetEditorTests/AssetEditorTests.csproj -c Release --filter "FullyQualifiedName~AnimPack"
+dotnet test Testing/Shared.Core.Test/Test.Shared.Core.csproj -c Release --filter "FullyQualifiedName~FileSaveServiceTests"
+dotnet test Shared/ByteParsing/Shared.ByteParsingTest/Shared.ByteParsingTest.csproj -c Release --filter "FullyQualifiedName~StringParserTest"
+dotnet test Testing/FileTypesTests/FileTypesTests.csproj -c Release --filter "FullyQualifiedName~DatFileParserTests"
+```
+
+- [ ] Confirm every targeted regression test passes.
+
+### Step 2: Run repository-wide verification
+
+```powershell
+dotnet test AssetEditor.CN.sln -c Release --no-restore
+dotnet build AssetEditor.CN.sln -c Release --no-restore
+```
+
+- [ ] Record test totals, failures, skips, and build warnings.
+- [ ] If the full suite exposes an unrelated pre-existing failure, prove the three targeted suites still pass and report the blocker precisely.
+
+### Step 3: Review the final diff
+
+```powershell
+git diff --check
+git status --short
+git diff --stat
+```
+
+- [ ] Verify no unrelated files changed.
+- [ ] Verify all dirty-state resets are gated by successful persistence.
+- [ ] Verify UTF-8 writers use byte counts and UTF-16 behavior is unchanged.
+- [ ] Verify loading an AnimPack table remains clean.
+

--- a/docs/superpowers/specs/2026-07-26-p0-data-integrity-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-26-p0-data-integrity-fixes-design.md
@@ -1,0 +1,100 @@
+# P0 Data Integrity Fixes
+
+## Context
+
+The current CN release passes its build and test suite, but three uncovered
+editor paths can still discard or corrupt user data:
+
+1. AnimPack table edits are not committed by the outer save command and are
+   not considered when changing the selected entry.
+2. File Save As treats confirmation as cancellation, while animation callers
+   clear their dirty state even when no file was saved.
+3. UTF-8 string writers store character counts where the formats require byte
+   counts.
+
+## Goals
+
+- Never report an animation edit as clean unless its save returned a file.
+- Commit the active AnimPack child editor before serializing the parent pack.
+- Warn before discarding pending table or XML edits when changing entries.
+- Track direct table header and row edits as dirty without marking freshly
+  loaded data dirty.
+- Write byte-accurate UTF-8 length prefixes for CA strings and DAT strings.
+- Preserve the existing UTF-16 CA string length convention.
+- Add regression tests that fail on the current implementation.
+
+## Non-goals
+
+- Refactoring unrelated save paths.
+- Changing AnimPack binary formats or editor layout.
+- Addressing the lower-priority unknown-format round-trip findings.
+- Optimizing AnimPack loading or 3D rendering.
+
+## Design
+
+### AnimPack edit lifecycle
+
+`AnimSetTableEditorViewModel` will mark itself dirty when a user changes a
+header value, a row value, or the row collection. Loading will suppress those
+notifications and finish with a clean state.
+
+`AnimPackViewModel` will use one pending-change check for both views:
+
+- XML mode uses `SelectedItemViewModel.HasUnsavedChanges()`.
+- Table mode uses `TableEditorVM.IsDirty`.
+
+The outer `Save()` method will commit the active child through
+`SaveActiveFile()` before serializing the parent AnimPack. If child conversion
+fails, parent saving stops and dirty state remains set. A successful child
+commit clears that child editor's dirty marker and marks the parent AnimPack
+dirty until the parent save succeeds.
+
+Changing the selected entry will apply the existing discard confirmation to
+either XML or table changes. Rejecting the confirmation keeps the current
+entry selected. Accepting it preserves the current explicit discard behavior.
+
+The editor-level `HasUnsavedChanges` value will include pending active child
+changes so closing the editor cannot bypass the prompt.
+
+### Save and Save As result handling
+
+`FileSaveService.SaveAs()` will return `null` only for cancellation or an
+invalid selected path. Confirmation will create or overwrite the selected
+PackFile and return it.
+
+Animation save callers will clear `IsDirty` only when `Save()` or `SaveAs()`
+returns a non-null `PackFile`. Cancellation and failure leave the editor dirty.
+
+### UTF-8 length prefixes
+
+`StringParser` will encode the value before building its prefix. UTF-8
+variants will store the encoded byte count. UTF-16 variants will continue to
+store the number of UTF-16 code units because their reader multiplies the
+stored count by two.
+
+`DatFileParser.WriteStr32()` will store the UTF-8 byte array length rather than
+`string.Length`.
+
+## Error handling
+
+- AnimPack child serialization errors abort parent saving.
+- Save dialog cancellation produces no file mutation and no dirty-state reset.
+- Existing parser error reporting remains unchanged.
+
+## Test strategy
+
+Tests will be added before production changes and observed failing for the
+expected reasons.
+
+- File save tests cover Save As confirmation, cancellation, new files, and
+  overwriting existing files.
+- Animation save tests verify cancellation keeps dirty state.
+- AnimPack tests verify direct table edits become dirty, fresh loads remain
+  clean, selection checks table changes, and outer save commits the active
+  table before writing the parent pack.
+- String parser tests cover Chinese, emoji, optional UTF-8 strings, and the
+  unchanged UTF-16 length convention.
+- DAT tests perform non-ASCII round trips and verify the stored byte count.
+
+After targeted tests pass, run the complete `AssetEditor.CN.sln` test suite,
+the Release build, and a clean worktree check.


### PR DESCRIPTION
## Summary

- preserve pending AnimPack table and XML edits across selection changes, view switches, child saves, and parent saves
- track direct table and structural changes, synchronize both editor representations, and retain dirty state when persistence fails
- correct Save As confirmation handling and keep animation editors dirty after cancellation
- write UTF-8 byte lengths for CA and DAT strings while preserving the UTF-16 code-unit convention
- add regression coverage for all corrected paths

## Root causes

The affected paths either serialized stale child state, treated a confirmed Save As result as cancellation, cleared dirty flags without a saved file, or prefixed UTF-8 data with character counts instead of encoded byte counts.

## User impact

These changes prevent silent AnimPack edit loss, false clean states after cancelled saves, and corruption of non-ASCII serialized strings.

## Validation

- `dotnet test AssetEditor.CN.sln -c Release --no-restore`: 371 tests passed
- `dotnet build AssetEditor.CN.sln -c Release --no-restore`: completed with 0 errors
- `git diff --check`: passed