### PR TITLE
Prevent MainWindow close reentrancy during asynchronous approval

### DIFF
--- a/AssetEditor/Views/MainWindow.xaml.cs
+++ b/AssetEditor/Views/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using AssetEditor.ViewModels;
 using CommonControls;
 using Microsoft.Extensions.DependencyInjection;
@@ -66,6 +67,8 @@ namespace AssetEditor.Views
                     return;
 
                 _closeApproved = true;
+                await System.Windows.Threading.Dispatcher.Yield(
+                    DispatcherPriority.Normal);
                 Close();
             }
             finally

--- a/Testing/AssetEditorTests/MainViewModelCloseTests.cs
+++ b/Testing/AssetEditorTests/MainViewModelCloseTests.cs
@@ -1,6 +1,9 @@
 using System.Windows;
+using System.Windows.Threading;
 using AssetEditor.Services;
 using AssetEditor.ViewModels;
+using AssetEditor.Views;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Shared.Core.Events;
 using Shared.Core.PackFiles;
@@ -11,6 +14,8 @@ using Shared.Core.Settings;
 using Shared.Core.ToolCreation;
 using Shared.Ui.BaseDialogs.PackFileTree;
 using Shared.Ui.BaseDialogs.PackFileTree.ContextMenu;
+using Shared.Ui.Common;
+using Shared.Ui.Common.ValueConverters;
 
 namespace AssetEditorTests;
 
@@ -20,6 +25,82 @@ public class MainViewModelCloseTests
     public void SetUp()
     {
         new LocalizationManager().LoadLanguage();
+    }
+
+    [NUnit.Framework.Test]
+    [NUnit.Framework.Apartment(ApartmentState.STA)]
+    public void Closing_SynchronousApproval_ClosesAfterClosingEventReturns()
+    {
+        var pack = new PackFileContainer("普通 Pack");
+        var editorManager = new Mock<IEditorManager>();
+        editorManager
+            .Setup(manager => manager.ShouldBlockCloseCommand(
+                It.IsAny<IEditorInterface>(),
+                It.IsAny<bool>()))
+            .Returns(true);
+        var viewModel = CreateMainViewModel(
+            editorManager.Object,
+            pack);
+        var settings = new ApplicationSettingsService(
+            GameTypeEnum.Warhammer3);
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton(LocalizationManager.Instance)
+            .AddSingleton(new PackAutoSaveService(
+                Mock.Of<IPackFileService>(),
+                settings))
+            .BuildServiceProvider();
+        NUnit.Framework.Assert.That(
+            Application.Current,
+            NUnit.Framework.Is.Null.Or.InstanceOf<TestApplication>());
+        _ = Application.Current as TestApplication ??
+            new TestApplication(serviceProvider);
+        NUnit.Framework.Assert.That(
+            Application.Current,
+            NUnit.Framework.Is.InstanceOf<IAssetEditorMain>());
+        var window = new MainWindow(settings, serviceProvider)
+        {
+            DataContext = viewModel
+        };
+        Exception? dispatcherException = null;
+        var closed = false;
+        DispatcherUnhandledExceptionEventHandler onUnhandledException =
+            (_, args) =>
+            {
+                dispatcherException = args.Exception;
+                args.Handled = true;
+            };
+        window.Dispatcher.UnhandledException += onUnhandledException;
+        window.Closed += (_, _) => closed = true;
+
+        try
+        {
+            var dispatcherFrame = new DispatcherFrame();
+            window.Show();
+            window.Dispatcher.BeginInvoke(
+                new Action(window.Close),
+                DispatcherPriority.Normal);
+            window.Dispatcher.BeginInvoke(
+                new Action(() => dispatcherFrame.Continue = false),
+                DispatcherPriority.Background);
+            Dispatcher.PushFrame(dispatcherFrame);
+
+            NUnit.Framework.Assert.Multiple(() =>
+            {
+                NUnit.Framework.Assert.That(
+                    dispatcherException,
+                    NUnit.Framework.Is.Null);
+                NUnit.Framework.Assert.That(
+                    closed,
+                    NUnit.Framework.Is.True);
+            });
+        }
+        finally
+        {
+            window.Dispatcher.UnhandledException -= onUnhandledException;
+            if (window.IsVisible)
+                window.Close();
+            viewModel.FileTree.Dispose();
+        }
     }
 
     [NUnit.Framework.Test]
@@ -231,5 +312,31 @@ public class MainViewModelCloseTests
                 guard => guard.CanCloseAsync(
                     It.IsAny<FolderProjectContainer>()) ==
                     Task.FromResult(true)));
+    }
+
+    private sealed class TestApplication : Application, IAssetEditorMain
+    {
+        public IServiceProvider ServiceProvider { get; }
+
+        public TestApplication(IServiceProvider serviceProvider)
+        {
+            ServiceProvider = serviceProvider;
+            ShutdownMode = ShutdownMode.OnExplicitShutdown;
+            Resources.MergedDictionaries.Add(CreateResourceDictionary(
+                "Themes/ColourDictionaries/DarkTheme.xaml"));
+            Resources.MergedDictionaries.Add(CreateResourceDictionary(
+                "Themes/ControlColours.xaml"));
+            Resources.MergedDictionaries.Add(CreateResourceDictionary(
+                "Themes/Controls.xaml"));
+            Resources["BoolToChangedPrefixStr"] =
+                new BoolToStringConverter { TrueValue = "*" };
+        }
+
+        private static ResourceDictionary CreateResourceDictionary(
+            string path) => new()
+            {
+                Source = new Uri(
+                    $"pack://application:,,,/AssetEditor.CN;component/{path}")
+            };
     }
 }


### PR DESCRIPTION
## Summary
- Yield the dispatcher before closing `MainWindow` after asynchronous close approval.
- Add an STA regression test covering synchronous approval, dispatcher exceptions, and the final closed state.

## Testing
- Added and ran the `MainViewModelCloseTests` regression coverage for the close workflow.