### PR TITLE
Synchronize Kitbash edit overlays across selection and rendering

### DIFF
--- a/GameWorld/ContentProject/Content/Shaders/EdgeQuadShader.fx
+++ b/GameWorld/ContentProject/Content/Shaders/EdgeQuadShader.fx
@@ -17,6 +17,7 @@ float ViewportWidth;
 float OverlayOpacity = 1.0;
 float BaseOpacity = 1.0;
 float EdgeDepthBias = 0.0;
+float EdgeHalfWidth = 1.0;
 float3 OverlayColor;
 bool CapabilityFlag_ApplyAnimation = false;
 float4x4 Animation_Tranforms[256];
@@ -172,7 +173,7 @@ VSOutput AnimatedEdgeQuadVS(
         mul(worldP1, ViewProjection),
         OverlayColor,
         OverlayColor,
-        1.0);
+        EdgeHalfWidth);
 }
 
 float4 EdgeQuadPS(VSOutput input) : COLOR0

--- a/GameWorld/View3D/Components/Selection/EdgeOverlayDataBuilder.cs
+++ b/GameWorld/View3D/Components/Selection/EdgeOverlayDataBuilder.cs
@@ -10,7 +10,6 @@ internal static class EdgeOverlayDataBuilder
 {
     private static readonly Vector3 WireColor = new(0.15f, 0.15f, 0.15f);
     private static readonly Vector3 SelectedColor = new(1.0f, 0.47f, 0.0f);
-    private const float SelectedEdgeHalfWidth = 1.25f;
 
     public static void Fill(
         Span<EdgeData> destination,
@@ -76,57 +75,4 @@ internal static class EdgeOverlayDataBuilder
         }
     }
 
-    public static void FillSelected(
-        Span<EdgeData> destination,
-        MeshObject geometry,
-        Matrix modelMatrix,
-        IReadOnlyList<(int v0, int v1)> edges)
-    {
-        ArgumentNullException.ThrowIfNull(geometry);
-        ArgumentNullException.ThrowIfNull(edges);
-
-        if (destination.Length != edges.Count)
-            throw new ArgumentException("The destination length must match the edge count.", nameof(destination));
-
-        for (var i = 0; i < edges.Count; i++)
-        {
-            var (v0, v1) = edges[i];
-            destination[i] = new EdgeData
-            {
-                P0 = Vector3.Transform(geometry.GetVertexById(v0), modelMatrix),
-                P1 = Vector3.Transform(geometry.GetVertexById(v1), modelMatrix),
-                C0 = SelectedColor,
-                C1 = SelectedColor,
-                Width = SelectedEdgeHalfWidth
-            };
-        }
-    }
-
-    public static void FillSelected(
-        Span<EdgeData> destination,
-        IReadOnlyList<Vector3> worldPositions,
-        IReadOnlyList<(int v0, int v1)> edges)
-    {
-        ArgumentNullException.ThrowIfNull(worldPositions);
-        ArgumentNullException.ThrowIfNull(edges);
-        if (destination.Length != edges.Count)
-        {
-            throw new ArgumentException(
-                "The destination length must match the edge count.",
-                nameof(destination));
-        }
-
-        for (var i = 0; i < edges.Count; i++)
-        {
-            var (v0, v1) = edges[i];
-            destination[i] = new EdgeData
-            {
-                P0 = worldPositions[v0],
-                P1 = worldPositions[v1],
-                C0 = SelectedColor,
-                C1 = SelectedColor,
-                Width = SelectedEdgeHalfWidth
-            };
-        }
-    }
 }

--- a/GameWorld/View3D/Components/Selection/SelectionManager.cs
+++ b/GameWorld/View3D/Components/Selection/SelectionManager.cs
@@ -64,17 +64,9 @@ namespace GameWorld.Core.Components.Selection
         private int _sampleIdx1 = 1;
 
         const int MaxRenderEdges = 50000;
+        const float SelectedEdgeHalfWidth = 2.0f;
         private EdgeData[] _edgeDataCache = Array.Empty<EdgeData>();
-        private (int v0, int v1)[] _selectedEdgeIndicesCache = Array.Empty<(int, int)>();
-        private EdgeData[] _selectedEdgeDataCache = Array.Empty<EdgeData>();
-        private Matrix _cachedSelectedEdgeRenderMatrix;
-        private Vector3 _selectedEdgeSamplePos0;
-        private Vector3 _selectedEdgeSamplePos1;
         private bool _selectedEdgeDataDirty = true;
-        private AnimationPlayer?
-            _cachedSelectedEdgeAnimationPlayer;
-        private long _cachedSelectedEdgeAnimationTimeUs =
-            long.MinValue;
 
         public SelectionManager(IEventHub eventHub, RenderEngineComponent renderEngine, IScopedResourceLibrary resourceLib, IDeviceResolver deviceResolverComponent)
         {
@@ -448,83 +440,16 @@ namespace GameWorld.Core.Components.Selection
                     RenderBuckedId.Wireframe,
                     GetWireframeRenderItem(edgeNode, pose));
 
-                if (!ShouldRenderDenseEditOverlay(
-                        edgeNode,
-                        pose))
+                if (selectionEdgeState
+                        .SelectedEdges.Count > 0)
                 {
-                    if (selectionEdgeState
-                            .SelectedEdges.Count > 0)
-                    {
-                        _renderEngine.AddRenderItem(
-                            RenderBuckedId.Selection,
-                            GetSelectedEdgeWireframeRenderItem(
-                                edgeNode,
-                                pose,
-                                selectionEdgeState
-                                    .SelectedEdges));
-                    }
-                }
-                else
-                {
-                    if (!_selectedEdgeDataDirty &&
-                        _selectedEdgeIndicesCache.Length >
-                            0)
-                    {
-                        var sampleEdge =
-                            _selectedEdgeIndicesCache[0];
-                        if (_cachedSelectedEdgeRenderMatrix !=
-                                pose.WorldTransform ||
-                            _selectedEdgeSamplePos0 !=
-                                edgeNode.Geometry
-                                    .GetVertexById(
-                                        sampleEdge.v0) ||
-                            _selectedEdgeSamplePos1 !=
-                                edgeNode.Geometry
-                                    .GetVertexById(
-                                        sampleEdge.v1))
-                        {
-                            _selectedEdgeDataDirty = true;
-                        }
-                    }
-
-                    var animationTimeUs =
-                        GetAnimationTimeUs(
+                    _renderEngine.AddRenderItem(
+                        RenderBuckedId.Selection,
+                        GetSelectedEdgeWireframeRenderItem(
                             edgeNode,
-                            pose);
-                    if (!_selectedEdgeDataDirty &&
-                        (!ReferenceEquals(
-                             _cachedSelectedEdgeAnimationPlayer,
-                             edgeNode.AnimationPlayer) ||
-                         _cachedSelectedEdgeAnimationTimeUs !=
-                             animationTimeUs))
-                    {
-                        _selectedEdgeDataDirty = true;
-                    }
-
-                    if (_selectedEdgeDataDirty)
-                    {
-                        var worldPositions =
-                            selectionEdgeState
-                                .SelectedEdges.Count == 0
-                                ? Array.Empty<Vector3>()
-                                : pose.GetWorldPositions();
-                        UpdateSelectedEdgeQuadData(
                             pose,
-                            worldPositions,
-                            selectionEdgeState);
-                        _cachedSelectedEdgeAnimationPlayer =
-                            edgeNode.AnimationPlayer;
-                        _cachedSelectedEdgeAnimationTimeUs =
-                            animationTimeUs;
-                    }
-
-                    if (_selectedEdgeDataCache.Length >
-                        0)
-                    {
-                        _renderEngine.AddRenderItem(
-                            RenderBuckedId.Selection,
-                            _edgeQuadRenderItem);
-                    }
+                            selectionEdgeState
+                                .SelectedEdges));
                 }
             }
 
@@ -645,7 +570,8 @@ namespace GameWorld.Core.Components.Selection
                         new Vector4(1, 0.47f, 0, 1),
                         0)
                     {
-                        DepthBias = 0.00004f
+                        DepthBias = 0.00004f,
+                        EdgeHalfWidth = SelectedEdgeHalfWidth
                     };
                 _selectedEdgeDataDirty = true;
             }
@@ -732,40 +658,6 @@ namespace GameWorld.Core.Components.Selection
 
             _edgeQuadRenderItem.Edges = _edgeDataCache;
             _edgeQuadRenderItem.MarkDirty();
-        }
-
-        private void UpdateSelectedEdgeQuadData(
-            MeshPoseSnapshot pose,
-            IReadOnlyList<Vector3> worldPositions,
-            EdgeSelectionState selectionState)
-        {
-            var selectedEdgeCount = selectionState.SelectedEdges.Count;
-            if (_selectedEdgeIndicesCache.Length != selectedEdgeCount)
-            {
-                _selectedEdgeIndicesCache = new (int, int)[selectedEdgeCount];
-                _selectedEdgeDataCache = new EdgeData[selectedEdgeCount];
-            }
-
-            selectionState.SelectedEdges.CopyTo(_selectedEdgeIndicesCache);
-            EdgeOverlayDataBuilder.FillSelected(
-                _selectedEdgeDataCache,
-                worldPositions,
-                _selectedEdgeIndicesCache);
-
-            _cachedSelectedEdgeRenderMatrix =
-                pose.WorldTransform;
-            if (selectedEdgeCount > 0)
-            {
-                var sampleEdge = _selectedEdgeIndicesCache[0];
-                _selectedEdgeSamplePos0 =
-                    pose.Geometry.GetVertexById(sampleEdge.v0);
-                _selectedEdgeSamplePos1 =
-                    pose.Geometry.GetVertexById(sampleEdge.v1);
-            }
-
-            _edgeQuadRenderItem.Edges = _selectedEdgeDataCache;
-            _edgeQuadRenderItem.MarkDirty();
-            _selectedEdgeDataDirty = false;
         }
 
         private void ResetEdgeCache()

--- a/GameWorld/View3D/Rendering/Geometry/MeshObject.cs
+++ b/GameWorld/View3D/Rendering/Geometry/MeshObject.cs
@@ -28,6 +28,7 @@ namespace GameWorld.Core.Rendering.Geometry
         public UiVertexFormat VertexFormat { get; private set; } = UiVertexFormat.Unknown;
         public string SkeletonName { get; private set; }  // SkeletonName
         public int TopologyVersion { get; private set; }
+        public int VertexDataVersion { get; private set; }
 
 
         public IGraphicsCardGeometry GetGeometryContext() => Context;
@@ -491,6 +492,7 @@ namespace GameWorld.Core.Rendering.Geometry
         public void RebuildVertexBuffer()
         {
             Context.RebuildVertexBuffer(VertexArray, VertexPositionNormalTextureCustom.VertexDeclaration);
+            VertexDataVersion++;
             if (!DeferBoundingBoxRebuild)
                 BuildBoundingBox();
         }
@@ -502,6 +504,7 @@ namespace GameWorld.Core.Rendering.Geometry
             Context.RebuildVertexBufferPartial(VertexArray, startIndex, count,
                 VertexPositionNormalTextureCustom.VertexDeclaration,
                 VertexPositionNormalTextureCustom.VertexDeclaration.VertexStride);
+            VertexDataVersion++;
         }
 
         public void RebuildIndexBuffer()

--- a/GameWorld/View3D/Rendering/RenderItems/AnimatedWireframeRenderItem.cs
+++ b/GameWorld/View3D/Rendering/RenderItems/AnimatedWireframeRenderItem.cs
@@ -70,10 +70,14 @@ namespace GameWorld.Core.Rendering.RenderItems
         ushort[] _lineIndices = [];
         VertexBuffer? _quadVertexBuffer;
         IndexBuffer? _quadIndexBuffer;
-        VertexBuffer? _instanceBuffer;
+        DynamicVertexBuffer? _instanceBuffer;
+        AnimatedEdgeQuadInstanceData[] _instanceData = [];
         VertexBufferBinding[] _bindings = [];
+        int _vertexDataVersion = -1;
+        bool _instanceDataDirty = true;
 
         public float DepthBias { get; set; } = 0.00002f;
+        public float EdgeHalfWidth { get; set; } = 1.0f;
         internal int IndexBufferBuildCount { get; private set; }
         internal int EdgePrimitiveCount =>
             _lineIndices.Length / 2;
@@ -109,6 +113,10 @@ namespace GameWorld.Core.Rendering.RenderItems
                 !ReferenceEquals(
                     _pose.Geometry,
                     pose.Geometry);
+            var vertexDataChanged =
+                geometryChanged ||
+                _vertexDataVersion !=
+                    pose.Geometry.VertexDataVersion;
             _pose = pose;
             if (_renderFullTopology)
             {
@@ -123,6 +131,9 @@ namespace GameWorld.Core.Rendering.RenderItems
             {
                 UpdateSelectedEdgeTopology();
             }
+
+            if (vertexDataChanged)
+                _instanceDataDirty = true;
         }
 
         public void UpdateEdges(
@@ -189,6 +200,8 @@ namespace GameWorld.Core.Rendering.RenderItems
                 _colour.W);
             effect.Parameters["EdgeDepthBias"].SetValue(
                 DepthBias);
+            effect.Parameters["EdgeHalfWidth"].SetValue(
+                EdgeHalfWidth);
             effect.Parameters["OverlayOpacity"].SetValue(
                 EditOverlayVisibility.CalculateDetailOpacity(
                     _pose.GetConservativeAnimatedBounds(),
@@ -253,7 +266,7 @@ namespace GameWorld.Core.Rendering.RenderItems
                 EdgeIndexCacheBuilder.BuildLineIndices(
                     indices,
                     _maxEdges);
-            InvalidateInstanceBuffer();
+            _instanceDataDirty = true;
         }
 
         void UpdateSelectedEdgeTopology()
@@ -281,45 +294,64 @@ namespace GameWorld.Core.Rendering.RenderItems
             _topologyVersion =
                 _pose.Geometry.TopologyVersion;
             _lineIndices = lineIndices.ToArray();
-            InvalidateInstanceBuffer();
+            _instanceDataDirty = true;
         }
 
         void EnsureBuffers(GraphicsDevice device)
         {
             if (_quadVertexBuffer == null)
                 CreateQuadBuffers(device);
-            if (_instanceBuffer != null)
+            if (_instanceBuffer == null ||
+                _instanceBuffer.VertexCount !=
+                    EdgePrimitiveCount)
+            {
+                _instanceBuffer?.Dispose();
+                _instanceBuffer = new DynamicVertexBuffer(
+                    device,
+                    AnimatedEdgeQuadInstanceData.VertexDeclaration,
+                    EdgePrimitiveCount,
+                    BufferUsage.WriteOnly);
+                _bindings =
+                [
+                    new VertexBufferBinding(_quadVertexBuffer),
+                    new VertexBufferBinding(_instanceBuffer, 0, 1)
+                ];
+                _instanceDataDirty = true;
+                IndexBufferBuildCount++;
+            }
+
+            if (!_instanceDataDirty)
                 return;
 
             var instances = BuildInstanceData();
-            _instanceBuffer = new VertexBuffer(
-                device,
-                AnimatedEdgeQuadInstanceData.VertexDeclaration,
+            _instanceBuffer.SetData(
+                instances,
+                0,
                 instances.Length,
-                BufferUsage.WriteOnly);
-            _instanceBuffer.SetData(instances);
-            _bindings =
-            [
-                new VertexBufferBinding(_quadVertexBuffer),
-                new VertexBufferBinding(_instanceBuffer, 0, 1)
-            ];
-            IndexBufferBuildCount++;
+                SetDataOptions.Discard);
+            _vertexDataVersion =
+                _pose.Geometry.VertexDataVersion;
+            _instanceDataDirty = false;
         }
 
         AnimatedEdgeQuadInstanceData[] BuildInstanceData()
         {
-            var instances =
-                new AnimatedEdgeQuadInstanceData[
-                    EdgePrimitiveCount];
+            if (_instanceData.Length != EdgePrimitiveCount)
+            {
+                _instanceData =
+                    new AnimatedEdgeQuadInstanceData[
+                        EdgePrimitiveCount];
+            }
+
             for (var edgeIndex = 0;
-                 edgeIndex < instances.Length;
+                 edgeIndex < _instanceData.Length;
                  edgeIndex++)
             {
                 var first = _pose.Geometry.VertexArray[
                     _lineIndices[edgeIndex * 2]];
                 var second = _pose.Geometry.VertexArray[
                     _lineIndices[edgeIndex * 2 + 1]];
-                instances[edgeIndex] =
+                _instanceData[edgeIndex] =
                     new AnimatedEdgeQuadInstanceData
                     {
                         BindP0 = first.Position3(),
@@ -331,7 +363,7 @@ namespace GameWorld.Core.Rendering.RenderItems
                     };
             }
 
-            return instances;
+            return _instanceData;
         }
 
         void CreateQuadBuffers(GraphicsDevice device)
@@ -367,13 +399,6 @@ namespace GameWorld.Core.Rendering.RenderItems
             _quadIndexBuffer.SetData(indices);
         }
 
-        void InvalidateInstanceBuffer()
-        {
-            _instanceBuffer?.Dispose();
-            _instanceBuffer = null;
-            _bindings = [];
-        }
-
         public void Dispose()
         {
             _instanceBuffer?.Dispose();
@@ -382,6 +407,7 @@ namespace GameWorld.Core.Rendering.RenderItems
             _instanceBuffer = null;
             _quadVertexBuffer = null;
             _quadIndexBuffer = null;
+            _instanceData = [];
             _bindings = [];
         }
     }

--- a/GameWorld/View3D/Rendering/VertexInstanceMesh.cs
+++ b/GameWorld/View3D/Rendering/VertexInstanceMesh.cs
@@ -77,6 +77,9 @@ namespace GameWorld.Core.Rendering
         // Blender uses same base size, but we add slight boost for visibility
         public float SelectedSizeBoost { get; set; } = 1.0f;
 
+        // Animated edit mode also shows a dense skinned wireframe, so its points need more separation.
+        const float AnimatedVertexSizeBoost = 1.5f;
+
         // Selection threshold multiplier (selection radius = render radius * this)
         public float SelectionThresholdMultiplier { get; set; } = 2.0f;
 
@@ -246,6 +249,7 @@ namespace GameWorld.Core.Rendering
                     selectedVertexes.VertexWeights[i];
                 _instanceData[i].InstanceScale =
                     VertexPixelSize +
+                    AnimatedVertexSizeBoost +
                     weight * SelectedSizeBoost;
                 _instanceData[i].InstanceColor =
                     Vector3.Lerp(

--- a/Testing/GameWorld.Core.Test/Components/Selection/EdgeOverlayDataBuilderTests.cs
+++ b/Testing/GameWorld.Core.Test/Components/Selection/EdgeOverlayDataBuilderTests.cs
@@ -53,27 +53,6 @@ public class EdgeOverlayDataBuilderTests
     }
 
     [Test]
-    public void FillSelected_UsesSelectionColorAndWiderScreenSpaceQuad()
-    {
-        var destination = new EdgeData[1];
-
-        EdgeOverlayDataBuilder.FillSelected(
-            destination,
-            CreateMesh(),
-            Matrix.Identity,
-            new[] { (0, 1) });
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(destination[0].P0, Is.EqualTo(new Vector3(1.0f, 2.0f, 3.0f)));
-            Assert.That(destination[0].P1, Is.EqualTo(new Vector3(-1.0f, 0.0f, 2.0f)));
-            Assert.That(destination[0].C0, Is.EqualTo(new Vector3(1.0f, 0.47f, 0.0f)));
-            Assert.That(destination[0].C1, Is.EqualTo(new Vector3(1.0f, 0.47f, 0.0f)));
-            Assert.That(destination[0].Width, Is.EqualTo(1.25f));
-        });
-    }
-
-    [Test]
     public void Fill_EvaluatedWorldPositionsUseCurrentPoseEndpoints()
     {
         var destination = new EdgeData[1];
@@ -98,33 +77,6 @@ public class EdgeOverlayDataBuilderTests
             Assert.That(
                 destination[0].P1,
                 Is.EqualTo(worldPositions[1]));
-        });
-    }
-
-    [Test]
-    public void FillSelected_EvaluatedWorldPositionsUseCurrentPoseEndpoints()
-    {
-        var destination = new EdgeData[1];
-        var worldPositions = new[]
-        {
-            new Vector3(20, 21, 22),
-            new Vector3(30, 31, 32),
-            new Vector3(40, 41, 42)
-        };
-
-        EdgeOverlayDataBuilder.FillSelected(
-            destination,
-            worldPositions,
-            new[] { (1, 2) });
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(
-                destination[0].P0,
-                Is.EqualTo(worldPositions[1]));
-            Assert.That(
-                destination[0].P1,
-                Is.EqualTo(worldPositions[2]));
         });
     }
 

--- a/Testing/GameWorld.Core.Test/Rendering/AnimatedWireframeOffscreenTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/AnimatedWireframeOffscreenTests.cs
@@ -117,6 +117,127 @@ public class AnimatedWireframeOffscreenTests
     }
 
     [Test]
+    public void Draw_VertexMutationMovesWireframeWithoutRecreatingInstanceBuffer()
+    {
+        var game = new WpfGameMock();
+        var device = game.GraphicsDevice;
+        var effect = game.Content.Load<Effect>(
+            "Shaders\\EdgeQuadShader");
+        var resources = new Mock<IScopedResourceLibrary>();
+        resources
+            .Setup(library =>
+                library.GetStaticEffect(
+                    ShaderTypes.EdgeQuad))
+            .Returns(effect);
+        var mesh = CreateMesh(device);
+        var pose = MeshPoseSnapshot.Create(
+            mesh,
+            Matrix.Identity,
+            [],
+            false);
+        using var renderItem =
+            new AnimatedWireframeRenderItem(
+                pose,
+                resources.Object,
+                Vector4.One,
+                50_000);
+        using var renderTarget = new RenderTarget2D(
+            device,
+            64,
+            64,
+            false,
+            SurfaceFormat.Color,
+            DepthFormat.Depth24);
+        var parameters = new CommonShaderParameters(
+            Matrix.Identity,
+            Matrix.Identity,
+            Vector3.Zero,
+            Vector3.Forward,
+            0,
+            0,
+            0,
+            1,
+            Vector3.One,
+            []);
+
+        try
+        {
+            device.SetRenderTarget(renderTarget);
+            device.Clear(
+                ClearOptions.Target |
+                    ClearOptions.DepthBuffer,
+                Color.Transparent,
+                1,
+                0);
+            device.BlendState = BlendState.Opaque;
+            device.DepthStencilState =
+                DepthStencilState.Default;
+            device.RasterizerState =
+                RasterizerState.CullNone;
+            renderItem.Draw(
+                device,
+                parameters,
+                RenderingTechnique.Normal);
+
+            for (var i = 0;
+                i < mesh.VertexArray.Length;
+                i++)
+            {
+                mesh.VertexArray[i].Position.X += 1.25f;
+            }
+
+            mesh.RebuildVertexBufferPartial(
+                0,
+                mesh.VertexArray.Length - 1);
+            renderItem.UpdatePose(
+                MeshPoseSnapshot.Create(
+                    mesh,
+                    Matrix.Identity,
+                    [],
+                    false));
+
+            device.Clear(
+                ClearOptions.Target |
+                    ClearOptions.DepthBuffer,
+                Color.Transparent,
+                1,
+                0);
+            renderItem.Draw(
+                device,
+                parameters,
+                RenderingTechnique.Normal);
+        }
+        finally
+        {
+            device.SetRenderTarget(null);
+        }
+
+        var pixels = new Color[64 * 64];
+        renderTarget.GetData(pixels);
+        var leftPixels = CountVisiblePixels(
+            pixels,
+            64,
+            0,
+            32);
+        var rightPixels = CountVisiblePixels(
+            pixels,
+            64,
+            32,
+            64);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(leftPixels, Is.EqualTo(0));
+            Assert.That(rightPixels, Is.GreaterThan(0));
+            Assert.That(
+                renderItem.IndexBufferBuildCount,
+                Is.EqualTo(1));
+        });
+
+        mesh.Dispose();
+    }
+
+    [Test]
     public void DefaultOverlay_KeepsAllUniqueEdgesAndSupportsSelectedSubset()
     {
         var game = new WpfGameMock();

--- a/Testing/GameWorld.Core.Test/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
@@ -1,8 +1,13 @@
 using System.Reflection;
+using GameWorld.Core.Animation;
 using GameWorld.Core.Components;
 using GameWorld.Core.Components.Input;
 using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.Components.Selection;
 using GameWorld.Core.Rendering;
+using GameWorld.Core.Rendering.Geometry;
+using GameWorld.Core.Rendering.RenderItems;
+using GameWorld.Core.SceneNodes;
 using GameWorld.Core.Services;
 using GameWorld.Core.Utility;
 using Microsoft.Xna.Framework;
@@ -10,7 +15,12 @@ using Microsoft.Xna.Framework.Graphics;
 using Moq;
 using Shared.Core.Events;
 using Shared.Core.PackFiles;
+using Shared.Core.Services;
 using Shared.Core.Settings;
+using Shared.GameFormats.Animation;
+using Shared.GameFormats.RigidModel;
+using Shared.GameFormats.RigidModel.MaterialHeaders;
+using Shared.GameFormats.RigidModel.Transforms;
 using Test.TestingUtility.Shared;
 
 namespace GameWorld.Core.Test.Rendering;
@@ -18,6 +28,161 @@ namespace GameWorld.Core.Test.Rendering;
 [NonParallelizable]
 public class RenderEngineSelectionMaskOffscreenTests
 {
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Render3DObjects_SelectedEdgeRemainsOrangeOverWireframe(
+        bool animated)
+    {
+        const int size = 64;
+        var game = new WpfGameMock();
+        var device = game.GraphicsDevice;
+        var deviceResolver = new Mock<IDeviceResolver>();
+        deviceResolver
+            .SetupGet(resolver => resolver.Device)
+            .Returns(device);
+        var camera = new ArcBallCamera(
+            deviceResolver.Object,
+            new Mock<IKeyboardComponent>().Object,
+            new Mock<IMouseComponent>().Object);
+        camera.Initialize();
+        var resources = new ResourceLibrary(
+            new Mock<IPackFileService>().Object);
+        resources.Initialize(device, game.Content);
+        var eventHub = new Mock<IEventHub>();
+        using var scopedResources =
+            new ScopedResourceLibrary(
+                resources,
+                eventHub.Object,
+                new Mock<IStandardDialogs>().Object);
+        var grid = new GridComponent(
+            camera,
+            resources,
+            deviceResolver.Object)
+        {
+            ShowGrid = false
+        };
+        var renderEngine = new RenderEngineComponent(
+            game,
+            resources,
+            camera,
+            deviceResolver.Object,
+            new ApplicationSettingsService(),
+            new SceneRenderParametersStore(),
+            eventHub.Object,
+            grid);
+        renderEngine.Initialize();
+        var selectionManager = new SelectionManager(
+            eventHub.Object,
+            renderEngine,
+            scopedResources,
+            deviceResolver.Object);
+        selectionManager.Initialize();
+        var mesh = CreateMesh(device, animated);
+        var material = new Mock<IRmvMaterial>();
+        material.SetupGet(value => value.ModelName).Returns("test");
+        material.SetupGet(value => value.PivotPoint).Returns(Vector3.Zero);
+        var animationPlayer = animated
+            ? CreateAnimationPlayer()
+            : new AnimationPlayer { IsEnabled = false };
+        var node = new Rmv2MeshNode(
+            mesh,
+            material.Object,
+            null!,
+            animationPlayer);
+        selectionManager.SetState(
+            new EdgeSelectionState
+            {
+                RenderObject = node,
+                SelectedEdges = [(0, 1)]
+            });
+        using var surface = new SolidMeshRenderItem(device);
+        renderEngine.AddRenderItem(
+            RenderBuckedId.Normal,
+            surface);
+        selectionManager.Draw(new GameTime());
+        var selectionRenderItems = GetRenderItems(
+            renderEngine,
+            RenderBuckedId.Selection);
+        Assert.That(
+            selectionRenderItems,
+            Has.Exactly(1)
+                .TypeOf<AnimatedWireframeRenderItem>(),
+            "Static and animated selected edges must use the same visible, depth-biased wireframe path.");
+        using var renderTarget = new RenderTarget2D(
+            device,
+            size,
+            size,
+            false,
+            SurfaceFormat.Color,
+            DepthFormat.Depth24);
+
+        device.SetRenderTarget(renderTarget);
+        device.Clear(
+            ClearOptions.Target | ClearOptions.DepthBuffer,
+            Color.Transparent,
+            1,
+            0);
+        device.BlendState = BlendState.Opaque;
+        device.DepthStencilState = DepthStencilState.Default;
+        InvokeRender3DObjects(renderEngine);
+        device.SetRenderTarget(null);
+
+        var pixels = new Color[size * size];
+        renderTarget.GetData(pixels);
+        var orangePixels = pixels.Count(IsOrange);
+        var widestOrangeColumn = Enumerable.Range(0, size)
+            .Max(
+                x => Enumerable.Range(0, size)
+                    .Count(
+                        y => IsOrange(pixels[y * size + x])));
+        var initialOrangeRow = GetAverageOrangeRow(
+            pixels,
+            size);
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                orangePixels,
+                Is.GreaterThan(0),
+                "A selected edge must remain orange when it overlaps the black edit wireframe.");
+            Assert.That(
+                widestOrangeColumn,
+                Is.GreaterThanOrEqualTo(2),
+                "A selected edge must be visibly thicker than the one-pixel edit wireframe.");
+        });
+
+        mesh.VertexArray[0].Position.Y += 0.6f;
+        mesh.VertexArray[1].Position.Y += 0.6f;
+        mesh.RebuildVertexBufferPartial(0, 1);
+        renderEngine.Update(new GameTime());
+        renderEngine.AddRenderItem(
+            RenderBuckedId.Normal,
+            surface);
+        selectionManager.Draw(new GameTime());
+
+        device.SetRenderTarget(renderTarget);
+        device.Clear(
+            ClearOptions.Target | ClearOptions.DepthBuffer,
+            Color.Transparent,
+            1,
+            0);
+        device.BlendState = BlendState.Opaque;
+        device.DepthStencilState = DepthStencilState.Default;
+        InvokeRender3DObjects(renderEngine);
+        device.SetRenderTarget(null);
+        renderTarget.GetData(pixels);
+        var movedOrangeRow = GetAverageOrangeRow(
+            pixels,
+            size);
+
+        Assert.That(
+            Math.Abs(movedOrangeRow - initialOrangeRow),
+            Is.GreaterThan(10),
+            "The orange selected edge must follow edited vertices instead of remaining at the original position.");
+
+        selectionManager.Dispose();
+        mesh.Dispose();
+    }
+
     [Test]
     public void Render3DObjects_ForegroundLineDoesNotCutSelectionMask()
     {
@@ -137,6 +302,20 @@ public class RenderEngineSelectionMaskOffscreenTests
         ]);
     }
 
+    private static IReadOnlyList<IRenderItem> GetRenderItems(
+        RenderEngineComponent renderEngine,
+        RenderBuckedId bucket)
+    {
+        var field = typeof(RenderEngineComponent).GetField(
+            "_renderItems",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.That(field, Is.Not.Null);
+        var renderItems = field!.GetValue(renderEngine) as
+            IReadOnlyDictionary<RenderBuckedId, List<IRenderItem>>;
+        Assert.That(renderItems, Is.Not.Null);
+        return renderItems![bucket];
+    }
+
     private sealed class SelectionMaskRenderItem : IRenderItem
     {
         private readonly Effect _effect;
@@ -225,5 +404,173 @@ public class RenderEngineSelectionMaskOffscreenTests
                 BlendIndices = Vector4.Zero
             };
         }
+    }
+
+    private sealed class SolidMeshRenderItem :
+        IRenderItem,
+        IDisposable
+    {
+        private readonly BasicEffect _effect;
+        private readonly VertexPositionColor[] _vertices =
+        [
+            new(new Vector3(-0.8f, -0.2f, 0.5f), Color.Gray),
+            new(new Vector3(-0.8f, 0.2f, 0.5f), Color.Gray),
+            new(new Vector3(0.8f, -0.2f, 0.5f), Color.Gray),
+            new(new Vector3(0.8f, -0.2f, 0.5f), Color.Gray),
+            new(new Vector3(-0.8f, 0.2f, 0.5f), Color.Gray),
+            new(new Vector3(0.8f, 0.2f, 0.5f), Color.Gray)
+        ];
+
+        public SolidMeshRenderItem(GraphicsDevice device)
+        {
+            _effect = new BasicEffect(device)
+            {
+                VertexColorEnabled = true,
+                World = Matrix.Identity,
+                View = Matrix.Identity,
+                Projection = Matrix.Identity
+            };
+        }
+
+        public bool SupportsTechnique(
+            RenderingTechnique technique)
+        {
+            return technique == RenderingTechnique.Normal;
+        }
+
+        public void Draw(
+            GraphicsDevice device,
+            CommonShaderParameters parameters,
+            RenderingTechnique renderingTechnique)
+        {
+            foreach (var pass in _effect.CurrentTechnique.Passes)
+            {
+                pass.Apply();
+                device.DrawUserPrimitives(
+                    PrimitiveType.TriangleList,
+                    _vertices,
+                    0,
+                    2);
+            }
+        }
+
+        public void Dispose()
+        {
+            _effect.Dispose();
+        }
+    }
+
+    private static MeshObject CreateMesh(
+        GraphicsDevice device,
+        bool animated)
+    {
+        var mesh = new MeshObject(
+            new GraphicsCardGeometry(device),
+            "test")
+        {
+            VertexArray =
+            [
+                CreateVertex(-0.8f, -0.2f),
+                CreateVertex(0.8f, -0.2f),
+                CreateVertex(-0.8f, 0.2f),
+                CreateVertex(0.8f, 0.2f)
+            ],
+            IndexArray = [0, 1, 2, 2, 1, 3]
+        };
+        mesh.ChangeVertexType(
+            animated
+                ? UiVertexFormat.Weighted
+                : UiVertexFormat.Static,
+            updateMesh: false);
+        mesh.BuildBoundingBox();
+        mesh.RebuildIndexBuffer();
+        mesh.RebuildVertexBuffer();
+        return mesh;
+    }
+
+    private static AnimationPlayer CreateAnimationPlayer()
+    {
+        var player = new AnimationPlayer();
+        var skeletonFile = new AnimationFile
+        {
+            Header = new AnimationFile.AnimationHeader
+            {
+                SkeletonName = "test_skeleton"
+            },
+            Bones =
+            [
+                new AnimationFile.BoneInfo
+                {
+                    Name = "root",
+                    ParentId = -1
+                }
+            ]
+        };
+        var skeletonFrame = new AnimationFile.Frame();
+        skeletonFrame.Transforms.Add(new RmvVector3(0, 0, 0));
+        skeletonFrame.Quaternion.Add(new RmvVector4(0, 0, 0, 1));
+        var skeletonPart = new AnimationFile.AnimationPart();
+        skeletonPart.DynamicFrames.Add(skeletonFrame);
+        skeletonFile.AnimationParts.Add(skeletonPart);
+        var skeleton = new GameSkeleton(skeletonFile, player);
+        var clip = new AnimationClip();
+        clip.DynamicFrames.Add(
+            new AnimationClip.KeyFrame
+            {
+                Position = [Vector3.Zero],
+                Rotation = [Quaternion.Identity],
+                Scale = [Vector3.One]
+            });
+        clip.PlayTimeInSec = 1;
+        player.SetAnimation(clip, skeleton);
+        player.IsEnabled = true;
+        player.Pause();
+        player.Refresh();
+        return player;
+    }
+
+    private static VertexPositionNormalTextureCustom CreateVertex(
+        float x,
+        float y)
+    {
+        return new VertexPositionNormalTextureCustom
+        {
+            Position = new Vector4(x, y, 0.5f, 1),
+            Normal = Vector3.UnitZ,
+            Tangent = Vector3.UnitX,
+            BiNormal = Vector3.UnitY,
+            BlendWeights = new Vector4(1, 0, 0, 0),
+            BlendIndices = Vector4.Zero
+        };
+    }
+
+    private static bool IsOrange(Color pixel)
+    {
+        return pixel.R > 200 &&
+               pixel.G is > 70 and < 190 &&
+               pixel.B < 40 &&
+               pixel.A > 0;
+    }
+
+    private static double GetAverageOrangeRow(
+        IReadOnlyList<Color> pixels,
+        int size)
+    {
+        var rowSum = 0;
+        var count = 0;
+        for (var index = 0; index < pixels.Count; index++)
+        {
+            if (!IsOrange(pixels[index]))
+                continue;
+
+            rowSum += index / size;
+            count++;
+        }
+
+        Assert.That(
+            count,
+            Is.GreaterThan(0),
+            "The selected edge must produce orange pixels.");
+        return (double)rowSum / count;
     }
 }

--- a/Testing/GameWorld.Core.Test/Rendering/VertexOverlayUploadTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/VertexOverlayUploadTests.cs
@@ -93,6 +93,75 @@ public class VertexOverlayUploadTests
     }
 
     [Test]
+    public void Draw_AnimatedUnselectedVertexHasLargerVisibleFootprint()
+    {
+        var game = new WpfGameMock();
+        var device = game.GraphicsDevice;
+        var effect = game.Content.Load<Effect>(
+            "Shaders\\VertexPointShader");
+        var deviceResolver = new Mock<IDeviceResolver>();
+        deviceResolver.SetupGet(x => x.Device).Returns(device);
+        var resources = new Mock<IScopedResourceLibrary>();
+        resources
+            .Setup(library =>
+                library.GetStaticEffect(
+                    ShaderTypes.VertexPoint))
+            .Returns(effect);
+        using var vertexRenderer = new VertexInstanceMesh(
+            deviceResolver.Object,
+            resources.Object);
+        var mesh = CreateCenteredAnimatedMesh(device);
+        var node = new Rmv2MeshNode(
+            mesh,
+            Mock.Of<IRmvMaterial>(),
+            null!,
+            null!);
+        var selection = new VertexSelectionState(node, 0);
+        var pose = GameWorld.Core.Animation.MeshPoseSnapshot.Create(
+            mesh,
+            Matrix.Identity,
+            [Matrix.Identity],
+            true);
+        using var renderTarget = new RenderTarget2D(
+            device,
+            64,
+            64,
+            false,
+            SurfaceFormat.Color,
+            DepthFormat.Depth24);
+
+        vertexRenderer.Update([Vector3.Zero], selection);
+        var staticPixels = DrawAndCountVisiblePixels(
+            device,
+            renderTarget,
+            () => vertexRenderer.Draw(
+                Matrix.Identity,
+                Matrix.Identity,
+                device));
+
+        vertexRenderer.UpdateAnimated(mesh, selection);
+        var animatedPixels = DrawAndCountVisiblePixels(
+            device,
+            renderTarget,
+            () => vertexRenderer.DrawAnimated(
+                pose,
+                Matrix.Identity,
+                Matrix.Identity,
+                device));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(staticPixels, Is.GreaterThan(0));
+            Assert.That(
+                animatedPixels,
+                Is.GreaterThan(staticPixels),
+                "Animated edit mode needs a larger unselected vertex footprint to remain visible over its dense wireframe.");
+        });
+
+        mesh.Dispose();
+    }
+
+    [Test]
     public void Draw_UnchangedOverlay_UploadsInstancesOnlyOnce()
     {
         var game = new WpfGameMock();
@@ -398,6 +467,24 @@ public class VertexOverlayUploadTests
         return mesh;
     }
 
+    private static MeshObject CreateCenteredAnimatedMesh(
+        GraphicsDevice device)
+    {
+        var mesh = new MeshObject(
+            new GraphicsCardGeometry(device),
+            "test")
+        {
+            VertexArray = [CreateAnimatedVertex(0)],
+            IndexArray = []
+        };
+        mesh.ChangeVertexType(
+            UiVertexFormat.Weighted,
+            updateMesh: false);
+        mesh.BuildBoundingBox();
+        mesh.RebuildVertexBuffer();
+        return mesh;
+    }
+
     private static VertexPositionNormalTextureCustom
         CreateAnimatedVertex(float x)
     {
@@ -429,5 +516,36 @@ public class VertexOverlayUploadTests
         }
 
         return count;
+    }
+
+    private static int DrawAndCountVisiblePixels(
+        GraphicsDevice device,
+        RenderTarget2D renderTarget,
+        Action draw)
+    {
+        try
+        {
+            device.SetRenderTarget(renderTarget);
+            device.Clear(
+                ClearOptions.Target |
+                    ClearOptions.DepthBuffer,
+                Color.Transparent,
+                1,
+                0);
+            device.DepthStencilState =
+                DepthStencilState.Default;
+            device.RasterizerState =
+                RasterizerState.CullNone;
+            draw();
+        }
+        finally
+        {
+            device.SetRenderTarget(null);
+        }
+
+        var pixels = new Color[
+            renderTarget.Width * renderTarget.Height];
+        renderTarget.GetData(pixels);
+        return pixels.Count(pixel => pixel.A != 0);
     }
 }


### PR DESCRIPTION
## Summary

- Keep edge overlay data synchronized with selected mesh geometry and vertex instances
- Update selection and wireframe rendering paths to reflect overlay changes consistently
- Add shader and offscreen coverage for edge overlays, selection masks, and vertex uploads

## Testing

- Added unit tests for edge overlay data construction
- Added offscreen rendering tests for animated wireframes and selection masks
- Added vertex overlay upload coverage