### PR TITLE
Preserve vertex overlays with scene backface culling

### DIFF
--- a/GameWorld/View3D/Rendering/EdgeQuadInstanceMesh.cs
+++ b/GameWorld/View3D/Rendering/EdgeQuadInstanceMesh.cs
@@ -166,16 +166,26 @@ namespace GameWorld.Core.Rendering
                     _currentInstanceCount));
 
             // Alpha blending for anti-aliased edges
+            var previousRasterizerState =
+                device.RasterizerState;
             device.BlendState = BlendState.AlphaBlend;
+            device.RasterizerState =
+                RasterizerState.CullNone;
+            try
+            {
+                device.Indices = _indexBuffer;
+                _effect.CurrentTechnique.Passes[0].Apply();
 
-            device.Indices = _indexBuffer;
-            _effect.CurrentTechnique.Passes[0].Apply();
-
-            device.SetVertexBuffers(_bindings);
-            // Draw 2 triangles (one quad) per instance
-            device.DrawInstancedPrimitives(PrimitiveType.TriangleList, 0, 0, 4, 0, 2, _currentInstanceCount);
-
-            device.BlendState = BlendState.Opaque;
+                device.SetVertexBuffers(_bindings);
+                // Draw 2 triangles (one quad) per instance
+                device.DrawInstancedPrimitives(PrimitiveType.TriangleList, 0, 0, 4, 0, 2, _currentInstanceCount);
+            }
+            finally
+            {
+                device.RasterizerState =
+                    previousRasterizerState;
+                device.BlendState = BlendState.Opaque;
+            }
         }
 
         public void Dispose()

--- a/GameWorld/View3D/Rendering/VertexInstanceMesh.cs
+++ b/GameWorld/View3D/Rendering/VertexInstanceMesh.cs
@@ -375,18 +375,30 @@ namespace GameWorld.Core.Rendering
             GraphicsDevice device,
             VertexBufferBinding[] bindings)
         {
+            var previousRasterizerState =
+                device.RasterizerState;
             device.BlendState = BlendState.AlphaBlend;
-            device.Indices = _indexBuffer;
-            _effect.CurrentTechnique.Passes[0].Apply();
-            device.SetVertexBuffers(bindings);
-            device.DrawInstancedPrimitives(
-                PrimitiveType.TriangleList,
-                0,
-                0,
-                4,
-                0,
-                2,
-                _currentInstanceCount);
+            device.RasterizerState =
+                RasterizerState.CullNone;
+            try
+            {
+                device.Indices = _indexBuffer;
+                _effect.CurrentTechnique.Passes[0].Apply();
+                device.SetVertexBuffers(bindings);
+                device.DrawInstancedPrimitives(
+                    PrimitiveType.TriangleList,
+                    0,
+                    0,
+                    4,
+                    0,
+                    2,
+                    _currentInstanceCount);
+            }
+            finally
+            {
+                device.RasterizerState =
+                    previousRasterizerState;
+            }
         }
 
         void EnsureInstanceCapacity(int requiredCount)

--- a/Testing/GameWorld.Core.Test/Rendering/EdgeQuadOffscreenTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/EdgeQuadOffscreenTests.cs
@@ -12,7 +12,7 @@ namespace GameWorld.Core.Test.Rendering;
 public class EdgeQuadOffscreenTests
 {
     [Test]
-    public void Draw_SelectedEdge_ProducesVisibleOrangePixels()
+    public void Draw_SelectedEdge_RemainsVisibleWithSceneBackfaceCulling()
     {
         var game = new WpfGameMock();
         var device = game.GraphicsDevice;
@@ -52,7 +52,8 @@ public class EdgeQuadOffscreenTests
             device.SetRenderTarget(renderTarget);
             device.Clear(ClearOptions.Target | ClearOptions.DepthBuffer, Color.Transparent, 1.0f, 0);
             device.DepthStencilState = DepthStencilState.Default;
-            device.RasterizerState = RasterizerState.CullNone;
+            device.RasterizerState =
+                RasterizerState.CullCounterClockwise;
             renderer.Draw(Matrix.Identity, Matrix.Identity, 64.0f, 64.0f, device);
         }
         finally

--- a/Testing/GameWorld.Core.Test/Rendering/VertexOverlayUploadTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/VertexOverlayUploadTests.cs
@@ -93,7 +93,7 @@ public class VertexOverlayUploadTests
     }
 
     [Test]
-    public void Draw_AnimatedUnselectedVertexHasLargerVisibleFootprint()
+    public void Draw_AnimatedUnselectedVertexRemainsVisibleAndHasLargerFootprintWithSceneBackfaceCulling()
     {
         var game = new WpfGameMock();
         var device = game.GraphicsDevice;
@@ -535,7 +535,7 @@ public class VertexOverlayUploadTests
             device.DepthStencilState =
                 DepthStencilState.Default;
             device.RasterizerState =
-                RasterizerState.CullNone;
+                RasterizerState.CullCounterClockwise;
             draw();
         }
         finally


### PR DESCRIPTION
## Summary

- Disable backface culling while rendering edge-quads and vertex overlays.
- Restore the previous rasterizer state after drawing, including when rendering fails.
- Update offscreen rendering tests to verify overlays remain visible under scene backface culling.

## Testing

- Updated `EdgeQuadOffscreenTests` and `VertexOverlayUploadTests` to exercise counter-clockwise scene culling.
- Tests not run (not requested).