### PR TITLE
Improve shared viewport settings and Win10 startup

### DIFF
--- a/AssetEditor/App.xaml.cs
+++ b/AssetEditor/App.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
@@ -47,6 +48,7 @@ namespace AssetEditor
 
             var forceValidateServiceScopes = Debugger.IsAttached;
             _serviceProvider = new DependencyInjectionConfig().Build(forceValidateServiceScopes);
+            LogRuntimeEnvironment();
 
             _ = _serviceProvider.GetRequiredService<RecentFilesTracker>(); // Force instance of the RecentFilesTracker
             _ = _serviceProvider.GetRequiredService<IScopeRepository>();  // Force instance of the IScopeRepository
@@ -173,6 +175,16 @@ namespace AssetEditor
             var newerReleases = await VersionChecker.GetNewerReleases();
             if (newerReleases != null)
                 uiCommandFactory.Create<OpenUpdaterWindowCommand>().Execute(newerReleases);
+        }
+
+        private static void LogRuntimeEnvironment()
+        {
+            Logging.Create<App>().Here().Information(
+                "Runtime environment: OS={OSDescription}; OSVersion={OSVersion}; Architecture={Architecture}; Framework={Framework}",
+                RuntimeInformation.OSDescription,
+                Environment.OSVersion.VersionString,
+                RuntimeInformation.ProcessArchitecture,
+                RuntimeInformation.FrameworkDescription);
         }
 
         void DispatcherUnhandledExceptionHandler(object sender, DispatcherUnhandledExceptionEventArgs args)

--- a/AssetEditor/Language_Cn.json
+++ b/AssetEditor/Language_Cn.json
@@ -1387,7 +1387,7 @@
   "SpecGloss.Mask": "遮罩",
 
   "Tint.Header": "阵营颜色预览",
-  "Tint.ToolTip": "遮罩贴图的红、绿、蓝通道分别使用下方三种预览颜色。修改颜色后视图会立即更新；这些颜色只属于编辑器预览，不会写入模型，游戏中仍由实际阵营数据决定最终颜色。",
+  "Tint.ToolTip": "遮罩贴图的红、绿、蓝通道分别使用下方三种预览颜色。修改颜色后视图会立即更新；保存后会成为所有 3D 编辑器共用的预览设置，但不会写入模型，游戏中仍由实际阵营数据决定最终颜色。",
   "Tint.PreviewCapability": "启用阵营色预览",
   "Tint.FactionColour0": "红通道（阵营色 1）",
   "Tint.FactionColour1": "绿通道（阵营色 2）",
@@ -1397,6 +1397,10 @@
   "Tint.Variation": "变体",
   "Tint.UseFactionColours": "使用阵营颜色",
   "Tint.FactionColour3Mask": "阵营颜色 3 遮罩",
+  "FactionTint.Menu": "阵营着色",
+  "FactionTint.Window.Title": "阵营着色",
+  "FactionTint.Enabled": "启用阵营着色",
+  "FactionTint.SaveGlobal": "保存阵营着色",
 
   "WeightedMaterial.Header": "RMV2 原始材质数据（诊断，只读）",
   "WeightedMaterial.ToolTip": "这是载入模型时的原始数据快照，通常无需查看，也不会随上方编辑实时更新。仅在动画附着、材质类型或贴图异常时，与同游戏、同材质的正常模型对比：顶点格式和材质类型应相符，贴图及参数列表可用于查找缺项。不要只凭数值猜测修改模型。",

--- a/AssetEditor/ViewModels/SettingsViewModel.cs
+++ b/AssetEditor/ViewModels/SettingsViewModel.cs
@@ -371,16 +371,21 @@ namespace AssetEditor.ViewModels
                 return false;
             }
 
-            settings = new ViewportRenderSettings(
-                CurrentRenderEngineBackgroundColour,
-                backgroundColour,
-                SimulateGameBackfaces,
-                ShowViewportGrid,
-                gridColour,
-                lightIntensity,
-                environmentLightRotationY,
-                directLightRotationX,
-                directLightRotationY);
+            settings = ViewportRenderSettings.From(
+                _settingsService.CurrentSettings) with
+            {
+                BackgroundColour =
+                    CurrentRenderEngineBackgroundColour,
+                CustomBackgroundColour = backgroundColour,
+                SimulateGameBackfaces = SimulateGameBackfaces,
+                ShowGrid = ShowViewportGrid,
+                GridColour = gridColour,
+                LightIntensity = lightIntensity,
+                EnvironmentLightRotationY =
+                    environmentLightRotationY,
+                DirectLightRotationX = directLightRotationX,
+                DirectLightRotationY = directLightRotationY
+            };
             return true;
         }
 

--- a/Editors/CscEditor/Editors.CscEditor/ViewModels/CscEditorViewModel.cs
+++ b/Editors/CscEditor/Editors.CscEditor/ViewModels/CscEditorViewModel.cs
@@ -15,6 +15,7 @@ using GameWorld.Core.Components.Rendering;
 using GameWorld.Core.Components.Selection;
 using GameWorld.Core.Services;
 using GameWorld.Core.WpfWindow;
+using GameWorld.Core.WpfWindow.FactionColourSettings;
 using Serilog;
 using Shared.Core.ErrorHandling;
 using Shared.Core.Events;
@@ -187,6 +188,7 @@ namespace Editors.CscEditor.ViewModels
         public ICommand AddCompositeSceneCommand { get; }
         public ICommand AddPrefabCommand { get; }
         public ICommand AddAnimationCommand { get; }
+        public ICommand OpenFactionColourSettingsCommand { get; }
 
         public CscEditorViewModel(
             IPackFileService packFileService,
@@ -201,7 +203,8 @@ namespace Editors.CscEditor.ViewModels
             CscPlaybackContext playbackContext,
             ArcBallCamera camera,
             SelectionManager selectionManager,
-            LocalizationManager localization)
+            LocalizationManager localization,
+            IFactionColourSettingsDialogService factionColourSettingsDialog)
         {
             _packFileService = packFileService;
             _fileSaveService = fileSaveService;
@@ -277,6 +280,8 @@ namespace Editors.CscEditor.ViewModels
             AddCompositeSceneCommand = new RelayCommand(AddCompositeScene);
             AddPrefabCommand = new RelayCommand(AddPrefab);
             AddAnimationCommand = new RelayCommand(AddAnimation);
+            OpenFactionColourSettingsCommand = new RelayCommand(
+                factionColourSettingsDialog.ShowDialog);
         }
 
         void OnPortholeFrameUpdated() => NotifyPropertyChanged(nameof(PortholeLiveFrame));

--- a/Editors/CscEditor/Editors.CscEditor/Views/CscEditorView.xaml
+++ b/Editors/CscEditor/Editors.CscEditor/Views/CscEditorView.xaml
@@ -74,6 +74,10 @@
                     <MenuItem Header="{loc:Loc Csc.Add.Prefab}" Command="{Binding AddPrefabCommand}"/>
                     <MenuItem Header="{loc:Loc Csc.Add.Group}" Command="{Binding AddLocatorCommand}"/>
                 </MenuItem>
+                <MenuItem
+                    Header="{loc:Loc FactionTint.Menu}"
+                    Padding="8,3"
+                    Command="{Binding OpenFactionColourSettingsCommand}" />
             </Menu>
             <Button Content="{loc:Loc General.Delete}" Command="{Binding DeleteSelectedCommand}" IsEnabled="{Binding HasSelection}" Style="{StaticResource AeButton.Danger}"/>
             <Separator/>

--- a/Editors/Kitbashing/KitbasherEditor/Core/SceneNodeEditor/Nodes/MeshNode/Mesh.Material/ModelMaterialViewModel.cs
+++ b/Editors/Kitbashing/KitbasherEditor/Core/SceneNodeEditor/Nodes/MeshNode/Mesh.Material/ModelMaterialViewModel.cs
@@ -30,6 +30,8 @@ namespace Editors.KitbasherEditor.ViewModels.SceneExplorer.Nodes.MeshSubViews
         private readonly IStandardDialogs _packFileUiProvider;
         private readonly SceneNodePropertyEditor _propertyEditor;
         private readonly SceneRenderParametersStore _sceneRenderParameters;
+        private readonly FactionColourSettingsService
+            _factionColourSettingsService;
         Rmv2MeshNode? _currentNode;
 
         [ObservableProperty] List<CapabilityMaterialsEnum> _possibleMaterialTypes;
@@ -52,7 +54,8 @@ namespace Editors.KitbasherEditor.ViewModels.SceneExplorer.Nodes.MeshSubViews
             CapabilityMaterialFactory abstractMaterialFactory,
             IStandardDialogs packFileUiProvider,
             SceneNodePropertyEditor propertyEditor,
-            SceneRenderParametersStore sceneRenderParameters)
+            SceneRenderParametersStore sceneRenderParameters,
+            FactionColourSettingsService factionColourSettingsService)
         {
             _uiCommandFactory = uiCommandFactory;
             _selectionManager = selectionManager;
@@ -63,6 +66,7 @@ namespace Editors.KitbasherEditor.ViewModels.SceneExplorer.Nodes.MeshSubViews
             _packFileUiProvider = packFileUiProvider;
             _propertyEditor = propertyEditor;
             _sceneRenderParameters = sceneRenderParameters;
+            _factionColourSettingsService = factionColourSettingsService;
             _possibleMaterialTypes = _materialFactory.GetPossibleMaterials();
         }
 
@@ -156,7 +160,8 @@ namespace Editors.KitbasherEditor.ViewModels.SceneExplorer.Nodes.MeshSubViews
                 material,
                 capability => new TintViewModel(
                     capability,
-                    _sceneRenderParameters));
+                    _sceneRenderParameters,
+                    _factionColourSettingsService));
         }
 
         TViewModel? CreateCapabilityView<T, TViewModel>(

--- a/Editors/Kitbashing/KitbasherEditor/Core/SceneNodeEditor/Nodes/MeshNode/Mesh.Material/Tint/TintView.xaml
+++ b/Editors/Kitbashing/KitbasherEditor/Core/SceneNodeEditor/Nodes/MeshNode/Mesh.Material/Tint/TintView.xaml
@@ -45,6 +45,14 @@
                     <colourpickerbutton:ColourPickerButtonView DataContext="{Binding FactionColour2}" HorizontalAlignment="Left" Width="20" Height="20" Background="Transparent"/>
                 </DockPanel>
 
+                <Button
+                    DockPanel.Dock="Top"
+                    Margin="0,8,0,0"
+                    HorizontalAlignment="Left"
+                    Command="{Binding SaveFactionColourSettingsCommand}"
+                    Content="{loc:Loc FactionTint.SaveGlobal}"
+                    Style="{StaticResource AeButton.Secondary}" />
+
             </DockPanel>
         </Expander>
     </ContentControl>

--- a/Editors/Kitbashing/KitbasherEditor/Core/SceneNodeEditor/Nodes/MeshNode/Mesh.Material/Tint/TintViewModel.cs
+++ b/Editors/Kitbashing/KitbasherEditor/Core/SceneNodeEditor/Nodes/MeshNode/Mesh.Material/Tint/TintViewModel.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using GameWorld.Core.Components.Rendering;
 using GameWorld.Core.Rendering.Materials.Capabilities;
+using GameWorld.Core.Services;
 using Microsoft.Xna.Framework;
 using Shared.Ui.BaseDialogs.ColourPickerButton;
 
@@ -10,6 +12,7 @@ namespace Editors.KitbasherEditor.ViewModels.SceneNodeEditor.Nodes.MeshNode.Mesh
     {
         private readonly TintCapability _tintCapability;
         private readonly SceneRenderParametersStore _sceneRenderParameters;
+        private readonly FactionColourSettingsService? _settingsService;
 
         [ObservableProperty] bool _applyFactionColours;
         [ObservableProperty] ColourPickerViewModel _factionColour0;
@@ -18,12 +21,16 @@ namespace Editors.KitbasherEditor.ViewModels.SceneNodeEditor.Nodes.MeshNode.Mesh
 
         public TintViewModel(
             TintCapability tintCapability,
-            SceneRenderParametersStore sceneRenderParameters)
+            SceneRenderParametersStore sceneRenderParameters,
+            FactionColourSettingsService? settingsService = null)
         {
             _tintCapability = tintCapability;
             _sceneRenderParameters = sceneRenderParameters;
-            _tintCapability.UseFactionColours = true;
-            _applyFactionColours = _tintCapability.ApplyCapability;
+            _settingsService = settingsService;
+            _tintCapability.UseFactionColours =
+                _sceneRenderParameters.FactionColoursEnabled;
+            _applyFactionColours =
+                _sceneRenderParameters.FactionColoursEnabled;
             _factionColour0 = new ColourPickerViewModel(
                 _sceneRenderParameters.FactionColour0,
                 value => OnFactionColourChanged(0, value));
@@ -37,9 +44,25 @@ namespace Editors.KitbasherEditor.ViewModels.SceneNodeEditor.Nodes.MeshNode.Mesh
 
         partial void OnApplyFactionColoursChanged(bool value)
         {
-            _tintCapability.ApplyCapability = value;
-            _tintCapability.UseFactionColours = true;
+            _sceneRenderParameters.FactionColoursEnabled = value;
+            _tintCapability.UseFactionColours = value;
         }
+
+        [RelayCommand(CanExecute = nameof(CanSaveFactionColourSettings))]
+        private void SaveFactionColourSettings()
+        {
+            _settingsService!.Save(new FactionColourSettings(
+                ApplyFactionColours,
+                FactionColourSettingsService.ToRgbString(
+                    _sceneRenderParameters.FactionColour0),
+                FactionColourSettingsService.ToRgbString(
+                    _sceneRenderParameters.FactionColour1),
+                FactionColourSettingsService.ToRgbString(
+                    _sceneRenderParameters.FactionColour2)));
+        }
+
+        private bool CanSaveFactionColourSettings() =>
+            _settingsService != null;
 
         private void OnFactionColourChanged(int index, Vector3 value)
         {

--- a/Editors/Kitbashing/Test.KitbashEditor/SceneNodeEditorPropertyTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/SceneNodeEditorPropertyTests.cs
@@ -13,6 +13,7 @@ using Moq;
 using Shared.Core.Events;
 using Shared.Core.PackFiles;
 using Shared.Core.Services;
+using Shared.Core.Settings;
 using Shared.GameFormats.RigidModel;
 using Shared.GameFormats.RigidModel.MaterialHeaders;
 using Shared.GameFormats.RigidModel.Transforms;
@@ -206,7 +207,10 @@ namespace Test.KitbashEditor
         {
             var commandExecutor = new CommandExecutor(Mock.Of<IEventHub>());
             var sceneParameters = new SceneRenderParametersStore();
-            var capability = new TintCapability();
+            var capability = new TintCapability
+            {
+                ApplyCapability = true
+            };
             var viewModel = new TintViewModel(capability, sceneParameters);
 
             viewModel.FactionColour0.PickedColor =
@@ -217,13 +221,13 @@ namespace Test.KitbashEditor
             {
                 Assert.That(
                     sceneParameters.FactionColour0.X,
-                    Is.EqualTo(64f / 256f));
+                    Is.EqualTo(64f / 255f));
                 Assert.That(
                     sceneParameters.FactionColour0.Y,
-                    Is.EqualTo(128f / 256f));
+                    Is.EqualTo(128f / 255f));
                 Assert.That(
                     sceneParameters.FactionColour0.Z,
-                    Is.EqualTo(255f / 256f));
+                    Is.EqualTo(1f));
                 Assert.That(commandExecutor.CanUndo(), Is.False);
             });
 
@@ -231,8 +235,42 @@ namespace Test.KitbashEditor
 
             Assert.Multiple(() =>
             {
-                Assert.That(capability.ApplyCapability, Is.False);
+                Assert.That(sceneParameters.FactionColoursEnabled, Is.False);
+                Assert.That(capability.UseFactionColours, Is.False);
+                Assert.That(capability.ApplyCapability, Is.True);
                 Assert.That(commandExecutor.CanUndo(), Is.False);
+            });
+        }
+
+        [Test]
+        public void SaveFactionPreview_PersistsSharedViewportSettings()
+        {
+            var sceneParameters = new SceneRenderParametersStore();
+            var applicationSettings = new ApplicationSettingsService();
+            var settingsService = new FactionColourSettingsService(
+                applicationSettings,
+                Mock.Of<IGlobalEventHub>());
+            var viewModel = new TintViewModel(
+                new TintCapability(),
+                sceneParameters,
+                settingsService);
+            viewModel.ApplyFactionColours = false;
+            viewModel.FactionColour1.PickedColor =
+                System.Windows.Media.Color.FromRgb(90, 150, 210);
+            viewModel.FactionColour1.OnHandleColourChanged();
+
+            viewModel.SaveFactionColourSettingsCommand.Execute(null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    applicationSettings.CurrentSettings
+                        .ViewportFactionColoursEnabled,
+                    Is.False);
+                Assert.That(
+                    applicationSettings.CurrentSettings
+                        .ViewportFactionColour1,
+                    Is.EqualTo("90,150,210"));
             });
         }
 

--- a/Editors/Shared/Editors.Shared.Core/Common/BaseControl/EditorHost.cs
+++ b/Editors/Shared/Editors.Shared.Core/Common/BaseControl/EditorHost.cs
@@ -7,6 +7,7 @@ using Editors.Shared.Core.Common.ReferenceModel;
 using GameWorld.Core.Components;
 using GameWorld.Core.Services;
 using GameWorld.Core.WpfWindow.Events;
+using GameWorld.Core.WpfWindow.FactionColourSettings;
 using Shared.Core.Events;
 using Shared.Core.Misc;
 using Shared.Core.Services;
@@ -36,6 +37,7 @@ namespace Editors.Shared.Core.Common.BaseControl
 
         public ICommand ResetCameraCommand { get; set; }
         public ICommand FocusCamerasCommand { get; set; }
+        public ICommand OpenFactionColourSettingsCommand { get; set; }
 
         public EditorHost(IEditorDatabase toolFactory,
             IComponentInserter componentInserter,
@@ -43,7 +45,8 @@ namespace Editors.Shared.Core.Common.BaseControl
             IWpfGame gameWorld,
             FocusSelectableObjectService focusSelectableObjectService,
             TEditor editor,
-            IEventHub eventHub)
+            IEventHub eventHub,
+            IFactionColourSettingsDialogService factionColourSettingsDialog)
         {
             ToolsFactory = toolFactory;
             Editor = editor;
@@ -54,6 +57,8 @@ namespace Editors.Shared.Core.Common.BaseControl
 
             ResetCameraCommand = new RelayCommand(ResetCameraAction);
             FocusCamerasCommand = new RelayCommand(FocusCameraAction);
+            OpenFactionColourSettingsCommand = new RelayCommand(
+                factionColourSettingsDialog.ShowDialog);
 
             componentInserter.Execute();
 

--- a/Editors/Shared/Editors.Shared.Core/Common/BaseControl/EditorHostBase.cs
+++ b/Editors/Shared/Editors.Shared.Core/Common/BaseControl/EditorHostBase.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Editors.Shared.Core.Common.AnimationPlayer;
 using Editors.Shared.Core.Common.ReferenceModel;
 using GameWorld.Core.Services;
+using GameWorld.Core.WpfWindow.FactionColourSettings;
 using Shared.Core.Services;
 using Shared.Core.ToolCreation;
 
@@ -15,6 +16,8 @@ namespace Editors.Shared.Core.Common.BaseControl
         private readonly FocusSelectableObjectService _focusSelectableObjectService;
         protected readonly SceneObjectViewModelBuilder _sceneObjectViewModelBuilder;
         protected readonly SceneObjectEditor _sceneObjectEditor;
+        private readonly IFactionColourSettingsDialogService
+            _factionColourSettingsDialog;
 
         protected FocusSelectableObjectService FocusService => _focusSelectableObjectService;
         protected SceneObjectEditor SceneObjectEditor => _sceneObjectEditor;
@@ -36,12 +39,16 @@ namespace Editors.Shared.Core.Common.BaseControl
             _focusSelectableObjectService = inputParams.FocusSelectableObjectService;
             _sceneObjectViewModelBuilder = inputParams.SceneObjectViewModelBuilder;
             _sceneObjectEditor = inputParams.SceneObjectEditor;
+            _factionColourSettingsDialog =
+                inputParams.FactionColourSettingsDialog;
 
             inputParams.ComponentInserter.Execute();
         }
 
         [RelayCommand] void ResetCamera() => _focusSelectableObjectService.ResetCamera();
         [RelayCommand] void FocusCamera() => _focusSelectableObjectService.FocusSelection();
+        [RelayCommand] void OpenFactionColourSettings() =>
+            _factionColourSettingsDialog.ShowDialog();
 
         public virtual void Close()
         {

--- a/Editors/Shared/Editors.Shared.Core/Common/BaseControl/EditorHostView.xaml
+++ b/Editors/Shared/Editors.Shared.Core/Common/BaseControl/EditorHostView.xaml
@@ -45,6 +45,9 @@
                 <MenuItem Header="{loc:Loc EditorHost.Menu.FocusSelection}" Command="{Binding FocusCameraCommand}"/>
                 <MenuItem Header="{loc:Loc EditorHost.Menu.Reset}" Command="{Binding ResetCameraCommand}"/>
             </MenuItem>
+            <MenuItem
+                Header="{loc:Loc FactionTint.Menu}"
+                Command="{Binding OpenFactionColourSettingsCommand}" />
         </Menu>
 
         <ContentControl Grid.Row="2" Grid.Column="0" Content="{Binding GameWorld, Mode=OneTime}"/>

--- a/Editors/Shared/Editors.Shared.Core/Common/BaseControl/IEditorHostParameters.cs
+++ b/Editors/Shared/Editors.Shared.Core/Common/BaseControl/IEditorHostParameters.cs
@@ -1,6 +1,7 @@
 ﻿using Editors.Shared.Core.Common.AnimationPlayer;
 using GameWorld.Core.Components;
 using GameWorld.Core.Services;
+using GameWorld.Core.WpfWindow.FactionColourSettings;
 using Shared.Core.Services;
 
 namespace Editors.Shared.Core.Common.BaseControl
@@ -13,6 +14,7 @@ namespace Editors.Shared.Core.Common.BaseControl
         IWpfGame GameWorld { get; }
         SceneObjectViewModelBuilder SceneObjectViewModelBuilder { get; }
         SceneObjectEditor SceneObjectEditor { get; }
+        IFactionColourSettingsDialogService FactionColourSettingsDialog { get; }
     }
 
     public class EditorHostParameters : IEditorHostParameters
@@ -23,7 +25,8 @@ namespace Editors.Shared.Core.Common.BaseControl
             IWpfGame gameWorld,
             FocusSelectableObjectService focusSelectableObjectService,
             SceneObjectViewModelBuilder sceneObjectViewModelBuilder,
-            SceneObjectEditor sceneObjectEditor)
+            SceneObjectEditor sceneObjectEditor,
+            IFactionColourSettingsDialogService factionColourSettingsDialog)
         {
             ComponentInserter = componentInserter;
             AnimationPlayerViewModel = animationPlayerViewModel;
@@ -31,6 +34,7 @@ namespace Editors.Shared.Core.Common.BaseControl
             FocusSelectableObjectService = focusSelectableObjectService;
             SceneObjectViewModelBuilder = sceneObjectViewModelBuilder;
             SceneObjectEditor = sceneObjectEditor;
+            FactionColourSettingsDialog = factionColourSettingsDialog;
         }
 
         public IComponentInserter ComponentInserter { get; }
@@ -40,5 +44,6 @@ namespace Editors.Shared.Core.Common.BaseControl
         public SceneObjectViewModelBuilder SceneObjectViewModelBuilder { get; }
 
         public SceneObjectEditor SceneObjectEditor { get; }
+        public IFactionColourSettingsDialogService FactionColourSettingsDialog { get; }
     }
 }

--- a/Editors/TwuiEditor/Editor.Twui/Editor/Presentation/TwuiMainView.xaml
+++ b/Editors/TwuiEditor/Editor.Twui/Editor/Presentation/TwuiMainView.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:Editors.Twui.Editor.Presentation" xmlns:componenteditor="clr-namespace:Editors.Twui.Editor.ComponentEditor"
+             xmlns:loc="clr-namespace:Shared.Ui.Common;assembly=Shared.Ui"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              Background="{DynamicResource AeBrush.Canvas}"
@@ -20,6 +21,10 @@
     </UserControl.Resources>
 
     <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="auto"/>
             <ColumnDefinition Width="5"/>
@@ -28,17 +33,23 @@
             <ColumnDefinition Width="auto"/>
         </Grid.ColumnDefinitions>
 
-        <local:HierarchyView Grid.Column="0"/>
+        <Menu Grid.Row="0" Grid.ColumnSpan="5">
+            <MenuItem
+                Header="{loc:Loc FactionTint.Menu}"
+                Command="{Binding OpenFactionColourSettingsCommand}" />
+        </Menu>
 
-        <GridSplitter Grid.Column="1" HorizontalAlignment="Stretch"
+        <local:HierarchyView Grid.Row="1" Grid.Column="0"/>
+
+        <GridSplitter Grid.Row="1" Grid.Column="1" HorizontalAlignment="Stretch"
                       Style="{StaticResource AeVerticalGridSplitterStyle}" />
 
-        <ContentControl  Grid.Column="2"  Content="{Binding Path=Scene, UpdateSourceTrigger=PropertyChanged, Mode=OneTime}"/>
+        <ContentControl Grid.Row="1" Grid.Column="2" Content="{Binding Path=Scene, UpdateSourceTrigger=PropertyChanged, Mode=OneTime}"/>
 
-        <GridSplitter Grid.Column="3" HorizontalAlignment="Stretch"
+        <GridSplitter Grid.Row="1" Grid.Column="3" HorizontalAlignment="Stretch"
                       Style="{StaticResource AeVerticalGridSplitterStyle}" />
 
-        <componenteditor:ComponentView Grid.Column="4" DataContext="{Binding ComponentManager, UpdateSourceTrigger=PropertyChanged}" />
+        <componenteditor:ComponentView Grid.Row="1" Grid.Column="4" DataContext="{Binding ComponentManager, UpdateSourceTrigger=PropertyChanged}" />
 
 
     </Grid>

--- a/Editors/TwuiEditor/Editor.Twui/Editor/TwuiEditor.cs
+++ b/Editors/TwuiEditor/Editor.Twui/Editor/TwuiEditor.cs
@@ -1,12 +1,15 @@
 ﻿using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Editors.Twui.Editor.ComponentEditor;
 using Editors.Twui.Editor.Rendering;
+using GameWorld.Core.WpfWindow.FactionColourSettings;
 using Shared.Core.Events;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
 using Shared.Core.Services;
 using Shared.Core.ToolCreation;
+using System.Windows.Input;
 
 namespace Editors.Twui.Editor
 {
@@ -24,14 +27,23 @@ namespace Editors.Twui.Editor
         [ObservableProperty] ComponentManger _componentManager;
         [ObservableProperty] IWpfGame _scene;
         private readonly IPackFileService _packFileService;
+        public ICommand OpenFactionColourSettingsCommand { get; }
 
-        public TwuiEditor(IEventHub eventHub, ComponentManger componentEditor, TwuiRenderComponent renderComponent, IWpfGame wpfGame, IPackFileService packFileService)
+        public TwuiEditor(
+            IEventHub eventHub,
+            ComponentManger componentEditor,
+            TwuiRenderComponent renderComponent,
+            IWpfGame wpfGame,
+            IPackFileService packFileService,
+            IFactionColourSettingsDialogService factionColourSettingsDialog)
         {
             _eventHub = eventHub;
             _componentManager = componentEditor;
             _renderComponent = renderComponent;
             _scene = wpfGame;
             _packFileService = packFileService;
+            OpenFactionColourSettingsCommand = new RelayCommand(
+                factionColourSettingsDialog.ShowDialog);
             wpfGame.ForceEnsureCreated();
             renderComponent.Initialize();
 

--- a/GameWorld/View3D/Components/Rendering/CommonShaderParameterBuilder.cs
+++ b/GameWorld/View3D/Components/Rendering/CommonShaderParameterBuilder.cs
@@ -29,7 +29,8 @@ namespace GameWorld.Core.Components.Rendering
 
                 _cachedFactionColours,
                 viewportHeight,
-                viewportWidth);
+                viewportWidth,
+                sceneLightParameters.FactionColoursEnabled);
 
             return commonShaderParameters;
         }

--- a/GameWorld/View3D/Components/Rendering/RenderEngineComponent.cs
+++ b/GameWorld/View3D/Components/Rendering/RenderEngineComponent.cs
@@ -61,7 +61,7 @@ namespace GameWorld.Core.Components.Rendering
         public SpriteFont ViewportOverlayFont { get; private set; }
 
         private ViewportShadingMode _shadingMode =
-            ViewportShadingMode.Solid;
+            ViewportShadingMode.MaterialPreview;
 
         public event Action<ViewportShadingMode>? ShadingModeChanged;
 

--- a/GameWorld/View3D/Components/Rendering/SceneRenderParametersStore.cs
+++ b/GameWorld/View3D/Components/Rendering/SceneRenderParametersStore.cs
@@ -21,12 +21,18 @@ namespace GameWorld.Core.Components.Rendering
         public float DirLightRotationRadians_Y => MathHelper.ToRadians(DirLightRotationDegrees_Y);
 
         public Vector3 FactionColour0 { get; set; } = Color.Red.ToVector3();
-        public Vector3 FactionColour1 { get; set; } = Color.Blue.ToVector3();
+        public Vector3 FactionColour1 { get; set; } =
+            new Color(100, 169, 226).ToVector3();
         public Vector3 FactionColour2 { get; set; } = Color.White.ToVector3();
+        public bool FactionColoursEnabled { get; set; } = true;
 
         public void ApplyGlobalLighting(ViewportRenderSettings settings)
         {
             _globalLighting = settings;
+            FactionColoursEnabled = settings.FactionColoursEnabled;
+            FactionColour0 = ParseFactionColour(settings.FactionColour0);
+            FactionColour1 = ParseFactionColour(settings.FactionColour1);
+            FactionColour2 = ParseFactionColour(settings.FactionColour2);
             if (_lightingOverrideCount == 0)
                 ApplyLighting(settings);
         }
@@ -54,6 +60,10 @@ namespace GameWorld.Core.Components.Rendering
             DirLightRotationDegrees_X = settings.DirectLightRotationX;
             DirLightRotationDegrees_Y = settings.DirectLightRotationY;
         }
+
+        private static Vector3 ParseFactionColour(string rgb) =>
+            ApplicationSettingsHelper.ParseCustomBackgroundColour(rgb)
+                .ToVector3();
 
         private sealed class LightingOverride(
             SceneRenderParametersStore owner) : IDisposable

--- a/GameWorld/View3D/DependencyInjectionContainer.cs
+++ b/GameWorld/View3D/DependencyInjectionContainer.cs
@@ -25,6 +25,7 @@ using GameWorld.Core.Services.SceneSaving.Material;
 using GameWorld.Core.Services.SceneSaving.Material.Strategies;
 using GameWorld.Core.Utility;
 using GameWorld.Core.WpfWindow;
+using GameWorld.Core.WpfWindow.FactionColourSettings;
 using Microsoft.Extensions.DependencyInjection;
 using Shared.Core.DependencyInjection;
 using Shared.Core.Services;
@@ -45,6 +46,10 @@ namespace GameWorld.Core
             // Settings
             serviceCollection.AddScoped<GeometrySaveSettings>();
             serviceCollection.AddScoped<SceneRenderParametersStore>();
+            serviceCollection.AddSingleton<FactionColourSettingsService>();
+            serviceCollection.AddTransient<
+                IFactionColourSettingsDialogService,
+                FactionColourSettingsDialogService>();
 
             // Services
             serviceCollection.AddSingleton<ISkeletonAnimationLookUpHelper, SkeletonAnimationLookUpHelper>();

--- a/GameWorld/View3D/Rendering/CommonShaderParameters.cs
+++ b/GameWorld/View3D/Rendering/CommonShaderParameters.cs
@@ -15,7 +15,8 @@ namespace GameWorld.Core.Rendering
         Vector3 LightColour,
         Vector3[] FactionColours,
         float ViewportHeight = 0,
-        float ViewportWidth = 0
+        float ViewportWidth = 0,
+        bool FactionColoursEnabled = true
         );
 
 }

--- a/GameWorld/View3D/Rendering/Materials/Shaders/CapabilityMaterial.cs
+++ b/GameWorld/View3D/Rendering/Materials/Shaders/CapabilityMaterial.cs
@@ -88,7 +88,11 @@ namespace GameWorld.Core.Rendering.Materials.Shaders
             var tintCapability = TryGetCapability<TintCapability>();
 
             if (tintCapability != null)
+            {
                 tintCapability.FactionColours = commonShaderParameters.FactionColours;
+                tintCapability.UseFactionColours =
+                    commonShaderParameters.FactionColoursEnabled;
+            }
 
             var effect = GetEffect();
             OnApply(effect);

--- a/GameWorld/View3D/Services/FactionColourSettingsService.cs
+++ b/GameWorld/View3D/Services/FactionColourSettingsService.cs
@@ -1,0 +1,72 @@
+using Microsoft.Xna.Framework;
+using Shared.Core.Events;
+using Shared.Core.Events.Global;
+using Shared.Core.Settings;
+
+namespace GameWorld.Core.Services
+{
+    public sealed record FactionColourSettings(
+        bool Enabled,
+        string Colour0,
+        string Colour1,
+        string Colour2);
+
+    public sealed class FactionColourSettingsService
+    {
+        private readonly ApplicationSettingsService _settingsService;
+        private readonly IGlobalEventHub _eventHub;
+
+        public FactionColourSettingsService(
+            ApplicationSettingsService settingsService,
+            IGlobalEventHub eventHub)
+        {
+            _settingsService = settingsService;
+            _eventHub = eventHub;
+        }
+
+        public FactionColourSettings Current
+        {
+            get
+            {
+                var settings = _settingsService.CurrentSettings;
+                return new FactionColourSettings(
+                    settings.ViewportFactionColoursEnabled,
+                    settings.ViewportFactionColour0,
+                    settings.ViewportFactionColour1,
+                    settings.ViewportFactionColour2);
+            }
+        }
+
+        public void Preview(FactionColourSettings factionSettings)
+        {
+            var settings = ViewportRenderSettings.From(
+                _settingsService.CurrentSettings) with
+            {
+                FactionColoursEnabled = factionSettings.Enabled,
+                FactionColour0 = factionSettings.Colour0,
+                FactionColour1 = factionSettings.Colour1,
+                FactionColour2 = factionSettings.Colour2
+            };
+            _eventHub.PublishGlobalEvent(
+                new ViewportRenderSettingsChangedEvent(settings));
+        }
+
+        public void Save(FactionColourSettings factionSettings)
+        {
+            var settings = _settingsService.CurrentSettings;
+            settings.ViewportFactionColoursEnabled =
+                factionSettings.Enabled;
+            settings.ViewportFactionColour0 = factionSettings.Colour0;
+            settings.ViewportFactionColour1 = factionSettings.Colour1;
+            settings.ViewportFactionColour2 = factionSettings.Colour2;
+            _settingsService.Save();
+            Preview(factionSettings);
+        }
+
+        public static string ToRgbString(Vector3 colour)
+        {
+            var converted = new Color(colour);
+            return $"{converted.R},{converted.G},{converted.B}";
+        }
+    }
+}

--- a/GameWorld/View3D/WpfWindow/FactionColourSettings/FactionColourSettingsDialogService.cs
+++ b/GameWorld/View3D/WpfWindow/FactionColourSettings/FactionColourSettingsDialogService.cs
@@ -1,0 +1,31 @@
+namespace GameWorld.Core.WpfWindow.FactionColourSettings
+{
+    public interface IFactionColourSettingsDialogService
+    {
+        void ShowDialog();
+    }
+
+    public sealed class FactionColourSettingsDialogService :
+        IFactionColourSettingsDialogService
+    {
+        private readonly Services.FactionColourSettingsService
+            _settingsService;
+
+        public FactionColourSettingsDialogService(
+            Services.FactionColourSettingsService settingsService)
+        {
+            _settingsService = settingsService;
+        }
+
+        public void ShowDialog()
+        {
+            var viewModel = new FactionColourSettingsViewModel(
+                _settingsService);
+            var window = new FactionColourSettingsWindow(viewModel);
+            if (window.ShowDialog() == true)
+                viewModel.Save();
+            else
+                viewModel.Cancel();
+        }
+    }
+}

--- a/GameWorld/View3D/WpfWindow/FactionColourSettings/FactionColourSettingsViewModel.cs
+++ b/GameWorld/View3D/WpfWindow/FactionColourSettings/FactionColourSettingsViewModel.cs
@@ -1,0 +1,61 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using GameWorld.Core.Services;
+using Shared.Core.Settings;
+using Shared.Ui.BaseDialogs.ColourPickerButton;
+
+namespace GameWorld.Core.WpfWindow.FactionColourSettings
+{
+    public partial class FactionColourSettingsViewModel : ObservableObject
+    {
+        private readonly FactionColourSettingsService _settingsService;
+        private readonly Services.FactionColourSettings _originalSettings;
+        private bool _allowPreview;
+
+        [ObservableProperty] private bool _enabled;
+
+        public ColourPickerViewModel Colour0 { get; }
+        public ColourPickerViewModel Colour1 { get; }
+        public ColourPickerViewModel Colour2 { get; }
+
+        public FactionColourSettingsViewModel(
+            FactionColourSettingsService settingsService)
+        {
+            _settingsService = settingsService;
+            _originalSettings = settingsService.Current;
+            _enabled = _originalSettings.Enabled;
+            Colour0 = CreatePicker(_originalSettings.Colour0);
+            Colour1 = CreatePicker(_originalSettings.Colour1);
+            Colour2 = CreatePicker(_originalSettings.Colour2);
+            _allowPreview = true;
+        }
+
+        partial void OnEnabledChanged(bool value) => Preview();
+
+        public void Save() => _settingsService.Save(CreateSettings());
+
+        public void Cancel() =>
+            _settingsService.Preview(_originalSettings);
+
+        private ColourPickerViewModel CreatePicker(string rgb) =>
+            new(
+                ApplicationSettingsHelper
+                    .ParseCustomBackgroundColour(rgb)
+                    .ToVector3(),
+                _ => Preview());
+
+        private void Preview()
+        {
+            if (_allowPreview)
+                _settingsService.Preview(CreateSettings());
+        }
+
+        private Services.FactionColourSettings CreateSettings() => new(
+            Enabled,
+            FactionColourSettingsService.ToRgbString(
+                Colour0.SelectedColour),
+            FactionColourSettingsService.ToRgbString(
+                Colour1.SelectedColour),
+            FactionColourSettingsService.ToRgbString(
+                Colour2.SelectedColour));
+    }
+}

--- a/GameWorld/View3D/WpfWindow/FactionColourSettings/FactionColourSettingsWindow.xaml
+++ b/GameWorld/View3D/WpfWindow/FactionColourSettings/FactionColourSettingsWindow.xaml
@@ -1,0 +1,96 @@
+<windowHandling:AssetEditorWindow
+    x:Class="GameWorld.Core.WpfWindow.FactionColourSettings.FactionColourSettingsWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:colourPicker="clr-namespace:Shared.Ui.BaseDialogs.ColourPickerButton;assembly=Shared.Ui"
+    xmlns:loc="clr-namespace:Shared.Ui.Common;assembly=Shared.Ui"
+    xmlns:windowHandling="clr-namespace:WindowHandling;assembly=Shared.Ui"
+    Title="{loc:Loc FactionTint.Window.Title}"
+    Width="460"
+    MinHeight="280"
+    ResizeMode="NoResize"
+    ShowInTaskbar="False"
+    SizeToContent="Height"
+    WindowStartupLocation="CenterOwner">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Grid Margin="20">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <CheckBox
+                Grid.ColumnSpan="2"
+                Margin="0,0,0,12"
+                Content="{loc:Loc FactionTint.Enabled}"
+                IsChecked="{Binding Enabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                Style="{StaticResource AeInput.CheckBox}" />
+
+            <TextBlock
+                Grid.Row="1"
+                Margin="0,0,16,10"
+                VerticalAlignment="Center"
+                Text="{loc:Loc Tint.FactionColour0}" />
+            <colourPicker:ColourPickerButtonView
+                Grid.Row="1"
+                Grid.Column="1"
+                Width="28"
+                Height="28"
+                Margin="0,0,0,10"
+                DataContext="{Binding Colour0}" />
+
+            <TextBlock
+                Grid.Row="2"
+                Margin="0,0,16,10"
+                VerticalAlignment="Center"
+                Text="{loc:Loc Tint.FactionColour1}" />
+            <colourPicker:ColourPickerButtonView
+                Grid.Row="2"
+                Grid.Column="1"
+                Width="28"
+                Height="28"
+                Margin="0,0,0,10"
+                DataContext="{Binding Colour1}" />
+
+            <TextBlock
+                Grid.Row="3"
+                Margin="0,0,16,0"
+                VerticalAlignment="Center"
+                Text="{loc:Loc Tint.FactionColour2}" />
+            <colourPicker:ColourPickerButtonView
+                Grid.Row="3"
+                Grid.Column="1"
+                Width="28"
+                Height="28"
+                DataContext="{Binding Colour2}" />
+        </Grid>
+
+        <Border Grid.Row="1" Style="{StaticResource AeWorkflow.DialogFooter}">
+            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+                <Button
+                    MinWidth="88"
+                    Margin="0,0,8,0"
+                    Content="{loc:Loc General.Cancel}"
+                    IsCancel="True"
+                    Style="{StaticResource AeButton.Secondary}" />
+                <Button
+                    MinWidth="88"
+                    Click="SaveButton_Click"
+                    Content="{loc:Loc General.Save}"
+                    IsDefault="True"
+                    Style="{StaticResource AeButton.Primary}" />
+            </StackPanel>
+        </Border>
+    </Grid>
+</windowHandling:AssetEditorWindow>

--- a/GameWorld/View3D/WpfWindow/FactionColourSettings/FactionColourSettingsWindow.xaml.cs
+++ b/GameWorld/View3D/WpfWindow/FactionColourSettings/FactionColourSettingsWindow.xaml.cs
@@ -1,0 +1,22 @@
+using System.Windows;
+using WindowHandling;
+
+namespace GameWorld.Core.WpfWindow.FactionColourSettings
+{
+    public partial class FactionColourSettingsWindow : AssetEditorWindow
+    {
+        public FactionColourSettingsWindow(
+            FactionColourSettingsViewModel viewModel)
+        {
+            InitializeComponent();
+            DataContext = viewModel;
+        }
+
+        private void SaveButton_Click(
+            object sender,
+            RoutedEventArgs eventArgs)
+        {
+            DialogResult = true;
+        }
+    }
+}

--- a/Shared/SharedCore/Settings/ApplicationSettingsService.cs
+++ b/Shared/SharedCore/Settings/ApplicationSettingsService.cs
@@ -7,6 +7,10 @@ namespace Shared.Core.Settings
 {
     public class ApplicationSettings
     {
+        public const string DefaultFactionColour0 = "255,0,0";
+        public const string DefaultFactionColour1 = "100,169,226";
+        public const string DefaultFactionColour2 = "255,255,255";
+
         public class GamePathPair
         {
             public GameTypeEnum Game { get; set; }
@@ -24,6 +28,13 @@ namespace Shared.Core.Settings
         public float ViewportEnvironmentLightRotationY { get; set; } = 20.0f;
         public float ViewportDirectLightRotationX { get; set; } = 0.0f;
         public float ViewportDirectLightRotationY { get; set; } = 0.0f;
+        public bool ViewportFactionColoursEnabled { get; set; } = true;
+        public string ViewportFactionColour0 { get; set; } =
+            DefaultFactionColour0;
+        public string ViewportFactionColour1 { get; set; } =
+            DefaultFactionColour1;
+        public string ViewportFactionColour2 { get; set; } =
+            DefaultFactionColour2;
         public bool StartMaximised { get; set; } = false;
         public List<GamePathPair> GameDirectories { get; set; } = [];
         public GameTypeEnum CurrentGame { get; set; } = GameTypeEnum.Warhammer3;

--- a/Shared/SharedCore/Settings/ViewportRenderSettings.cs
+++ b/Shared/SharedCore/Settings/ViewportRenderSettings.cs
@@ -9,7 +9,11 @@ namespace Shared.Core.Settings
         float LightIntensity,
         float EnvironmentLightRotationY,
         float DirectLightRotationX,
-        float DirectLightRotationY)
+        float DirectLightRotationY,
+        bool FactionColoursEnabled = true,
+        string FactionColour0 = ApplicationSettings.DefaultFactionColour0,
+        string FactionColour1 = ApplicationSettings.DefaultFactionColour1,
+        string FactionColour2 = ApplicationSettings.DefaultFactionColour2)
     {
         public static ViewportRenderSettings From(
             ApplicationSettings settings)
@@ -23,7 +27,11 @@ namespace Shared.Core.Settings
                 settings.ViewportLightIntensity,
                 settings.ViewportEnvironmentLightRotationY,
                 settings.ViewportDirectLightRotationX,
-                settings.ViewportDirectLightRotationY);
+                settings.ViewportDirectLightRotationY,
+                settings.ViewportFactionColoursEnabled,
+                settings.ViewportFactionColour0,
+                settings.ViewportFactionColour1,
+                settings.ViewportFactionColour2);
         }
     }
 }

--- a/Shared/SharedUI/Assembly.cs
+++ b/Shared/SharedUI/Assembly.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AssetEditorTests")]

--- a/Shared/SharedUI/BaseDialogs/ColourPickerButton/ColourPickerViewModel.cs
+++ b/Shared/SharedUI/BaseDialogs/ColourPickerButton/ColourPickerViewModel.cs
@@ -30,7 +30,10 @@ namespace Shared.Ui.BaseDialogs.ColourPickerButton
         [RelayCommand]
         public void OnHandleColourChanged()
         {
-            SelectedColour = new Vector3(PickedColor.R / 256f, PickedColor.G / 256f, PickedColor.B / 256f);
+            SelectedColour = new Vector3(
+                PickedColor.R / 255f,
+                PickedColor.G / 255f,
+                PickedColor.B / 255f);
             _onColourChangedCallback?.Invoke(SelectedColour);
         }
     }

--- a/Shared/SharedUI/Common/DarkTitleBarHelper.cs
+++ b/Shared/SharedUI/Common/DarkTitleBarHelper.cs
@@ -8,7 +8,8 @@ using Shared.Core.Settings;
 namespace CommonControls
 {
     /// <summary>
-    /// Enables dark mode title bar on Windows 11+ via DWM API.
+    /// Enables the optional dark title bar via DWM when the Windows build
+    /// supports it.
     /// Automatically follows the current theme - dark themes get dark title bar, light themes get light title bar.
     /// Call DarkTitleBarHelper.Enable(this) in a Window constructor.
     /// </summary>
@@ -16,8 +17,21 @@ namespace CommonControls
     {
         private static readonly ConditionalWeakTable<Window, Registration> Registrations = new();
 
-        [DllImport("dwmapi.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
-        static extern void DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
+        internal delegate int DwmSetWindowAttributeDelegate(
+            IntPtr hwnd,
+            int attribute,
+            ref int attributeValue,
+            int attributeSize);
+
+        [DllImport(
+            "dwmapi.dll",
+            EntryPoint = "DwmSetWindowAttribute",
+            PreserveSig = true)]
+        private static extern int DwmSetWindowAttributeNative(
+            IntPtr hwnd,
+            int attribute,
+            ref int attributeValue,
+            int attributeSize);
 
         const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
 
@@ -31,8 +45,36 @@ namespace CommonControls
             var isDark = !ThemesController.CurrentTheme.ToString().Contains("Light");
             var value = isDark ? 1 : 0;
             var handle = new WindowInteropHelper(window).Handle;
-            if (handle != IntPtr.Zero)
-                DwmSetWindowAttribute(handle, DWMWA_USE_IMMERSIVE_DARK_MODE, ref value, sizeof(int));
+            TrySetImmersiveDarkMode(
+                handle,
+                value,
+                DwmSetWindowAttributeNative);
+        }
+
+        internal static bool TrySetImmersiveDarkMode(
+            IntPtr handle,
+            int value,
+            DwmSetWindowAttributeDelegate setter)
+        {
+            if (handle == IntPtr.Zero)
+                return false;
+
+            try
+            {
+                return setter(
+                    handle,
+                    DWMWA_USE_IMMERSIVE_DARK_MODE,
+                    ref value,
+                    sizeof(int)) >= 0;
+            }
+            catch (DllNotFoundException)
+            {
+                return false;
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return false;
+            }
         }
 
         private sealed class Registration

--- a/Testing/AssetEditorTests/FactionColourSettingsWindowTests.cs
+++ b/Testing/AssetEditorTests/FactionColourSettingsWindowTests.cs
@@ -1,0 +1,84 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using GameWorld.Core.Services;
+using GameWorld.Core.WpfWindow.FactionColourSettings;
+using NUnit.Framework;
+using Shared.Core.Services;
+using Shared.Core.Settings;
+using Shared.Ui.BaseDialogs.ColourPickerButton;
+using NUnitAssert = NUnit.Framework.Assert;
+
+namespace AssetEditorTests;
+
+[NonParallelizable]
+public class FactionColourSettingsWindowTests
+{
+    [SetUp]
+    public void SetUp() => new LocalizationManager().LoadLanguage();
+
+    [Test]
+    public void Window_RendersSharedFactionSettingsControls()
+    {
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () =>
+            {
+                var settings = new ApplicationSettingsService();
+                var service = new FactionColourSettingsService(
+                    settings,
+                    new TestEventHub());
+                var window = new FactionColourSettingsWindow(
+                    new FactionColourSettingsViewModel(service));
+
+                try
+                {
+                    window.Show();
+                    window.UpdateLayout();
+
+                    NUnitAssert.Multiple(() =>
+                    {
+                        NUnitAssert.That(window.Title,
+                            Is.EqualTo("阵营着色"));
+                        NUnitAssert.That(
+                            FindVisualChildren<ColourPickerButtonView>(
+                                window).Count(),
+                            Is.EqualTo(3));
+                        NUnitAssert.That(
+                            FindVisualChildren<CheckBox>(window)
+                                .Any(item => Equals(
+                                    item.Content,
+                                    "启用阵营着色")),
+                            Is.True);
+                        NUnitAssert.That(
+                            FindVisualChildren<Button>(window)
+                                .Any(item => Equals(
+                                    item.Content,
+                                    "保存")),
+                            Is.True);
+                    });
+                }
+                finally
+                {
+                    window.Close();
+                }
+            });
+    }
+
+    private static IEnumerable<T> FindVisualChildren<T>(
+        DependencyObject parent)
+        where T : DependencyObject
+    {
+        for (var index = 0;
+             index < VisualTreeHelper.GetChildrenCount(parent);
+             index++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, index);
+            if (child is T match)
+                yield return match;
+
+            foreach (var descendant in FindVisualChildren<T>(child))
+                yield return descendant;
+        }
+    }
+}

--- a/Testing/AssetEditorTests/SettingsViewModelTests.cs
+++ b/Testing/AssetEditorTests/SettingsViewModelTests.cs
@@ -347,6 +347,10 @@ public class SettingsViewModelTests
     public void ColourPickers_PreviewExactBackgroundAndGridColours()
     {
         var settings = new ApplicationSettingsService();
+        settings.CurrentSettings.ViewportFactionColoursEnabled = false;
+        settings.CurrentSettings.ViewportFactionColour0 = "1,2,3";
+        settings.CurrentSettings.ViewportFactionColour1 = "4,5,6";
+        settings.CurrentSettings.ViewportFactionColour2 = "7,8,9";
         var eventHub = new TestEventHub();
         var previews = new List<ViewportRenderSettings>();
         eventHub.Register<ViewportRenderSettingsChangedEvent>(
@@ -393,6 +397,12 @@ public class SettingsViewModelTests
                     NUnitAssert.That(
                         previews.Last().GridColour,
                         Is.EqualTo("70,80,90"));
+                    NUnitAssert.That(
+                        previews.Last().FactionColoursEnabled,
+                        Is.False);
+                    NUnitAssert.That(
+                        previews.Last().FactionColour0,
+                        Is.EqualTo("1,2,3"));
                 });
             });
         autoSave.Stop();

--- a/Testing/AssetEditorTests/UiFoundationWindowTests.cs
+++ b/Testing/AssetEditorTests/UiFoundationWindowTests.cs
@@ -43,11 +43,19 @@ public class UiFoundationWindowTests
                     DarkTitleBarHelper.Enable(window);
                     window.Show();
 
-                    NUnitAssert.That(ReadDarkTitleBar(window), Is.EqualTo(1));
+                    if (!TryReadDarkTitleBar(window, out var darkValue))
+                    {
+                        NUnitAssert.Ignore(
+                            "This Windows build does not support the optional immersive dark title-bar attribute.");
+                    }
+                    NUnitAssert.That(darkValue, Is.EqualTo(1));
 
                     ThemesController.SetTheme(ThemeType.LightTheme);
 
-                    NUnitAssert.That(ReadDarkTitleBar(window), Is.EqualTo(0));
+                    NUnitAssert.That(
+                        TryReadDarkTitleBar(window, out var lightValue),
+                        Is.True);
+                    NUnitAssert.That(lightValue, Is.EqualTo(0));
                 }
                 finally
                 {
@@ -97,6 +105,30 @@ public class UiFoundationWindowTests
 
                 dialog.Close();
             });
+    }
+
+    [Test]
+    public void UnsupportedDarkTitleBarAttribute_DoesNotThrow()
+    {
+        var invoked = false;
+
+        var result = DarkTitleBarHelper.TrySetImmersiveDarkMode(
+            new IntPtr(1),
+            1,
+            (IntPtr handle,
+                int attribute,
+                ref int value,
+                int size) =>
+            {
+                invoked = true;
+                return unchecked((int)0x80070057);
+            });
+
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(invoked, Is.True);
+            NUnitAssert.That(result, Is.False);
+        });
     }
 
     [TestCase(MessageBoxImage.None, false)]
@@ -228,16 +260,17 @@ public class UiFoundationWindowTests
             "Native Windows MessageBox calls bypass the unified dialog.");
     }
 
-    private static int ReadDarkTitleBar(Window window)
+    private static bool TryReadDarkTitleBar(
+        Window window,
+        out int value)
     {
-        var value = 0;
+        value = 0;
         var result = DwmGetWindowAttribute(
             new WindowInteropHelper(window).Handle,
             DwmwaUseImmersiveDarkMode,
             ref value,
             sizeof(int));
-        NUnitAssert.That(result, Is.EqualTo(0));
-        return value;
+        return result >= 0;
     }
 
     private static string FindSolutionRoot()

--- a/Testing/GameWorld.Core.Test/Rendering/FactionColourSettingsServiceTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/FactionColourSettingsServiceTests.cs
@@ -1,0 +1,95 @@
+using GameWorld.Core.Services;
+using Moq;
+using Shared.Core.Events;
+using Shared.Core.Events.Global;
+using Shared.Core.Settings;
+
+namespace GameWorld.Core.Test.Rendering;
+
+public class FactionColourSettingsServiceTests
+{
+    [Test]
+    public void Save_PersistsSharedSettingsAndPublishesGlobalPreview()
+    {
+        var applicationSettings = new ApplicationSettingsService();
+        var eventHub = new Mock<IGlobalEventHub>();
+        ViewportRenderSettingsChangedEvent published = null!;
+        eventHub
+            .Setup(hub => hub.PublishGlobalEvent(
+                It.IsAny<ViewportRenderSettingsChangedEvent>()))
+            .Callback<ViewportRenderSettingsChangedEvent>(
+                value => published = value);
+        var service = new FactionColourSettingsService(
+            applicationSettings,
+            eventHub.Object);
+        var factionSettings = new FactionColourSettings(
+            false,
+            "1,2,3",
+            "4,5,6",
+            "7,8,9");
+
+        service.Save(factionSettings);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                applicationSettings.CurrentSettings
+                    .ViewportFactionColoursEnabled,
+                Is.False);
+            Assert.That(
+                applicationSettings.CurrentSettings
+                    .ViewportFactionColour0,
+                Is.EqualTo("1,2,3"));
+            Assert.That(
+                applicationSettings.CurrentSettings
+                    .ViewportFactionColour1,
+                Is.EqualTo("4,5,6"));
+            Assert.That(
+                applicationSettings.CurrentSettings
+                    .ViewportFactionColour2,
+                Is.EqualTo("7,8,9"));
+            Assert.That(published, Is.Not.Null);
+            Assert.That(published!.Settings.FactionColoursEnabled,
+                Is.False);
+            Assert.That(published.Settings.FactionColour1,
+                Is.EqualTo("4,5,6"));
+        });
+    }
+
+    [Test]
+    public void Preview_PublishesWithoutChangingPersistedSettings()
+    {
+        var applicationSettings = new ApplicationSettingsService();
+        var eventHub = new Mock<IGlobalEventHub>();
+        ViewportRenderSettingsChangedEvent published = null!;
+        eventHub
+            .Setup(hub => hub.PublishGlobalEvent(
+                It.IsAny<ViewportRenderSettingsChangedEvent>()))
+            .Callback<ViewportRenderSettingsChangedEvent>(
+                value => published = value);
+        var service = new FactionColourSettingsService(
+            applicationSettings,
+            eventHub.Object);
+
+        service.Preview(new FactionColourSettings(
+            false,
+            "9,8,7",
+            "6,5,4",
+            "3,2,1"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                applicationSettings.CurrentSettings
+                    .ViewportFactionColoursEnabled,
+                Is.True);
+            Assert.That(
+                applicationSettings.CurrentSettings
+                    .ViewportFactionColour0,
+                Is.EqualTo(ApplicationSettings.DefaultFactionColour0));
+            Assert.That(published, Is.Not.Null);
+            Assert.That(published!.Settings.FactionColour0,
+                Is.EqualTo("9,8,7"));
+        });
+    }
+}

--- a/Testing/GameWorld.Core.Test/Rendering/Shaders/FactionTintTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/Shaders/FactionTintTests.cs
@@ -103,6 +103,44 @@ public class FactionTintTests
     }
 
     [Test]
+    public void MaterialApply_ForwardsGlobalFactionPreviewStateToEffect()
+    {
+        var game = new WpfGameMock();
+        var effect = game.Content.Load<Effect>(
+            "Shaders\\Pbr\\SpecGloss\\SpecGloss_main");
+        var resources = new Mock<IScopedResourceLibrary>();
+        resources
+            .Setup(library => library.GetStaticEffect(
+                ShaderTypes.Pbr_SpecGloss))
+            .Returns(effect);
+        var material = new FactionTintMaterial(resources.Object);
+        var parameters = new CommonShaderParameters(
+            Matrix.Identity,
+            Matrix.Identity,
+            Vector3.Zero,
+            Vector3.Zero,
+            0,
+            0,
+            0,
+            1,
+            Vector3.One,
+            [Vector3.UnitX, Vector3.UnitY, Vector3.UnitZ],
+            FactionColoursEnabled: false);
+
+        material.Apply(parameters, Matrix.Identity);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(material.Tint.UseFactionColours, Is.False);
+            Assert.That(
+                effect.Parameters["Tint_UseFactionColours"]
+                    .GetValueBoolean(),
+                Is.False);
+            Assert.That(material.Tint.ApplyCapability, Is.True);
+        });
+    }
+
+    [Test]
     public void SpecGlossShader_AppliesFactionColourFromMaskChannel()
     {
         var game = new WpfGameMock();
@@ -126,6 +164,42 @@ public class FactionTintTests
         {
             Assert.That(redPixel.R, Is.GreaterThan(redPixel.B + 20));
             Assert.That(bluePixel.B, Is.GreaterThan(bluePixel.R + 20));
+        });
+    }
+
+    [Test]
+    public void SpecGlossShader_DisabledFactionPreviewLeavesDiffuseUntinted()
+    {
+        var game = new WpfGameMock();
+        var device = game.GraphicsDevice;
+        var effect = game.Content.Load<Effect>(
+            "Shaders\\Pbr\\SpecGloss\\SpecGloss_main");
+        using var diffuse = CreateTexture(device, Color.White);
+        using var mask = CreateTexture(device, Color.Red);
+        ConfigureSpecGlossEffect(effect, diffuse, mask);
+
+        var tintedPixel = RenderFactionColour(
+            device,
+            effect,
+            new Vector3(1, 0, 0));
+        effect.Parameters["Tint_UseFactionColours"]
+            .SetValue(false);
+        var untintedPixel = RenderFactionColour(
+            device,
+            effect,
+            new Vector3(1, 0, 0));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                tintedPixel.R,
+                Is.GreaterThan(tintedPixel.G + 20));
+            Assert.That(
+                Math.Abs(untintedPixel.R - untintedPixel.G),
+                Is.LessThanOrEqualTo(2));
+            Assert.That(
+                Math.Abs(untintedPixel.G - untintedPixel.B),
+                Is.LessThanOrEqualTo(2));
         });
     }
 
@@ -252,5 +326,26 @@ public class FactionTintTests
             BlendWeights = Vector4.Zero,
             BlendIndices = Vector4.Zero
         };
+    }
+
+    private sealed class FactionTintMaterial : CapabilityMaterial
+    {
+        public TintCapability Tint { get; } = new();
+
+        public FactionTintMaterial(IScopedResourceLibrary resources)
+            : base(
+                CapabilityMaterialsEnum.SpecGlossPbr_Default,
+                ShaderTypes.Pbr_SpecGloss,
+                resources)
+        {
+            Capabilities =
+            [
+                new CommonShaderParametersCapability(),
+                Tint
+            ];
+        }
+
+        protected override CapabilityMaterial CreateCloneInstance() =>
+            new FactionTintMaterial(_resourceLibrary);
     }
 }

--- a/Testing/GameWorld.Core.Test/Rendering/ViewportRenderSettingsRuntimeTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/ViewportRenderSettingsRuntimeTests.cs
@@ -20,6 +20,24 @@ namespace GameWorld.Core.Test.Rendering;
 public class ViewportRenderSettingsRuntimeTests
 {
     [Test]
+    public void Constructor_DefaultsSharedViewportsToMaterialPreview()
+    {
+        var renderEngine = new RenderEngineComponent(
+            null!,
+            null!,
+            null!,
+            null!,
+            new ApplicationSettingsService(),
+            new SceneRenderParametersStore(),
+            Mock.Of<IEventHub>(),
+            new GridComponent(null!, null!, null!));
+
+        Assert.That(
+            renderEngine.ShadingMode,
+            Is.EqualTo(ViewportShadingMode.MaterialPreview));
+    }
+
+    [Test]
     public void GridVisibilityOverride_PreservesCscCameraModeAcrossGlobalChanges()
     {
         var grid = new GridComponent(null!, null!, null!);
@@ -36,7 +54,7 @@ public class ViewportRenderSettingsRuntimeTests
     }
 
     [Test]
-    public void GlobalViewportChange_UpdatesVisualDefaultsWithoutTouchingFactionPreview()
+    public void GlobalViewportChange_UpdatesVisualAndFactionDefaults()
     {
         var game = new WpfGameMock();
         var deviceResolver = new Mock<IDeviceResolver>();
@@ -56,6 +74,7 @@ public class ViewportRenderSettingsRuntimeTests
             deviceResolver.Object);
         var scene = new SceneRenderParametersStore
         {
+            FactionColoursEnabled = true,
             FactionColour0 = new Vector3(0.1f, 0.2f, 0.3f),
             FactionColour1 = new Vector3(0.4f, 0.5f, 0.6f),
             FactionColour2 = new Vector3(0.7f, 0.8f, 0.9f)
@@ -81,7 +100,11 @@ public class ViewportRenderSettingsRuntimeTests
                 1.75f,
                 45.0f,
                 -15.0f,
-                120.0f)));
+                120.0f,
+                false,
+                "10,20,30",
+                "40,50,60",
+                "70,80,90")));
 
         var background = (Color)typeof(RenderEngineComponent)
             .GetField(
@@ -99,12 +122,13 @@ public class ViewportRenderSettingsRuntimeTests
             Assert.That(scene.EnvLightRotationDegrees_Y, Is.EqualTo(45.0f));
             Assert.That(scene.DirLightRotationDegrees_X, Is.EqualTo(-15.0f));
             Assert.That(scene.DirLightRotationDegrees_Y, Is.EqualTo(120.0f));
+            Assert.That(scene.FactionColoursEnabled, Is.False);
             Assert.That(scene.FactionColour0,
-                Is.EqualTo(new Vector3(0.1f, 0.2f, 0.3f)));
+                Is.EqualTo(new Color(10, 20, 30).ToVector3()));
             Assert.That(scene.FactionColour1,
-                Is.EqualTo(new Vector3(0.4f, 0.5f, 0.6f)));
+                Is.EqualTo(new Color(40, 50, 60).ToVector3()));
             Assert.That(scene.FactionColour2,
-                Is.EqualTo(new Vector3(0.7f, 0.8f, 0.9f)));
+                Is.EqualTo(new Color(70, 80, 90).ToVector3()));
         });
     }
 

--- a/Testing/Shared.Core.Test/Settings/ViewportRenderSettingsTests.cs
+++ b/Testing/Shared.Core.Test/Settings/ViewportRenderSettingsTests.cs
@@ -35,15 +35,40 @@ public class ViewportRenderSettingsTests
                 Is.EqualTo(0.0f));
             Assert.That(viewportSettings.DirectLightRotationY,
                 Is.EqualTo(0.0f));
+            Assert.That(viewportSettings.FactionColoursEnabled, Is.True);
+            Assert.That(viewportSettings.FactionColour0,
+                Is.EqualTo("255,0,0"));
+            Assert.That(viewportSettings.FactionColour1,
+                Is.EqualTo("100,169,226"));
+            Assert.That(viewportSettings.FactionColour2,
+                Is.EqualTo("255,255,255"));
         });
     }
 
     [Test]
-    public void ViewportSettingsSerialization_DoesNotContainFactionPreviewColours()
+    public void ViewportSettingsSerialization_PreservesFactionPreview()
     {
-        var json = JsonSerializer.Serialize(
-            ViewportRenderSettings.From(new ApplicationSettings()));
+        var settings = new ApplicationSettings
+        {
+            ViewportFactionColoursEnabled = false,
+            ViewportFactionColour0 = "1,2,3",
+            ViewportFactionColour1 = "4,5,6",
+            ViewportFactionColour2 = "7,8,9"
+        };
 
-        Assert.That(json, Does.Not.Contain("Faction"));
+        var json = JsonSerializer.Serialize(settings);
+        var loaded = JsonSerializer.Deserialize<ApplicationSettings>(json)!;
+        var viewportSettings = ViewportRenderSettings.From(loaded);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(viewportSettings.FactionColoursEnabled, Is.False);
+            Assert.That(viewportSettings.FactionColour0,
+                Is.EqualTo("1,2,3"));
+            Assert.That(viewportSettings.FactionColour1,
+                Is.EqualTo("4,5,6"));
+            Assert.That(viewportSettings.FactionColour2,
+                Is.EqualTo("7,8,9"));
+        });
     }
 }


### PR DESCRIPTION
## 用户可见变化
- 阵营着色配置改为所有 3D 编辑器共用并持久保存，默认蓝色降低饱和度
- 除 Kitbash 外的 3D 编辑器顶部增加“阵营着色”入口；Kitbash 继续使用右侧属性栏
- 修复其他 3D 编辑器加载模型后回到实体着色的问题，默认保持材质预览
- Win10 不支持可选深色标题栏参数时安全降级，不再导致启动退出

## 验证
- `dotnet restore AssetEditor.CN.sln`
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore`：0 警告，0 错误
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal`：通过
- `git diff --check`：通过