### PR TITLE
Fix first-run settings window ownership

### DIFF
--- a/AssetEditor/UiCommands/OpenSettingsDialogCommand.cs
+++ b/AssetEditor/UiCommands/OpenSettingsDialogCommand.cs
@@ -18,8 +18,9 @@ namespace AssetEditor.UiCommands
 
         public void Execute()
         {
+            var owner = Application.Current.MainWindow;
             var window = _serviceProvider.GetRequiredService<SettingsWindow>();
-            window.Owner = Application.Current.MainWindow;
+            window.Owner = owner;
             window.DataContext = _serviceProvider.GetRequiredService<SettingsViewModel>();
             window.ShowDialog();
         }

--- a/Testing/AssetEditorTests/OpenSettingsDialogCommandTests.cs
+++ b/Testing/AssetEditorTests/OpenSettingsDialogCommandTests.cs
@@ -1,0 +1,99 @@
+using System.Windows;
+using AssetEditor.Services.Settings;
+using AssetEditor.UiCommands;
+using AssetEditor.ViewModels;
+using AssetEditor.Views.Settings;
+using Moq;
+using NUnit.Framework;
+using Shared.Core.PackFiles;
+using Shared.Core.Services;
+using Shared.Core.Settings;
+using NUnitAssert = NUnit.Framework.Assert;
+
+namespace AssetEditorTests;
+
+[NonParallelizable]
+public class OpenSettingsDialogCommandTests
+{
+    [SetUp]
+    public void SetUp() => new LocalizationManager().LoadLanguage();
+
+    [Test]
+    public void Execute_WhenSettingsWindowIsFirstWindow_ShowsWithoutSelfOwnerException()
+    {
+        var settings = new ApplicationSettingsService();
+        var autoSave = new PackAutoSaveService(
+            Mock.Of<IPackFileService>(),
+            settings);
+        var viewModel = new SettingsViewModel(
+            settings,
+            new ApplicationSettingsApplier(
+                settings,
+                autoSave,
+                new TestEventHub()),
+            Mock.Of<IStandardDialogs>());
+
+        try
+        {
+            WpfTestApplicationHost.InvokeWithThemeResources(
+                Mock.Of<IServiceProvider>(),
+                () =>
+                {
+                    Application.Current.MainWindow = null;
+                    using var services = new SettingsServiceProvider(viewModel);
+                    var command = new OpenSettingsDialogCommand(services);
+
+                    NUnitAssert.That(
+                        Application.Current.MainWindow,
+                        Is.Null);
+                    NUnitAssert.DoesNotThrow(command.Execute);
+                    NUnitAssert.That(services.WasShown, Is.True);
+                });
+        }
+        finally
+        {
+            autoSave.Stop();
+        }
+    }
+
+    private sealed class SettingsServiceProvider : IServiceProvider, IDisposable
+    {
+        private readonly SettingsViewModel _viewModel;
+        private SettingsWindow? _window;
+
+        public bool WasShown { get; private set; }
+
+        public SettingsServiceProvider(SettingsViewModel viewModel)
+        {
+            _viewModel = viewModel;
+        }
+
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(SettingsViewModel))
+                return _viewModel;
+            if (serviceType != typeof(SettingsWindow))
+                return null;
+
+            _window = new SettingsWindow();
+            _window.Loaded += (_, _) =>
+            {
+                WasShown = true;
+                _window.DataContext = null;
+                _window.Close();
+            };
+            return _window;
+        }
+
+        public void Dispose()
+        {
+            if (_window != null)
+            {
+                _window.DataContext = null;
+                _window.Close();
+            }
+
+            Application.Current.MainWindow = null;
+        }
+    }
+}


### PR DESCRIPTION
## 改动

- 在创建设置窗口前保存当前主窗口引用，避免首次启动时设置窗口成为自己的 Owner
- 新增真实 WPF 回归测试，覆盖“设置窗口是第一个窗口”的启动顺序

## 根因

首次启动时主窗口尚未创建。WPF 会自动把第一个实例化的 `SettingsWindow` 设为 `Application.MainWindow`，旧代码随后把它设置为自己的 Owner，触发 `ArgumentException`，并因显式关闭模式留下 CMD 进程。

## 影响

- 修复 Win10/Win11 新用户首次启动崩溃
- 主窗口已存在时，设置窗口仍保持原有 Owner 和模态行为
- 不修改其他 UI、用户配置或版本号

## 验证

- Win10 22H2 用户通过 v2.2.1 差分热修复实测：问题已修复
- `dotnet restore AssetEditor.CN.sln`
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore`
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity minimal`：2696 通过、6 跳过、0 失败
- `git diff --cached --check`