### PR TITLE
修复编辑器回归并隔离 Kitbash 模型编辑组件

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,9 @@
 - `Shared/SharedCore` 放置无 WPF 业务界面的核心服务与模型，`Shared/GameFiles` 放置游戏格式，`Shared/SharedUI` 放置跨模块、无业务含义的通用 WPF 组件。
 - `Shared.Ui` 只能引用 `Shared/` 内项目，不得反向依赖 `AssetEditor`、`Editors` 或具体业务编辑器；已有 `SharedUiArchitectureTests` 是这条边界的自动门禁。
 - 只有被多个模块真实复用、无业务含义且可独立验证的 UI 才进入 `Shared.Ui`；对话框等通用依赖优先走 `IStandardDialogs` 等现有抽象。
+- `KitbashEditor` 是唯一承担模型编辑的编辑器；其他编辑器中的模型只用于参考、预览或辅助展示，不得把它们视为模型编辑入口。
+- 其他编辑器可以共用公共 View3D 场景组件；`KitbashEditor` 的模型选择、变换、编辑覆盖层及专属三维场景效果必须由 `Editors/Kitbashing/KitbasherEditor` 内的独立组件实现，并且只在 Kitbash 编辑器作用域注册。Kitbash 专属行为不得通过共享组件中的模式开关、编辑器类型判断或共享默认值实现。
+- Kitbash 独立组件可以复用无编辑器语义的底层数据结构、数学、设备和绘制原语，但不得改变其他编辑器使用的共享场景组件行为。修改 `GameWorld/View3D` 中的共享选择、Gizmo、输入或渲染组件前，必须先证明该行为对所有使用者都成立；仅服务 Kitbash 的需求应留在 Kitbash 模块。
 - 比较上游 `D:\TheAssetEditor` 时必须实时核对两边 HEAD、分支、工作区、行为、项目引用、本地化和测试；文件名相同或旧记忆不能证明功能等价。
 
 ## Pack 与文件夹工程

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@
 - `Shared.Ui` 只能引用 `Shared/` 内项目，不得反向依赖 `AssetEditor`、`Editors` 或具体业务编辑器；已有 `SharedUiArchitectureTests` 是这条边界的自动门禁。
 - 只有被多个模块真实复用、无业务含义且可独立验证的 UI 才进入 `Shared.Ui`；对话框等通用依赖优先走 `IStandardDialogs` 等现有抽象。
 - `KitbashEditor` 是唯一承担模型编辑的编辑器；其他编辑器中的模型只用于参考、预览或辅助展示，不得把它们视为模型编辑入口。
-- 其他编辑器可以共用公共 View3D 场景组件；`KitbashEditor` 的模型选择、变换、编辑覆盖层及专属三维场景效果必须由 `Editors/Kitbashing/KitbasherEditor` 内的独立组件实现，并且只在 Kitbash 编辑器作用域注册。Kitbash 专属行为不得通过共享组件中的模式开关、编辑器类型判断或共享默认值实现。
+- 其他编辑器可以共用公共 View3D 场景组件；`KitbashEditor` 的模型选择、变换、编辑覆盖层及专属三维场景效果必须由 `Editors/Kitbashing/KitbasherEditor` 内的独立组件实现，并且只允许由 Kitbash 编辑器的组成入口创建和插入。不得把这些专属组件注册为所有编辑器作用域都能解析的服务，也不得通过共享组件中的模式开关、编辑器类型判断或共享默认值实现 Kitbash 专属行为。
 - Kitbash 独立组件可以复用无编辑器语义的底层数据结构、数学、设备和绘制原语，但不得改变其他编辑器使用的共享场景组件行为。修改 `GameWorld/View3D` 中的共享选择、Gizmo、输入或渲染组件前，必须先证明该行为对所有使用者都成立；仅服务 Kitbash 的需求应留在 Kitbash 模块。
 - 比较上游 `D:\TheAssetEditor` 时必须实时核对两边 HEAD、分支、工作区、行为、项目引用、本地化和测试；文件名相同或旧记忆不能证明功能等价。
 

--- a/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationBoneGizmoComponent.cs
+++ b/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationBoneGizmoComponent.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
+using GameWorld.Core.Commands;
+using GameWorld.Core.Components;
+using GameWorld.Core.Components.Gizmo;
+using GameWorld.Core.Components.Input;
+using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.Components.Selection;
+using GameWorld.Core.Services;
+using GameWorld.Core.Utility;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Shared.Core.Events;
+
+namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
+{
+    public sealed class AnimationBoneGizmoComponent :
+        BaseComponent,
+        IDisposable
+    {
+        private readonly IEventHub _eventHub;
+        private readonly IKeyboardComponent _keyboard;
+        private readonly IMouseComponent _mouse;
+        private readonly ArcBallCamera _camera;
+        private readonly CommandExecutor _commandExecutor;
+        private readonly RenderEngineComponent _renderEngine;
+        private readonly IDeviceResolver _deviceResolver;
+        private readonly CommandFactory _commandFactory;
+        private readonly SelectionManager _selectionManager;
+        private Gizmo? _gizmo;
+        private TransformGizmoWrapper? _activeTransformation;
+        private bool _isTransformActive;
+        private bool _isEnabled;
+
+        public AnimationBoneGizmoComponent(
+            IEventHub eventHub,
+            IKeyboardComponent keyboard,
+            IMouseComponent mouse,
+            ArcBallCamera camera,
+            CommandExecutor commandExecutor,
+            RenderEngineComponent renderEngine,
+            IDeviceResolver deviceResolver,
+            CommandFactory commandFactory,
+            SelectionManager selectionManager)
+        {
+            _eventHub = eventHub;
+            _keyboard = keyboard;
+            _mouse = mouse;
+            _camera = camera;
+            _commandExecutor = commandExecutor;
+            _renderEngine = renderEngine;
+            _deviceResolver = deviceResolver;
+            _commandFactory = commandFactory;
+            _selectionManager = selectionManager;
+            UpdateOrder = (int)ComponentUpdateOrderEnum.Gizmo;
+            DrawOrder = (int)ComponentDrawOrderEnum.Gizmo;
+        }
+
+        public override void Initialize()
+        {
+            if (Isinitialized)
+                return;
+
+            _gizmo = new Gizmo(
+                _camera,
+                _mouse,
+                _deviceResolver.Device,
+                _renderEngine)
+            {
+                ActivePivot = PivotType.ObjectCenter
+            };
+            _gizmo.SetKeyboard(_keyboard);
+            _gizmo.TranslateEvent += OnTranslate;
+            _gizmo.RotateEvent += OnRotate;
+            _gizmo.ScaleEvent += OnScale;
+            _gizmo.StartEvent += OnTransformStart;
+            _gizmo.StopEvent += OnTransformEnd;
+            _eventHub.Register<SelectionChangedEvent>(
+                this,
+                HandleSelectionChanged);
+            OnSelectionChanged(_selectionManager.GetState());
+            base.Initialize();
+        }
+
+        private void OnSelectionChanged(ISelectionState? state)
+        {
+            if (_gizmo == null)
+                return;
+
+            var previousTransformation = _activeTransformation;
+            if (previousTransformation != null &&
+                _isTransformActive)
+            {
+                previousTransformation.CancelTransform();
+                _gizmo.AbortTransformInteraction();
+                ReleaseMouseOwnership();
+            }
+
+            _isTransformActive = false;
+            previousTransformation?.Dispose();
+            _activeTransformation = null;
+            _gizmo.Selection.Clear();
+
+            if (state is not BoneSelectionState boneSelection ||
+                boneSelection.SelectedBones.Count == 0)
+            {
+                _gizmo.ResetDeltas();
+                return;
+            }
+
+            _activeTransformation = new TransformGizmoWrapper(
+                _commandFactory,
+                new List<int>(boneSelection.SelectedBones),
+                boneSelection);
+            _gizmo.Selection.Add(_activeTransformation);
+            _gizmo.ResetDeltas();
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            if (_gizmo == null ||
+                _selectionManager.GetState() is not BoneSelectionState)
+            {
+                return;
+            }
+
+            if (_gizmo.IsInModalTransform)
+            {
+                _gizmo.SnapEnabled = IsControlDown();
+                _gizmo.Update(
+                    gameTime,
+                    !_keyboard.IsKeyDown(Keys.LeftAlt));
+                return;
+            }
+
+            if (!_isEnabled)
+                return;
+
+            _gizmo.SnapEnabled = IsControlDown();
+            _gizmo.Update(
+                gameTime,
+                !_keyboard.IsKeyDown(Keys.LeftAlt));
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            if (_gizmo == null ||
+                _selectionManager.GetState() is not BoneSelectionState ||
+                (!_isEnabled && !_gizmo.IsInModalTransform))
+            {
+                return;
+            }
+
+            _gizmo.Draw();
+        }
+
+        private void OnTransformStart()
+        {
+            if (_activeTransformation == null)
+                return;
+
+            _activeTransformation.BeginTransform();
+            _isTransformActive = true;
+            _mouse.MouseOwner = this;
+        }
+
+        private void OnTransformEnd()
+        {
+            if (_gizmo == null)
+                return;
+
+            try
+            {
+                if (_gizmo.IsModalCancelled)
+                    _activeTransformation?.CancelTransform();
+                else
+                    _activeTransformation?.CommitTransform(
+                        _commandExecutor);
+            }
+            finally
+            {
+                _isTransformActive = false;
+                _gizmo.IsModalCancelled = false;
+                ReleaseMouseOwnership();
+            }
+        }
+
+        private void OnTranslate(
+            ITransformable transformable,
+            TransformationEventArgs args)
+        {
+            _activeTransformation?.GizmoTranslateEvent(
+                (Vector3)args.Value!,
+                args.Pivot);
+        }
+
+        private void OnRotate(
+            ITransformable transformable,
+            TransformationEventArgs args)
+        {
+            _activeTransformation?.GizmoRotateEvent(
+                (Matrix)args.Value!,
+                args.Pivot);
+        }
+
+        private void OnScale(
+            ITransformable transformable,
+            TransformationEventArgs args)
+        {
+            _activeTransformation?.GizmoScaleEvent(
+                (Vector3)args.Value!,
+                args.Pivot);
+        }
+
+        public void SetGizmoMode(GizmoMode mode)
+        {
+            if (_gizmo == null)
+                return;
+
+            _gizmo.ActiveMode = mode;
+            _isEnabled = true;
+        }
+
+        public void ResetScale()
+        {
+            if (_gizmo != null)
+                _gizmo.ScaleModifier = 1;
+        }
+
+        public void Disable() => _isEnabled = false;
+
+        private bool IsControlDown() =>
+            _keyboard.IsKeyDown(Keys.LeftControl) ||
+            _keyboard.IsKeyDown(Keys.RightControl);
+
+        private void ReleaseMouseOwnership()
+        {
+            if (_mouse.MouseOwner != this)
+                return;
+
+            _mouse.MouseOwner = null;
+            _mouse.ClearStates();
+        }
+
+        private void HandleSelectionChanged(
+            SelectionChangedEvent notification) =>
+            OnSelectionChanged(notification.NewState);
+
+        public void Dispose()
+        {
+            _eventHub.UnRegister(this);
+            ExceptionDispatchInfo? primaryError = null;
+            var transformation = _activeTransformation;
+
+            if (transformation != null && _isTransformActive)
+            {
+                try
+                {
+                    transformation.CancelTransform();
+                }
+                catch (Exception exception)
+                {
+                    primaryError = ExceptionDispatchInfo.Capture(
+                        exception);
+                }
+            }
+
+            _isTransformActive = false;
+            if (_gizmo != null)
+            {
+                try
+                {
+                    _gizmo.AbortTransformInteraction();
+                }
+                catch (Exception exception)
+                {
+                    primaryError ??= ExceptionDispatchInfo.Capture(
+                        exception);
+                }
+            }
+
+            try
+            {
+                ReleaseMouseOwnership();
+            }
+            catch (Exception exception)
+            {
+                primaryError ??= ExceptionDispatchInfo.Capture(
+                    exception);
+            }
+
+            try
+            {
+                transformation?.Dispose();
+            }
+            catch (Exception exception)
+            {
+                primaryError ??= ExceptionDispatchInfo.Capture(
+                    exception);
+            }
+
+            _activeTransformation = null;
+            if (_gizmo != null)
+            {
+                try
+                {
+                    _gizmo.Selection.Clear();
+                    _gizmo.Dispose();
+                }
+                catch (Exception exception)
+                {
+                    primaryError ??= ExceptionDispatchInfo.Capture(
+                        exception);
+                }
+
+                _gizmo = null;
+            }
+
+            primaryError?.Throw();
+        }
+    }
+}

--- a/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationBoneSelectionComponent.cs
+++ b/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationBoneSelectionComponent.cs
@@ -1,0 +1,377 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GameWorld.Core.Commands;
+using GameWorld.Core.Commands.Bone;
+using GameWorld.Core.Commands.Object;
+using GameWorld.Core.Components;
+using GameWorld.Core.Components.Input;
+using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.Components.Selection;
+using GameWorld.Core.SceneNodes;
+using GameWorld.Core.Services;
+using GameWorld.Core.Utility;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Keys = Microsoft.Xna.Framework.Input.Keys;
+using MouseButton = GameWorld.Core.Components.Input.MouseButton;
+
+namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
+{
+    public sealed class AnimationBoneSelectionComponent :
+        BaseComponent,
+        IDisposable
+    {
+        private const int BonePointSelectionHalfSize = 4;
+
+        private readonly IMouseComponent _mouse;
+        private readonly IKeyboardComponent _keyboard;
+        private readonly ArcBallCamera _camera;
+        private readonly SelectionManager _selectionManager;
+        private readonly CommandFactory _commandFactory;
+        private readonly SceneManager _sceneManager;
+        private readonly RenderEngineComponent _renderEngine;
+        private readonly IDeviceResolver _deviceResolver;
+        private Texture2D? _selectionTexture;
+        private bool _isMouseDown;
+        private Vector2 _startDrag;
+        private Vector2 _currentMousePosition;
+
+        public AnimationBoneSelectionComponent(
+            IMouseComponent mouse,
+            IKeyboardComponent keyboard,
+            ArcBallCamera camera,
+            SelectionManager selectionManager,
+            CommandFactory commandFactory,
+            SceneManager sceneManager,
+            RenderEngineComponent renderEngine,
+            IDeviceResolver deviceResolver)
+        {
+            _mouse = mouse;
+            _keyboard = keyboard;
+            _camera = camera;
+            _selectionManager = selectionManager;
+            _commandFactory = commandFactory;
+            _sceneManager = sceneManager;
+            _renderEngine = renderEngine;
+            _deviceResolver = deviceResolver;
+            UpdateOrder = (int)ComponentUpdateOrderEnum.SelectionComponent;
+            DrawOrder = (int)ComponentDrawOrderEnum.SelectionComponent;
+        }
+
+        public override void Initialize()
+        {
+            if (Isinitialized)
+                return;
+
+            _selectionTexture = new Texture2D(
+                _deviceResolver.Device,
+                1,
+                1);
+            _selectionTexture.SetData([Color.White]);
+            base.Initialize();
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            var state = _selectionManager.GetState();
+            if (state is not ObjectSelectionState and
+                not BoneSelectionState)
+            {
+                ReleaseMouseOwnership();
+                return;
+            }
+
+            if (!_mouse.IsMouseOwner(this))
+                return;
+
+            _currentMousePosition = _mouse.Position();
+            if (_mouse.IsMouseButtonPressed(MouseButton.Left))
+            {
+                _startDrag = _currentMousePosition;
+                _isMouseDown = true;
+                _mouse.MouseOwner = this;
+            }
+
+            if (!_mouse.IsMouseButtonReleased(MouseButton.Left))
+                return;
+
+            if (_isMouseDown)
+            {
+                var rectangle = CreateSelectionRectangle(
+                    _startDrag,
+                    _currentMousePosition);
+                var isModification =
+                    _keyboard.IsKeyDown(Keys.LeftShift);
+                var removeSelection =
+                    _keyboard.IsKeyDown(Keys.LeftControl);
+
+                if (rectangle.Width * rectangle.Height >= 10)
+                {
+                    SelectFromRectangle(
+                        rectangle,
+                        isModification,
+                        removeSelection);
+                }
+                else
+                {
+                    SelectFromPoint(
+                        _currentMousePosition,
+                        isModification,
+                        removeSelection);
+                }
+            }
+
+            ReleaseMouseOwnership();
+        }
+
+        private void SelectFromRectangle(
+            Rectangle rectangle,
+            bool isModification,
+            bool removeSelection)
+        {
+            var state = _selectionManager.GetState();
+            if (state is BoneSelectionState boneSelection)
+            {
+                SelectBones(
+                    boneSelection,
+                    rectangle,
+                    isModification,
+                    removeSelection);
+                return;
+            }
+
+            if (state is not ObjectSelectionState objectSelection)
+                return;
+
+            var selectedObjects = _sceneManager
+                .SelectObjects(_camera.UnprojectRectangle(rectangle))
+                .ToList();
+            if (selectedObjects.Count == 0 && !isModification)
+            {
+                if (objectSelection.SelectionCount() != 0)
+                    ExecuteObjectSelection([], false, false);
+                return;
+            }
+
+            ExecuteObjectSelection(
+                selectedObjects,
+                isModification,
+                removeSelection);
+        }
+
+        private void SelectFromPoint(
+            Vector2 mousePosition,
+            bool isModification,
+            bool removeSelection)
+        {
+            var state = _selectionManager.GetState();
+            if (state is BoneSelectionState boneSelection)
+            {
+                var pointRectangle = new Rectangle(
+                    (int)mousePosition.X -
+                        BonePointSelectionHalfSize,
+                    (int)mousePosition.Y -
+                        BonePointSelectionHalfSize,
+                    BonePointSelectionHalfSize * 2,
+                    BonePointSelectionHalfSize * 2);
+                SelectBones(
+                    boneSelection,
+                    pointRectangle,
+                    isModification,
+                    removeSelection);
+                return;
+            }
+
+            if (state is not ObjectSelectionState objectSelection)
+                return;
+
+            var selectedObject = _sceneManager.SelectObject(
+                _camera.CreateCameraRay(mousePosition));
+            if (selectedObject == null && !isModification)
+            {
+                if (objectSelection.SelectionCount() != 0)
+                    ExecuteObjectSelection([], false, false);
+                return;
+            }
+
+            if (selectedObject != null)
+            {
+                ExecuteObjectSelection(
+                    [selectedObject],
+                    isModification,
+                    removeSelection);
+            }
+        }
+
+        private void SelectBones(
+            BoneSelectionState state,
+            Rectangle rectangle,
+            bool isModification,
+            bool removeSelection)
+        {
+            if (state.RenderObject is not Rmv2MeshNode mesh ||
+                state.Skeleton == null ||
+                state.CurrentAnimation == null)
+            {
+                return;
+            }
+
+            var intersects = IntersectionMath.IntersectBones(
+                _camera.UnprojectRectangle(rectangle),
+                mesh,
+                state.Skeleton,
+                mesh.RenderMatrix,
+                out var bones);
+            if (intersects)
+            {
+                _commandFactory.Create<BoneSelectionCommand>()
+                    .Configure(command => command.Configure(
+                        bones,
+                        isModification,
+                        removeSelection))
+                    .BuildAndExecute();
+            }
+            else if (!isModification &&
+                     !removeSelection &&
+                     state.SelectedBones.Count != 0)
+            {
+                _commandFactory.Create<BoneSelectionCommand>()
+                    .Configure(command => command.Configure(
+                        [],
+                        false,
+                        false))
+                    .BuildAndExecute();
+            }
+        }
+
+        private void ExecuteObjectSelection(
+            IEnumerable<ISelectable> selectedObjects,
+            bool isModification,
+            bool removeSelection)
+        {
+            _commandFactory.Create<ObjectSelectionCommand>()
+                .Configure(command => command.Configure(
+                    new List<ISelectable>(selectedObjects),
+                    isModification,
+                    removeSelection))
+                .BuildAndExecute();
+        }
+
+        public bool SetObjectSelectionMode()
+        {
+            var state = _selectionManager.GetState();
+            if (state?.Mode == GeometrySelectionMode.Object)
+                return false;
+
+            _commandFactory.Create<ObjectSelectionModeCommand>()
+                .Configure(command => command.Configure(
+                    state?.GetSingleSelectedObject(),
+                    GeometrySelectionMode.Object))
+                .BuildAndExecute();
+            return true;
+        }
+
+        public bool SetBoneSelectionMode()
+        {
+            var state = _selectionManager.GetState();
+            if (state?.Mode == GeometrySelectionMode.Bone)
+                return false;
+
+            var selectedObject = state?.GetSingleSelectedObject();
+            if (selectedObject == null)
+                return false;
+
+            _commandFactory.Create<ObjectSelectionModeCommand>()
+                .Configure(command => command.Configure(
+                    selectedObject,
+                    GeometrySelectionMode.Bone))
+                .BuildAndExecute();
+            return true;
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            if (!_isMouseDown || _selectionTexture == null)
+                return;
+
+            var destination = CreateSelectionRectangle(
+                _startDrag,
+                _currentMousePosition);
+            const int lineWidth = 2;
+            var top = new Rectangle(
+                destination.X,
+                destination.Y,
+                destination.Width,
+                lineWidth);
+            var bottom = new Rectangle(
+                destination.X,
+                destination.Y + destination.Height,
+                destination.Width + lineWidth,
+                lineWidth);
+            var left = new Rectangle(
+                destination.X,
+                destination.Y,
+                lineWidth,
+                destination.Height);
+            var right = new Rectangle(
+                destination.X + destination.Width,
+                destination.Y,
+                lineWidth,
+                destination.Height);
+
+            _renderEngine.CommonSpriteBatch.Begin(
+                SpriteSortMode.Deferred,
+                BlendState.AlphaBlend);
+            _renderEngine.CommonSpriteBatch.Draw(
+                _selectionTexture,
+                destination,
+                Color.White * 0.5f);
+            _renderEngine.CommonSpriteBatch.Draw(
+                _selectionTexture,
+                top,
+                Color.Red * 0.75f);
+            _renderEngine.CommonSpriteBatch.Draw(
+                _selectionTexture,
+                bottom,
+                Color.Red * 0.75f);
+            _renderEngine.CommonSpriteBatch.Draw(
+                _selectionTexture,
+                left,
+                Color.Red * 0.75f);
+            _renderEngine.CommonSpriteBatch.Draw(
+                _selectionTexture,
+                right,
+                Color.Red * 0.75f);
+            _renderEngine.CommonSpriteBatch.End();
+        }
+
+        private void ReleaseMouseOwnership()
+        {
+            _isMouseDown = false;
+            if (_mouse.MouseOwner != this)
+                return;
+
+            _mouse.MouseOwner = null;
+            _mouse.ClearStates();
+        }
+
+        private static Rectangle CreateSelectionRectangle(
+            Vector2 start,
+            Vector2 stop)
+        {
+            return new Rectangle(
+                (int)Math.Min(start.X, stop.X),
+                (int)Math.Min(start.Y, stop.Y),
+                Math.Abs((int)(stop.X - start.X)),
+                Math.Abs((int)(stop.Y - start.Y)));
+        }
+
+        public void Dispose()
+        {
+            ReleaseMouseOwnership();
+            _selectionTexture?.Dispose();
+            _selectionTexture = null;
+        }
+    }
+}

--- a/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationKeyframeEditorViewModel.cs
+++ b/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationKeyframeEditorViewModel.cs
@@ -37,12 +37,14 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
         private CopyPastePose _copyPastePose;
         private CopyPasteFromClipboardPose _copyPasteClipboardPose;
         private InterpolateBetweenPose _interpolateBetweenPose;
+        private readonly BoneSelectionHighlightComponent
+            _boneSelectionHighlight;
 
-        public SelectionComponent SelectionComponent { get => _selectionComponent; private set { _selectionComponent = value; } }
-        private SelectionComponent _selectionComponent;
+        public AnimationBoneSelectionComponent SelectionComponent { get => _selectionComponent; private set { _selectionComponent = value; } }
+        private AnimationBoneSelectionComponent _selectionComponent;
 
-        public GizmoComponent GizmoComponent { get => _gizmoComponent; private set { _gizmoComponent = value; } }
-        private GizmoComponent _gizmoComponent;
+        public AnimationBoneGizmoComponent GizmoComponent { get => _gizmoComponent; private set { _gizmoComponent = value; } }
+        private AnimationBoneGizmoComponent _gizmoComponent;
 
         public CommandFactory CommandFactory { get => _commandFactory; private set { _commandFactory = value; } }
         private CommandFactory _commandFactory;
@@ -162,13 +164,14 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
 
         public AnimationKeyframeEditorViewModel(IPackFileService pfs,
             ISkeletonAnimationLookUpHelper skeletonAnimationLookUpHelper,
-            SelectionComponent selectionComponent,
+            AnimationBoneSelectionComponent selectionComponent,
             SceneObjectViewModelBuilder sceneObjectViewModelBuilder,
             AnimationPlayerViewModel animationPlayerViewModel,
             SceneObjectEditor sceneObjectBuilder,
             CommandFactory commandFactory,
             SelectionManager selectionManager,
-            GizmoComponent gizmoComponent,
+            AnimationBoneGizmoComponent gizmoComponent,
+            BoneSelectionHighlightComponent boneSelectionHighlight,
             CommandExecutor commandExecutor,
             IFileSaveService packFileSaveService,
             IStandardDialogs standardDialogs)
@@ -185,6 +188,7 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
             _selectionManager = selectionManager;
 
             _gizmoComponent = gizmoComponent;
+            _boneSelectionHighlight = boneSelectionHighlight;
             _commandExecutor = commandExecutor;
             _packFileSaveService = packFileSaveService;
             _standardDialogs = standardDialogs;
@@ -211,6 +215,9 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
 
         public void Initialize(EditorHost<AnimationKeyframeEditorViewModel> owner)
         {
+           owner.GameWorld.Value.AddComponent(_selectionComponent);
+           owner.GameWorld.Value.AddComponent(_gizmoComponent);
+           owner.GameWorld.Value.AddComponent(_boneSelectionHighlight);
            //var riderItem = _sceneObjectViewModelBuilder.CreateAsset(true, "Rider", Color.Black, null);
            //var mountItem = _sceneObjectViewModelBuilder.CreateAsset(true, "Mount", Color.Black, null);
            //mountItem.Data.IsSelectable = true;

--- a/Editors/AnimationEditor/CampaignAnimationCreator/CampaignAnimationCreatorViewModel.cs
+++ b/Editors/AnimationEditor/CampaignAnimationCreator/CampaignAnimationCreatorViewModel.cs
@@ -5,6 +5,7 @@ using Editors.Shared.Core.Common;
 using Editors.Shared.Core.Common.BaseControl;
 using Editors.Shared.Core.Common.ReferenceModel;
 using GameWorld.Core.Animation;
+using GameWorld.Core.Components.Selection;
 using Microsoft.Xna.Framework;
 using Shared.Core.PackFiles;
 using Shared.Core.Services;
@@ -28,8 +29,13 @@ namespace AnimationEditor.CampaignAnimationCreator
             IEditorHostParameters editorHostParameters,
             IPackFileService packFileService,
             ConvertCampaignAnimationCommand convertCommand,
-            SaveCampaignAnimationCommand saveCommand) : base(editorHostParameters)
+            SaveCampaignAnimationCommand saveCommand,
+            ReferenceObjectSelectionComponent objectSelection,
+            ReferenceObjectSelectionOutlineComponent selectionOutline)
+            : base(editorHostParameters)
         {
+            GameWorld!.AddComponent(objectSelection);
+            GameWorld.AddComponent(selectionOutline);
             DisplayName = LocalizationManager.Instance.Get("DisplayName.CampaignAnimationTool");
             _packFileService = packFileService;
             _convertCommand = convertCommand;

--- a/Editors/AnimationEditor/DependencyInjectionContainer.cs
+++ b/Editors/AnimationEditor/DependencyInjectionContainer.cs
@@ -21,9 +21,12 @@ namespace Editors.AnimationVisualEditors
 
             serviceCollection.AddScoped<EditorHost<MountAnimationCreatorViewModel>>();
             serviceCollection.AddScoped<MountAnimationCreatorViewModel>();
+            serviceCollection.AddScoped<MountVertexSelectionComponent>();
 
             serviceCollection.AddScoped<EditorHost<AnimationKeyframeEditorViewModel>>();
             serviceCollection.AddScoped<AnimationKeyframeEditorViewModel>();
+            serviceCollection.AddScoped<AnimationBoneSelectionComponent>();
+            serviceCollection.AddScoped<AnimationBoneGizmoComponent>();
 
             RegisterAllAsInterface<IDeveloperConfiguration>(serviceCollection, ServiceLifetime.Transient);
         }

--- a/Editors/AnimationEditor/MountAnimationCreator/MountAnimationCreatorViewModel.cs
+++ b/Editors/AnimationEditor/MountAnimationCreator/MountAnimationCreatorViewModel.cs
@@ -42,6 +42,12 @@ namespace AnimationEditor.MountAnimationCreator
         private readonly SelectionManager _selectionManager;
         private readonly ISkeletonAnimationLookUpHelper _skeletonAnimationLookUpHelper;
         private readonly IStandardDialogs _standardDialogs;
+        private readonly MountVertexSelectionComponent
+            _vertexSelectionComponent;
+        private readonly ReferenceObjectSelectionComponent
+            _objectSelectionComponent;
+        private readonly ReferenceObjectSelectionOutlineComponent
+            _selectionOutlineComponent;
 
         SceneObject _mount;
         SceneObject _rider;
@@ -84,6 +90,9 @@ namespace AnimationEditor.MountAnimationCreator
             SceneObjectEditor sceneObjectBuilder,
             IFileSaveService fileSaveService,
             IUiCommandFactory uiCommandFactory,
+            MountVertexSelectionComponent vertexSelectionComponent,
+            ReferenceObjectSelectionComponent objectSelectionComponent,
+            ReferenceObjectSelectionOutlineComponent selectionOutlineComponent,
             IStandardDialogs standardDialogs)
         {
             _sceneObjectViewModelBuilder = sceneObjectViewModelBuilder;
@@ -91,6 +100,9 @@ namespace AnimationEditor.MountAnimationCreator
             _sceneObjectBuilder = sceneObjectBuilder;
             _fileSaveService = fileSaveService;
             _uiCommandFactory = uiCommandFactory;
+            _vertexSelectionComponent = vertexSelectionComponent;
+            _objectSelectionComponent = objectSelectionComponent;
+            _selectionOutlineComponent = selectionOutlineComponent;
             _standardDialogs = standardDialogs;
             _pfs = pfs;
 
@@ -120,6 +132,12 @@ namespace AnimationEditor.MountAnimationCreator
 
         public void Initialize(EditorHost<MountAnimationCreatorViewModel> owner)
         {
+            owner.GameWorld.Value.AddComponent(
+                _vertexSelectionComponent);
+            owner.GameWorld.Value.AddComponent(
+                _objectSelectionComponent);
+            owner.GameWorld.Value.AddComponent(
+                _selectionOutlineComponent);
            // var riderItem = _sceneObjectViewModelBuilder.CreateAsset(true, "Rider", Color.Black, _inputRiderData);
            // var mountItem = _sceneObjectViewModelBuilder.CreateAsset(true, "Mount", Color.Black, _inputMountData);
            // mountItem.Data.IsSelectable = true;

--- a/Editors/AnimationEditor/MountAnimationCreator/MountVertexSelectionComponent.cs
+++ b/Editors/AnimationEditor/MountAnimationCreator/MountVertexSelectionComponent.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using GameWorld.Core.Animation;
+using GameWorld.Core.Components;
+using GameWorld.Core.Components.Input;
+using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.Components.Selection;
+using GameWorld.Core.Rendering;
+using GameWorld.Core.Rendering.RenderItems;
+using GameWorld.Core.SceneNodes;
+using GameWorld.Core.Services;
+using GameWorld.Core.Utility;
+using Microsoft.Xna.Framework;
+using Keys = Microsoft.Xna.Framework.Input.Keys;
+using MouseButton = GameWorld.Core.Components.Input.MouseButton;
+
+namespace AnimationEditor.MountAnimationCreator
+{
+    public sealed class MountVertexSelectionComponent :
+        BaseComponent,
+        IDisposable
+    {
+        private readonly SelectionManager _selectionManager;
+        private readonly IKeyboardComponent _keyboard;
+        private readonly IMouseComponent _mouse;
+        private readonly ArcBallCamera _camera;
+        private readonly IDeviceResolver _deviceResolver;
+        private readonly IScopedResourceLibrary _resourceLibrary;
+        private readonly RenderEngineComponent _renderEngine;
+        private VertexInstanceMesh? _vertexRenderer;
+        private VertexRenderItem? _vertexRenderItem;
+        private Rmv2MeshNode? _wireframeMesh;
+        private AnimatedWireframeRenderItem? _wireframeRenderItem;
+        private bool _isMouseDown;
+        private Vector2 _startDrag;
+        private Vector2 _currentMousePosition;
+
+        public MountVertexSelectionComponent(
+            SelectionManager selectionManager,
+            IKeyboardComponent keyboard,
+            IMouseComponent mouse,
+            ArcBallCamera camera,
+            IDeviceResolver deviceResolver,
+            IScopedResourceLibrary resourceLibrary,
+            RenderEngineComponent renderEngine)
+        {
+            _selectionManager = selectionManager;
+            _keyboard = keyboard;
+            _mouse = mouse;
+            _camera = camera;
+            _deviceResolver = deviceResolver;
+            _resourceLibrary = resourceLibrary;
+            _renderEngine = renderEngine;
+            UpdateOrder = (int)ComponentUpdateOrderEnum.SelectionComponent;
+        }
+
+        public override void Initialize()
+        {
+            if (_selectionManager.GetState() == null)
+            {
+                _selectionManager.CreateSelectionSate(
+                    GeometrySelectionMode.Object,
+                    null,
+                    false);
+            }
+
+            _vertexRenderer = new VertexInstanceMesh(
+                _deviceResolver,
+                _resourceLibrary);
+            _vertexRenderItem = new VertexRenderItem
+            {
+                VertexRenderer = _vertexRenderer,
+            };
+            base.Initialize();
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            if (_keyboard.IsKeyReleased(Keys.Tab) &&
+                !_keyboard.IsKeyDownOrReleased(Keys.LeftAlt) &&
+                !_keyboard.IsKeyDownOrReleased(Keys.RightAlt))
+            {
+                ToggleVertexSelectionMode();
+            }
+
+            if (_selectionManager.GetState() is not
+                VertexSelectionState vertexSelection)
+            {
+                return;
+            }
+
+            if (!_mouse.IsMouseOwner(this))
+                return;
+
+            _currentMousePosition = _mouse.Position();
+            if (_mouse.IsMouseButtonPressed(MouseButton.Left))
+            {
+                _startDrag = _currentMousePosition;
+                _isMouseDown = true;
+                if (_mouse.MouseOwner != this)
+                    _mouse.MouseOwner = this;
+            }
+
+            if (_mouse.IsMouseButtonReleased(MouseButton.Left))
+            {
+                var rectangle = CreateSelectionRectangle(
+                    _startDrag,
+                    _currentMousePosition);
+                var isModification =
+                    _keyboard.IsKeyDown(Keys.LeftShift);
+                var removeSelection =
+                    _keyboard.IsKeyDown(Keys.LeftControl);
+                if (_isMouseDown && rectangle.Width * rectangle.Height >= 10)
+                {
+                    SelectFromRectangle(
+                        vertexSelection,
+                        rectangle,
+                        isModification,
+                        removeSelection);
+                }
+                else
+                {
+                    SelectFromPoint(
+                        vertexSelection,
+                        _currentMousePosition,
+                        isModification,
+                        removeSelection);
+                }
+
+                _isMouseDown = false;
+            }
+
+            if (!_isMouseDown && _mouse.MouseOwner == this)
+            {
+                _mouse.MouseOwner = null;
+                _mouse.ClearStates();
+            }
+        }
+
+        private void ToggleVertexSelectionMode()
+        {
+            var state = _selectionManager.GetState();
+            if (state is ObjectSelectionState objectSelection)
+            {
+                var selectedObject =
+                    objectSelection.GetSingleSelectedObject();
+                if (selectedObject != null)
+                {
+                    _selectionManager.CreateSelectionSate(
+                        GeometrySelectionMode.Vertex,
+                        selectedObject);
+                }
+                return;
+            }
+
+            if (state is not VertexSelectionState vertexSelection)
+                return;
+
+            var renderObject = vertexSelection.RenderObject;
+            var replacement = (ObjectSelectionState)
+                _selectionManager.CreateSelectionSate(
+                    GeometrySelectionMode.Object,
+                    null);
+            replacement.ModifySelection([renderObject], false);
+        }
+
+        private void SelectFromRectangle(
+            VertexSelectionState state,
+            Rectangle screenRectangle,
+            bool isModification,
+            bool removeSelection)
+        {
+            var worldPositions = GetWorldPositions(state);
+            var intersects = IntersectionMath.IntersectVertices(
+                _camera.UnprojectRectangle(screenRectangle),
+                state.RenderObject.Geometry,
+                worldPositions,
+                out var vertices);
+            ApplySelection(
+                state,
+                intersects ? vertices : [],
+                isModification,
+                removeSelection);
+        }
+
+        private void SelectFromPoint(
+            VertexSelectionState state,
+            Vector2 mousePosition,
+            bool isModification,
+            bool removeSelection)
+        {
+            var viewport = _deviceResolver.Device.Viewport;
+            var distance = IntersectionMath.IntersectVertex(
+                mousePosition,
+                state.RenderObject.Geometry,
+                GetWorldPositions(state),
+                _camera.ViewMatrix * _camera.ProjectionMatrix,
+                viewport.Width,
+                viewport.Height,
+                out var vertex,
+                new HashSet<int>(state.SelectedVertices));
+            ApplySelection(
+                state,
+                distance == null ? [] : [vertex],
+                isModification,
+                removeSelection);
+        }
+
+        private static Vector3[] GetWorldPositions(
+            VertexSelectionState state)
+        {
+            return state.RenderObject is Rmv2MeshNode mesh
+                ? MeshPoseSnapshot.Capture(mesh).GetWorldPositions()
+                : state.RenderObject.Geometry.GetVertexList()
+                    .ConvertAll(vertex => Vector3.Transform(
+                        vertex,
+                        state.RenderObject.RenderMatrix))
+                    .ToArray();
+        }
+
+        private void ApplySelection(
+            VertexSelectionState state,
+            IEnumerable<int> vertices,
+            bool isModification,
+            bool removeSelection)
+        {
+            if (!isModification && !removeSelection)
+                state.SetSelection(vertices);
+            else
+                state.ModifySelection(vertices, removeSelection);
+
+            _vertexRenderItem?.MarkDirty();
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            if (_selectionManager.GetState() is not
+                    VertexSelectionState selection ||
+                selection.RenderObject is not Rmv2MeshNode mesh ||
+                _vertexRenderItem == null)
+            {
+                return;
+            }
+
+            var pose = MeshPoseSnapshot.Capture(mesh);
+            if (_wireframeRenderItem == null ||
+                _wireframeMesh != mesh)
+            {
+                _wireframeRenderItem?.Dispose();
+                _wireframeMesh = mesh;
+                _wireframeRenderItem =
+                    new AnimatedWireframeRenderItem(
+                        pose,
+                        _resourceLibrary,
+                        new Vector4(0.15f, 0.15f, 0.15f, 1));
+            }
+            else
+            {
+                _wireframeRenderItem.UpdatePose(pose);
+            }
+
+            _renderEngine.AddRenderItem(
+                RenderBuckedId.Wireframe,
+                _wireframeRenderItem);
+            _vertexRenderItem.Node = mesh;
+            _vertexRenderItem.Pose = pose;
+            _vertexRenderItem.WorldPositions = null;
+            _vertexRenderItem.SelectedVertices = selection;
+            _renderEngine.AddRenderItem(
+                RenderBuckedId.Normal,
+                _vertexRenderItem);
+        }
+
+        public void Dispose()
+        {
+            _wireframeRenderItem?.Dispose();
+            _wireframeRenderItem = null;
+            _wireframeMesh = null;
+            _vertexRenderer?.Dispose();
+            _vertexRenderer = null;
+            _vertexRenderItem = null;
+        }
+
+        private static Rectangle CreateSelectionRectangle(
+            Vector2 start,
+            Vector2 stop)
+        {
+            return new Rectangle(
+                (int)Math.Min(start.X, stop.X),
+                (int)Math.Min(start.Y, stop.Y),
+                Math.Abs((int)(stop.X - start.X)),
+                Math.Abs((int)(stop.Y - start.Y)));
+        }
+    }
+}

--- a/Editors/AnimationReTarget/Editors.AnimatioReTarget/Editor/AnimationRetargetEditor.cs
+++ b/Editors/AnimationReTarget/Editors.AnimatioReTarget/Editor/AnimationRetargetEditor.cs
@@ -7,6 +7,7 @@ using Editors.Shared.Core.Common;
 using Editors.Shared.Core.Common.AnimationPlayer;
 using Editors.Shared.Core.Common.BaseControl;
 using GameWorld.Core.Animation;
+using GameWorld.Core.Components.Selection;
 using Microsoft.Xna.Framework;
 using Shared.Core.Events;
 using Shared.Core.PackFiles;
@@ -62,6 +63,8 @@ namespace Editors.AnimatioReTarget.Editor
             SaveManager saveManager,
             BoneManager boneManager,
             AnimationReTargetRenderingComponent renderingComponent,
+            ReferenceObjectSelectionComponent objectSelection,
+            ReferenceObjectSelectionOutlineComponent selectionOutline,
             IPackFileService pfs) : base(editorHostParameters)
         {
             DisplayName = LocalizationManager.Instance.Get("DisplayName.AnimationTransferTool");
@@ -76,6 +79,8 @@ namespace Editors.AnimatioReTarget.Editor
             _eventHub = eventHub;
             _saveManager = saveManager;
 
+            GameWorld!.AddComponent(objectSelection);
+            GameWorld.AddComponent(selectionOutline);
             GameWorld.AddComponent(renderingComponent);
 
             _eventHub.Register<SceneObjectUpdateEvent>(this, OnSceneObjectUpdated);

--- a/Editors/CscEditor/Editors.CscEditor/DependencyInjectionContainer.cs
+++ b/Editors/CscEditor/Editors.CscEditor/DependencyInjectionContainer.cs
@@ -22,9 +22,8 @@ namespace Editors.CscEditor
             serviceCollection.AddScoped<CscPlaybackContext>();
             serviceCollection.AddScoped<CscSceneGraphBuilder>();
 
-            // Game components (picked up by IComponentInserter)
-            RegisterGameComponent<CscAnimationComponent>(serviceCollection);
-            RegisterGameComponent<CscGizmoComponent>(serviceCollection);
+            serviceCollection.AddScoped<CscAnimationComponent>();
+            serviceCollection.AddScoped<CscGizmoComponent>();
         }
 
         public override void RegisterTools(IEditorDatabase editorDatabase)

--- a/Editors/CscEditor/Editors.CscEditor/Services/CscGizmoComponent.cs
+++ b/Editors/CscEditor/Editors.CscEditor/Services/CscGizmoComponent.cs
@@ -12,7 +12,7 @@ using Microsoft.Xna.Framework.Input;
 namespace Editors.CscEditor.Services
 {
     /// <summary>
-    /// A CSC-specific transform gizmo. The stock <see cref="GizmoComponent"/> bakes transforms
+    /// A CSC-specific transform gizmo. The Kitbash model gizmo bakes transforms
     /// into mesh vertices (the Kitbasher model), which is wrong here - moving a CSC element means
     /// editing its position/rotation/scale channels. This component reuses the low-level
     /// <see cref="Gizmo"/> widget and routes its deltas into the selected element's channel data.

--- a/Editors/CscEditor/Editors.CscEditor/ViewModels/CscEditorViewModel.cs
+++ b/Editors/CscEditor/Editors.CscEditor/ViewModels/CscEditorViewModel.cs
@@ -197,12 +197,14 @@ namespace Editors.CscEditor.ViewModels
             IEventHub eventHub,
             IWpfGame gameWorld,
             IComponentInserter componentInserter,
+            View3DCoreComponentSet coreComponents,
             CscSceneGraphBuilder sceneBuilder,
             CscAnimationComponent animationComponent,
             CscGizmoComponent gizmoComponent,
             CscPlaybackContext playbackContext,
             ArcBallCamera camera,
             SelectionManager selectionManager,
+            ReferenceObjectSelectionComponent objectSelectionComponent,
             LocalizationManager localization,
             IFactionColourSettingsDialogService factionColourSettingsDialog)
         {
@@ -236,7 +238,11 @@ namespace Editors.CscEditor.ViewModels
             PortholeBackImage = LoadPackImage("ui/skins/default/porthole_back.png");
             PortholeFrameImage = LoadPackImage("ui/skins/default/porthole.png");
 
-            componentInserter.Execute();
+            componentInserter.Execute(
+                coreComponents,
+                objectSelectionComponent,
+                animationComponent,
+                gizmoComponent);
 
             _gizmo.ElementModified += OnGizmoModifiedElement;
             _gizmo.DragStarted += OnEditGestureStarted;

--- a/Editors/Kitbashing/KitbasherEditor/Components/KitbashModelGizmoComponent.cs
+++ b/Editors/Kitbashing/KitbasherEditor/Components/KitbashModelGizmoComponent.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using GameWorld.Core.Commands;
 using GameWorld.Core.Commands.Object;
+using GameWorld.Core.Components;
+using GameWorld.Core.Components.Gizmo;
 using GameWorld.Core.Components.Input;
 using GameWorld.Core.Components.Rendering;
 using GameWorld.Core.Components.Selection;
@@ -13,13 +15,16 @@ using Shared.Core.Events;
 using Shared.Core.ErrorHandling;
 using System.Runtime.ExceptionServices;
 
-namespace GameWorld.Core.Components.Gizmo
+namespace Editors.KitbasherEditor.Components
 {
-    public class GizmoComponent : BaseComponent, IDisposable
+    public sealed class KitbashModelGizmoComponent :
+        BaseComponent,
+        IDisposable
     {
         private readonly IMouseComponent _mouse;
         private readonly IEventHub _eventHub;
-        private readonly ILogger _logger = Logging.Create<GizmoComponent>();
+        private readonly ILogger _logger =
+            Logging.Create<KitbashModelGizmoComponent>();
 
         private readonly IKeyboardComponent _keyboard;
         private readonly SelectionManager _selectionManager;
@@ -37,7 +42,7 @@ namespace GameWorld.Core.Components.Gizmo
         private GeometrySelectionMode _lastEditSubMode = GeometrySelectionMode.Vertex;
 
 
-        public GizmoComponent(IEventHub eventHub,
+        public KitbashModelGizmoComponent(IEventHub eventHub,
             IKeyboardComponent keyboardComponent, IMouseComponent mouseComponent, ArcBallCamera camera, CommandExecutor commandExecutor,
             RenderEngineComponent resourceLibary, IDeviceResolver deviceResolverComponent, CommandFactory commandFactory,
             SelectionManager selectionManager)
@@ -72,7 +77,7 @@ namespace GameWorld.Core.Components.Gizmo
         }
 
         /// <summary>
-        /// Get the Gizmo instance (for SelectionComponent to check modal transform state)
+        /// Get the Gizmo instance for KitbashSelectionInputComponent to check modal transform state.
         /// </summary>
         public Gizmo Gizmo => _gizmo;
 

--- a/Editors/Kitbashing/KitbasherEditor/Components/KitbashSceneComponentSet.cs
+++ b/Editors/Kitbashing/KitbasherEditor/Components/KitbashSceneComponentSet.cs
@@ -1,0 +1,66 @@
+using GameWorld.Core.Commands;
+using GameWorld.Core.Components;
+using GameWorld.Core.Components.Input;
+using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.Components.Selection;
+using GameWorld.Core.Services;
+using GameWorld.Core.Utility;
+using Microsoft.Xna.Framework;
+using Shared.Core.Events;
+
+namespace Editors.KitbasherEditor.Components
+{
+    public sealed class KitbashSceneComponentSet
+    {
+        public KitbashSelectionOverlayComponent SelectionOverlay { get; }
+        public KitbashSelectionInputComponent SelectionInput { get; }
+        public KitbashModelGizmoComponent ModelGizmo { get; }
+        public IGameComponent[] Components { get; }
+
+        public KitbashSceneComponentSet(
+            IEventHub eventHub,
+            IKeyboardComponent keyboard,
+            IMouseComponent mouse,
+            ArcBallCamera camera,
+            CommandExecutor commandExecutor,
+            RenderEngineComponent renderEngine,
+            IDeviceResolver deviceResolver,
+            CommandFactory commandFactory,
+            SelectionManager selectionManager,
+            SceneManager sceneManager,
+            IScopedResourceLibrary resourceLibrary)
+        {
+            ModelGizmo = new KitbashModelGizmoComponent(
+                eventHub,
+                keyboard,
+                mouse,
+                camera,
+                commandExecutor,
+                renderEngine,
+                deviceResolver,
+                commandFactory,
+                selectionManager);
+            SelectionInput = new KitbashSelectionInputComponent(
+                mouse,
+                keyboard,
+                camera,
+                selectionManager,
+                deviceResolver,
+                commandFactory,
+                sceneManager,
+                renderEngine,
+                ModelGizmo);
+            SelectionOverlay = new KitbashSelectionOverlayComponent(
+                selectionManager,
+                renderEngine,
+                resourceLibrary,
+                deviceResolver);
+            Components =
+            [
+                SelectionOverlay,
+                SelectionInput,
+                ModelGizmo
+            ];
+        }
+    }
+}

--- a/Editors/Kitbashing/KitbasherEditor/Components/KitbashSelectionInputComponent.cs
+++ b/Editors/Kitbashing/KitbasherEditor/Components/KitbashSelectionInputComponent.cs
@@ -10,9 +10,10 @@ using GameWorld.Core.Commands.Edge;
 using GameWorld.Core.Commands.Face;
 using GameWorld.Core.Commands.Object;
 using GameWorld.Core.Commands.Vertex;
-using GameWorld.Core.Components.Gizmo;
+using GameWorld.Core.Components;
 using GameWorld.Core.Components.Input;
 using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.Components.Selection;
 using GameWorld.Core.SceneNodes;
 using GameWorld.Core.Services;
 using GameWorld.Core.Utility;
@@ -22,9 +23,11 @@ using Shared.Core.Services;
 using Keys = Microsoft.Xna.Framework.Input.Keys;
 using MouseButton = GameWorld.Core.Components.Input.MouseButton;
 
-namespace GameWorld.Core.Components.Selection
+namespace Editors.KitbasherEditor.Components
 {
-    public class SelectionComponent : BaseComponent, IDisposable
+    public sealed class KitbashSelectionInputComponent :
+        BaseComponent,
+        IDisposable
     {
         //SpriteBatch _spriteBatch;
         Texture2D _textTexture;
@@ -43,14 +46,14 @@ namespace GameWorld.Core.Components.Selection
         private readonly CommandFactory _commandFactory;
         private readonly SceneManager _sceneManger;
         private readonly RenderEngineComponent _resourceLibrary;
-        private readonly GizmoComponent _gizmoComponent;
+        private readonly KitbashModelGizmoComponent _gizmoComponent;
 
-        public SelectionComponent(
+        public KitbashSelectionInputComponent(
             IMouseComponent mouseComponent, IKeyboardComponent keyboardComponent,
             ArcBallCamera camera, SelectionManager selectionManager,
             IDeviceResolver deviceResolverComponent, CommandFactory commandFactory,
             SceneManager sceneManager, RenderEngineComponent resourceLibrary,
-            GizmoComponent gizmoComponent)
+            KitbashModelGizmoComponent gizmoComponent)
         {
             _mouseComponent = mouseComponent;
             _keyboardComponent = keyboardComponent;
@@ -471,7 +474,7 @@ namespace GameWorld.Core.Components.Selection
 
         bool ChangeSelectionMode()
         {
-            // F1/F2/F3 removed - use Tab to toggle Object/Edit mode, 1/2/3 for sub-modes (handled by GizmoComponent)
+            // F1/F2/F3 removed - use Tab to toggle Object/Edit mode, 1/2/3 for sub-modes.
             if (_keyboardComponent.IsKeyReleased(Keys.F9))
             {
                 if (SetBoneSelectionMode())

--- a/Editors/Kitbashing/KitbasherEditor/Components/KitbashSelectionOverlayComponent.cs
+++ b/Editors/Kitbashing/KitbasherEditor/Components/KitbashSelectionOverlayComponent.cs
@@ -1,0 +1,763 @@
+using System;
+using System.Collections.Generic;
+using GameWorld.Core.Animation;
+using GameWorld.Core.Components;
+using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.Components.Selection;
+using GameWorld.Core.Rendering;
+using GameWorld.Core.Rendering.Geometry;
+using GameWorld.Core.Rendering.RenderItems;
+using GameWorld.Core.SceneNodes;
+using GameWorld.Core.Services;
+using GameWorld.Core.Utility;
+using Microsoft.Xna.Framework;
+
+namespace Editors.KitbasherEditor.Components
+{
+    public sealed class KitbashSelectionOverlayComponent :
+        BaseComponent,
+        IDisposable
+    {
+        private static readonly Vector3 WireColour = new(
+            0.15f,
+            0.15f,
+            0.15f);
+        private static readonly Vector3 SelectedColour = new(
+            1.0f,
+            0.47f,
+            0.0f);
+        private static readonly Vector3 SelectedVertexColour = new(
+            2.0f,
+            0.65f,
+            0.0f);
+        private static readonly Vector3 ActiveColour = Vector3.One;
+
+        private const float WireHalfWidth = 0.75f;
+        private const float SelectedEdgeHalfWidth = 2.0f;
+        private const float ActiveEdgeHalfWidth = 2.25f;
+        private const float WireDepthBias = 0.00002f;
+        private const float SelectedEdgeDepthBias = 0.00004f;
+        private const float ActiveEdgeDepthBias = 0.00006f;
+        private const float SelectedFaceOpacity = 0.24f;
+        private const float ActiveFaceOpacity = 0.34f;
+        private const float SelectedFaceDepthBias = 0.00001f;
+        private const float ActiveFaceDepthBias = 0.00003f;
+        private const int MaxRenderEdges = 50000;
+
+        private readonly SelectionManager _selectionManager;
+        private readonly RenderEngineComponent _renderEngine;
+        private readonly IScopedResourceLibrary _resourceLibrary;
+        private readonly IDeviceResolver _deviceResolver;
+        private readonly HashSet<Rmv2MeshNode> _outlinedMeshes = [];
+
+        private VertexInstanceMesh? _vertexRenderer;
+        private EdgeQuadInstanceMesh? _edgeQuadRenderer;
+        private EdgeQuadRenderItem? _edgeQuadRenderItem;
+        private VertexRenderItem? _vertexRenderItem;
+        private Rmv2MeshNode? _wireframeMesh;
+        private AnimatedWireframeRenderItem? _wireframeRenderItem;
+        private Rmv2MeshNode? _selectedEdgeWireframeMesh;
+        private AnimatedWireframeRenderItem?
+            _selectedEdgeWireframeRenderItem;
+        private Rmv2MeshNode? _activeEdgeWireframeMesh;
+        private AnimatedWireframeRenderItem?
+            _activeEdgeWireframeRenderItem;
+        private AnimatedSelectionRenderItem?
+            _faceSelectionRenderItem;
+        private AnimatedSelectionRenderItem?
+            _activeFaceSelectionRenderItem;
+
+        private (int v0, int v1)[] _cachedEdgeIndices = [];
+        private Rmv2MeshNode? _cachedEdgeMesh;
+        private MeshObject? _cachedEdgeGeometry;
+        private ushort[]? _cachedEdgeIndexArray;
+        private int _cachedEdgeIndexLength = -1;
+        private int _cachedEdgeTopologyVersion = -1;
+        private Matrix _cachedEdgeRenderMatrix;
+        private Vector3[] _cachedVertexWorldPositions = [];
+        private Vector3 _samplePosition0;
+        private Vector3 _samplePosition1;
+        private int _sampleIndex0;
+        private int _sampleIndex1 = 1;
+        private EdgeData[] _edgeDataCache = [];
+        private bool _edgeDataDirty = true;
+        private bool _selectedEdgeDataDirty = true;
+        private bool _activeEdgeDataDirty = true;
+        private bool _vertexWireframeSelectionDirty = true;
+
+        public KitbashSelectionOverlayComponent(
+            SelectionManager selectionManager,
+            RenderEngineComponent renderEngine,
+            IScopedResourceLibrary resourceLibrary,
+            IDeviceResolver deviceResolver)
+        {
+            _selectionManager = selectionManager;
+            _renderEngine = renderEngine;
+            _resourceLibrary = resourceLibrary;
+            _deviceResolver = deviceResolver;
+            _selectionManager.SelectionChanged +=
+                SelectionManager_SelectionChanged;
+        }
+
+        public override void Initialize()
+        {
+            _vertexRenderer = new VertexInstanceMesh(
+                _deviceResolver,
+                _resourceLibrary)
+            {
+                SelectedColour = SelectedVertexColour
+            };
+            _edgeQuadRenderer = new EdgeQuadInstanceMesh(
+                _deviceResolver,
+                _resourceLibrary);
+            _edgeQuadRenderItem = new EdgeQuadRenderItem
+            {
+                EdgeQuadRenderer = _edgeQuadRenderer
+            };
+            _vertexRenderItem = new VertexRenderItem
+            {
+                VertexRenderer = _vertexRenderer
+            };
+
+            base.Initialize();
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            var selectionState = _selectionManager.GetState();
+
+            DrawSelectionOutline(selectionState);
+            DrawFaceSelection(selectionState);
+            DrawVertexSelection(selectionState);
+            DrawEdgeSelection(selectionState);
+
+            base.Draw(gameTime);
+        }
+
+        private void DrawSelectionOutline(
+            ISelectionState selectionState)
+        {
+            ClearSelectionOutline();
+            if (selectionState is ObjectSelectionState objectSelection)
+            {
+                foreach (var selected in objectSelection.CurrentSelection())
+                {
+                    if (selected is Rmv2MeshNode mesh)
+                    {
+                        mesh.SetSelectionOutline(true);
+                        _outlinedMeshes.Add(mesh);
+                    }
+                }
+            }
+            else if (selectionState.Mode is
+                         GeometrySelectionMode.Edge or
+                         GeometrySelectionMode.Face &&
+                     selectionState.GetSingleSelectedObject() is
+                         Rmv2MeshNode editMesh)
+            {
+                editMesh.SetSelectionOutline(true);
+                _outlinedMeshes.Add(editMesh);
+            }
+
+            if (_outlinedMeshes.Count > 0)
+                _renderEngine.RequestSelectionOutline();
+        }
+
+        private void ClearSelectionOutline()
+        {
+            foreach (var mesh in _outlinedMeshes)
+                mesh.SetSelectionOutline(false);
+            _outlinedMeshes.Clear();
+        }
+
+        private void DrawFaceSelection(
+            ISelectionState selectionState)
+        {
+            if (selectionState is not
+                    FaceSelectionState faceSelection ||
+                faceSelection.RenderObject is not
+                    Rmv2MeshNode meshNode)
+            {
+                return;
+            }
+
+            var pose = MeshPoseSnapshot.Capture(meshNode);
+            _renderEngine.AddRenderItem(
+                RenderBuckedId.Selection,
+                GetFaceSelectionRenderItem(
+                    pose,
+                    faceSelection.SelectedFaces));
+            if (faceSelection.ActiveFace is { } activeFace &&
+                faceSelection.SelectedFaces.Contains(activeFace))
+            {
+                _renderEngine.AddRenderItem(
+                    RenderBuckedId.Selection,
+                    GetActiveFaceSelectionRenderItem(
+                        pose,
+                        activeFace));
+            }
+
+            _renderEngine.AddRenderItem(
+                RenderBuckedId.Wireframe,
+                GetWireframeRenderItem(meshNode, pose));
+        }
+
+        private void DrawVertexSelection(
+            ISelectionState selectionState)
+        {
+            if (selectionState is not
+                    VertexSelectionState vertexSelection ||
+                vertexSelection.RenderObject is not
+                    Rmv2MeshNode meshNode ||
+                _vertexRenderItem == null ||
+                _edgeQuadRenderItem == null)
+            {
+                ResetEdgeCache();
+                return;
+            }
+
+            var pose = MeshPoseSnapshot.Capture(meshNode);
+            if (pose.ApplyAnimation)
+            {
+                _edgeDataDirty = true;
+                _renderEngine.AddRenderItem(
+                    RenderBuckedId.Wireframe,
+                    GetWireframeRenderItem(
+                        meshNode,
+                        pose,
+                        vertexSelection.SelectedVertices));
+                _vertexRenderItem.Node = meshNode;
+                _vertexRenderItem.Pose = pose;
+                _vertexRenderItem.WorldPositions = null;
+                _vertexRenderItem.SelectedVertices =
+                    vertexSelection;
+                _renderEngine.AddRenderItem(
+                    RenderBuckedId.Normal,
+                    _vertexRenderItem);
+                return;
+            }
+
+            PrepareDenseVertexOverlay(
+                meshNode,
+                pose,
+                vertexSelection);
+            _renderEngine.AddRenderItem(
+                RenderBuckedId.Normal,
+                _edgeQuadRenderItem);
+            _vertexRenderItem.Node = meshNode;
+            _vertexRenderItem.ModelMatrix = pose.WorldTransform;
+            _vertexRenderItem.Pose = null;
+            _vertexRenderItem.WorldPositions =
+                _cachedVertexWorldPositions;
+            _vertexRenderItem.SelectedVertices =
+                vertexSelection;
+            _renderEngine.AddRenderItem(
+                RenderBuckedId.Normal,
+                _vertexRenderItem);
+        }
+
+        private void PrepareDenseVertexOverlay(
+            Rmv2MeshNode meshNode,
+            MeshPoseSnapshot pose,
+            VertexSelectionState vertexSelection)
+        {
+            var geometry = meshNode.Geometry;
+            var topologyChanged =
+                _cachedEdgeMesh != meshNode ||
+                _cachedEdgeGeometry != geometry ||
+                !ReferenceEquals(
+                    _cachedEdgeIndexArray,
+                    geometry.IndexArray) ||
+                _cachedEdgeIndexLength !=
+                    geometry.IndexArray.Length ||
+                _cachedEdgeTopologyVersion !=
+                    geometry.TopologyVersion;
+
+            if (topologyChanged)
+            {
+                _cachedEdgeMesh = meshNode;
+                _cachedEdgeGeometry = geometry;
+                _cachedEdgeIndexArray = geometry.IndexArray;
+                _cachedEdgeIndexLength =
+                    geometry.IndexArray.Length;
+                _cachedEdgeTopologyVersion =
+                    geometry.TopologyVersion;
+                _cachedEdgeIndices = BuildEdges(
+                    geometry.IndexArray,
+                    MaxRenderEdges);
+                _edgeDataCache =
+                    new EdgeData[_cachedEdgeIndices.Length];
+
+                var vertexCount = geometry.VertexCount();
+                vertexSelection.SelectedVertices.RemoveAll(
+                    index => index < 0 || index >= vertexCount);
+                if (vertexSelection.VertexWeights.Count !=
+                    vertexCount)
+                {
+                    vertexSelection.VertexWeights =
+                        new List<float>(new float[vertexCount]);
+                }
+
+                vertexSelection.UpdateWeights(
+                    _selectionManager.VertexSelectionFalloff);
+                _edgeDataDirty = true;
+            }
+
+            UpdateSampleIndices(
+                vertexSelection,
+                geometry.VertexCount());
+            DetectDenseOverlayChanges(geometry, pose);
+
+            if (!_edgeDataDirty)
+                return;
+
+            var currentVertexCount = geometry.VertexCount();
+            if (_cachedVertexWorldPositions.Length !=
+                currentVertexCount)
+            {
+                _cachedVertexWorldPositions =
+                    new Vector3[currentVertexCount];
+            }
+
+            pose.FillWorldPositions(_cachedVertexWorldPositions);
+            _vertexRenderItem?.MarkDirty();
+            FillEdgeData(
+                _edgeDataCache,
+                _cachedVertexWorldPositions,
+                _cachedEdgeIndices,
+                vertexSelection.VertexWeights);
+            _cachedEdgeRenderMatrix = pose.WorldTransform;
+            _edgeQuadRenderItem!.Edges = _edgeDataCache;
+            _edgeQuadRenderItem.MarkDirty();
+            _edgeDataDirty = false;
+
+            if (currentVertexCount > 0)
+            {
+                _samplePosition0 = geometry.GetVertexById(
+                    _sampleIndex0);
+                _samplePosition1 = geometry.GetVertexById(
+                    _sampleIndex1);
+            }
+        }
+
+        private void UpdateSampleIndices(
+            VertexSelectionState vertexSelection,
+            int vertexCount)
+        {
+            var firstSelectedVertex = -1;
+            var secondSelectedVertex = -1;
+            foreach (var index in
+                     vertexSelection.SelectedVertices)
+            {
+                if (index < 0 || index >= vertexCount)
+                    continue;
+
+                if (firstSelectedVertex == -1)
+                    firstSelectedVertex = index;
+                else
+                {
+                    secondSelectedVertex = index;
+                    break;
+                }
+            }
+
+            if (secondSelectedVertex != -1)
+            {
+                _sampleIndex0 = firstSelectedVertex;
+                _sampleIndex1 = secondSelectedVertex;
+            }
+            else if (firstSelectedVertex != -1)
+            {
+                _sampleIndex0 = firstSelectedVertex;
+                _sampleIndex1 = _sampleIndex0 < vertexCount - 1
+                    ? _sampleIndex0 + 1
+                    : 0;
+            }
+            else
+            {
+                _sampleIndex0 = 0;
+                _sampleIndex1 = vertexCount > 1 ? 1 : 0;
+            }
+        }
+
+        private void DetectDenseOverlayChanges(
+            MeshObject geometry,
+            MeshPoseSnapshot pose)
+        {
+            var vertexCount = geometry.VertexCount();
+            if (!_edgeDataDirty && vertexCount > 0)
+            {
+                var position0 = geometry.GetVertexById(
+                    _sampleIndex0);
+                var position1 = geometry.GetVertexById(
+                    _sampleIndex1);
+                if (position0 != _samplePosition0 ||
+                    position1 != _samplePosition1)
+                {
+                    _edgeDataDirty = true;
+                }
+            }
+
+            if (!_edgeDataDirty &&
+                _cachedEdgeRenderMatrix != pose.WorldTransform)
+            {
+                _edgeDataDirty = true;
+            }
+        }
+
+        private void DrawEdgeSelection(
+            ISelectionState selectionState)
+        {
+            if (selectionState is not
+                    EdgeSelectionState edgeSelection ||
+                edgeSelection.RenderObject is not
+                    Rmv2MeshNode meshNode)
+            {
+                return;
+            }
+
+            var pose = MeshPoseSnapshot.Capture(meshNode);
+            _renderEngine.AddRenderItem(
+                RenderBuckedId.Wireframe,
+                GetWireframeRenderItem(meshNode, pose));
+
+            if (edgeSelection.SelectedEdges.Count > 0)
+            {
+                _renderEngine.AddRenderItem(
+                    RenderBuckedId.Selection,
+                    GetSelectedEdgeWireframeRenderItem(
+                        meshNode,
+                        pose,
+                        edgeSelection.SelectedEdges));
+            }
+
+            if (edgeSelection.ActiveEdge is { } activeEdge &&
+                edgeSelection.SelectedEdges.Contains(activeEdge))
+            {
+                _renderEngine.AddRenderItem(
+                    RenderBuckedId.Selection,
+                    GetActiveEdgeWireframeRenderItem(
+                        meshNode,
+                        pose,
+                        activeEdge));
+            }
+        }
+
+        private AnimatedWireframeRenderItem
+            GetWireframeRenderItem(
+                Rmv2MeshNode meshNode,
+                MeshPoseSnapshot pose,
+                IReadOnlyCollection<int>? selectedVertices = null)
+        {
+            var created = false;
+            if (_wireframeRenderItem == null ||
+                _wireframeMesh != meshNode)
+            {
+                _wireframeRenderItem?.Dispose();
+                _wireframeMesh = meshNode;
+                _wireframeRenderItem =
+                    new AnimatedWireframeRenderItem(
+                        pose,
+                        _resourceLibrary,
+                        new Vector4(WireColour, 1))
+                    {
+                        DepthBias = WireDepthBias,
+                        EdgeHalfWidth = WireHalfWidth
+                    };
+                created = true;
+            }
+            else
+            {
+                _wireframeRenderItem.UpdatePose(pose);
+            }
+
+            if (selectedVertices == null)
+            {
+                _wireframeRenderItem.ClearSelectedVertices();
+            }
+            else if (created ||
+                     _vertexWireframeSelectionDirty)
+            {
+                _wireframeRenderItem.UpdateSelectedVertices(
+                    selectedVertices,
+                    SelectedColour);
+                _vertexWireframeSelectionDirty = false;
+            }
+
+            return _wireframeRenderItem;
+        }
+
+        private AnimatedWireframeRenderItem
+            GetSelectedEdgeWireframeRenderItem(
+                Rmv2MeshNode meshNode,
+                MeshPoseSnapshot pose,
+                IEnumerable<(int v0, int v1)> selectedEdges)
+        {
+            if (_selectedEdgeWireframeRenderItem == null ||
+                _selectedEdgeWireframeMesh != meshNode)
+            {
+                _selectedEdgeWireframeRenderItem?.Dispose();
+                _selectedEdgeWireframeMesh = meshNode;
+                _selectedEdgeWireframeRenderItem =
+                    new AnimatedWireframeRenderItem(
+                        pose,
+                        _resourceLibrary,
+                        new Vector4(SelectedColour, 1),
+                        0)
+                    {
+                        DepthBias = SelectedEdgeDepthBias,
+                        EdgeHalfWidth = SelectedEdgeHalfWidth
+                    };
+                _selectedEdgeDataDirty = true;
+            }
+            else
+            {
+                _selectedEdgeWireframeRenderItem.UpdatePose(pose);
+            }
+
+            if (_selectedEdgeDataDirty)
+            {
+                _selectedEdgeWireframeRenderItem.UpdateEdges(
+                    selectedEdges);
+                _selectedEdgeDataDirty = false;
+            }
+
+            return _selectedEdgeWireframeRenderItem;
+        }
+
+        private AnimatedWireframeRenderItem
+            GetActiveEdgeWireframeRenderItem(
+                Rmv2MeshNode meshNode,
+                MeshPoseSnapshot pose,
+                (int v0, int v1) activeEdge)
+        {
+            if (_activeEdgeWireframeRenderItem == null ||
+                _activeEdgeWireframeMesh != meshNode)
+            {
+                _activeEdgeWireframeRenderItem?.Dispose();
+                _activeEdgeWireframeMesh = meshNode;
+                _activeEdgeWireframeRenderItem =
+                    new AnimatedWireframeRenderItem(
+                        pose,
+                        _resourceLibrary,
+                        new Vector4(ActiveColour, 1),
+                        0)
+                    {
+                        DepthBias = ActiveEdgeDepthBias,
+                        EdgeHalfWidth = ActiveEdgeHalfWidth
+                    };
+                _activeEdgeDataDirty = true;
+            }
+            else
+            {
+                _activeEdgeWireframeRenderItem.UpdatePose(pose);
+            }
+
+            if (_activeEdgeDataDirty)
+            {
+                _activeEdgeWireframeRenderItem.UpdateEdges(
+                    [activeEdge]);
+                _activeEdgeDataDirty = false;
+            }
+
+            return _activeEdgeWireframeRenderItem;
+        }
+
+        private AnimatedSelectionRenderItem
+            GetFaceSelectionRenderItem(
+                MeshPoseSnapshot pose,
+                IReadOnlyList<int> selectedFaces)
+        {
+            if (_faceSelectionRenderItem == null)
+            {
+                _faceSelectionRenderItem =
+                    new AnimatedSelectionRenderItem(
+                        pose,
+                        _resourceLibrary,
+                        new Vector4(
+                            SelectedColour,
+                            SelectedFaceOpacity),
+                        selectedFaces)
+                    {
+                        DepthBias = SelectedFaceDepthBias
+                    };
+            }
+            else
+            {
+                _faceSelectionRenderItem.UpdatePose(pose);
+                _faceSelectionRenderItem.UpdateSelectedFaces(
+                    selectedFaces);
+            }
+
+            return _faceSelectionRenderItem;
+        }
+
+        private AnimatedSelectionRenderItem
+            GetActiveFaceSelectionRenderItem(
+                MeshPoseSnapshot pose,
+                int activeFace)
+        {
+            if (_activeFaceSelectionRenderItem == null)
+            {
+                _activeFaceSelectionRenderItem =
+                    new AnimatedSelectionRenderItem(
+                        pose,
+                        _resourceLibrary,
+                        new Vector4(
+                            ActiveColour,
+                            ActiveFaceOpacity),
+                        [activeFace])
+                    {
+                        DepthBias = ActiveFaceDepthBias
+                    };
+            }
+            else
+            {
+                _activeFaceSelectionRenderItem.UpdatePose(pose);
+                _activeFaceSelectionRenderItem.UpdateSelectedFaces(
+                    [activeFace]);
+            }
+
+            return _activeFaceSelectionRenderItem;
+        }
+
+        private void SelectionManager_SelectionChanged(
+            ISelectionState selectionState)
+        {
+            ClearSelectionOutline();
+            _edgeDataDirty = true;
+            _selectedEdgeDataDirty = true;
+            _activeEdgeDataDirty = true;
+            _vertexWireframeSelectionDirty = true;
+            _vertexRenderItem?.MarkDirty();
+        }
+
+        private void ResetEdgeCache()
+        {
+            _cachedVertexWorldPositions = [];
+            if (_cachedEdgeMesh == null &&
+                _cachedEdgeIndices.Length == 0 &&
+                _edgeDataCache.Length == 0)
+            {
+                _edgeDataDirty = true;
+                return;
+            }
+
+            _cachedEdgeMesh = null;
+            _cachedEdgeGeometry = null;
+            _cachedEdgeIndexArray = null;
+            _cachedEdgeIndexLength = -1;
+            _cachedEdgeTopologyVersion = -1;
+            _cachedEdgeIndices = [];
+            _edgeDataCache = [];
+            _edgeDataDirty = true;
+
+            if (_edgeQuadRenderItem != null)
+            {
+                _edgeQuadRenderItem.Edges = _edgeDataCache;
+                _edgeQuadRenderItem.MarkDirty();
+            }
+        }
+
+        private static (int v0, int v1)[] BuildEdges(
+            ReadOnlySpan<ushort> indices,
+            int maxEdges)
+        {
+            var processedEdges =
+                new HashSet<(int v0, int v1)>();
+            var edges = new List<(int v0, int v1)>(
+                Math.Min(maxEdges, indices.Length));
+            for (var index = 0;
+                 index + 2 < indices.Length;
+                 index += 3)
+            {
+                if (AddEdge(
+                        indices[index],
+                        indices[index + 1],
+                        processedEdges,
+                        edges,
+                        maxEdges) ||
+                    AddEdge(
+                        indices[index + 1],
+                        indices[index + 2],
+                        processedEdges,
+                        edges,
+                        maxEdges) ||
+                    AddEdge(
+                        indices[index],
+                        indices[index + 2],
+                        processedEdges,
+                        edges,
+                        maxEdges))
+                {
+                    break;
+                }
+            }
+
+            return edges.ToArray();
+        }
+
+        private static bool AddEdge(
+            int first,
+            int second,
+            HashSet<(int v0, int v1)> processedEdges,
+            List<(int v0, int v1)> edges,
+            int maxEdges)
+        {
+            if (first == second)
+                return false;
+
+            var edge = first < second
+                ? (first, second)
+                : (second, first);
+            if (processedEdges.Add(edge))
+                edges.Add(edge);
+            return edges.Count == maxEdges;
+        }
+
+        private static void FillEdgeData(
+            Span<EdgeData> destination,
+            IReadOnlyList<Vector3> worldPositions,
+            IReadOnlyList<(int v0, int v1)> edges,
+            IReadOnlyList<float> weights)
+        {
+            for (var index = 0;
+                 index < edges.Count;
+                 index++)
+            {
+                var (first, second) = edges[index];
+                destination[index] = new EdgeData
+                {
+                    P0 = worldPositions[first],
+                    P1 = worldPositions[second],
+                    C0 = Vector3.Lerp(
+                        WireColour,
+                        SelectedColour,
+                        weights[first]),
+                    C1 = Vector3.Lerp(
+                        WireColour,
+                        SelectedColour,
+                        weights[second]),
+                    Width = 0
+                };
+            }
+        }
+
+        public void Dispose()
+        {
+            ClearSelectionOutline();
+            _selectionManager.SelectionChanged -=
+                SelectionManager_SelectionChanged;
+            _vertexRenderer?.Dispose();
+            _vertexRenderer = null;
+            _edgeQuadRenderer?.Dispose();
+            _edgeQuadRenderer = null;
+            _wireframeRenderItem?.Dispose();
+            _wireframeRenderItem = null;
+            _selectedEdgeWireframeRenderItem?.Dispose();
+            _selectedEdgeWireframeRenderItem = null;
+            _activeEdgeWireframeRenderItem?.Dispose();
+            _activeEdgeWireframeRenderItem = null;
+        }
+    }
+}

--- a/Editors/Kitbashing/KitbasherEditor/Components/KitbashSelectionOverlayComponent.cs
+++ b/Editors/Kitbashing/KitbasherEditor/Components/KitbashSelectionOverlayComponent.cs
@@ -80,6 +80,7 @@ namespace Editors.KitbasherEditor.Components
         private int _sampleIndex0;
         private int _sampleIndex1 = 1;
         private EdgeData[] _edgeDataCache = [];
+        private readonly HashSet<int> _cachedPriorityVertices = [];
         private bool _edgeDataDirty = true;
         private bool _selectedEdgeDataDirty = true;
         private bool _activeEdgeDataDirty = true;
@@ -262,6 +263,9 @@ namespace Editors.KitbasherEditor.Components
             VertexSelectionState vertexSelection)
         {
             var geometry = meshNode.Geometry;
+            var vertexCount = geometry.VertexCount();
+            vertexSelection.SelectedVertices.RemoveAll(
+                index => index < 0 || index >= vertexCount);
             var topologyChanged =
                 _cachedEdgeMesh != meshNode ||
                 _cachedEdgeGeometry != geometry ||
@@ -272,8 +276,11 @@ namespace Editors.KitbasherEditor.Components
                     geometry.IndexArray.Length ||
                 _cachedEdgeTopologyVersion !=
                     geometry.TopologyVersion;
+            var selectedVerticesChanged =
+                !_cachedPriorityVertices.SetEquals(
+                    vertexSelection.SelectedVertices);
 
-            if (topologyChanged)
+            if (topologyChanged || selectedVerticesChanged)
             {
                 _cachedEdgeMesh = meshNode;
                 _cachedEdgeGeometry = geometry;
@@ -284,13 +291,14 @@ namespace Editors.KitbasherEditor.Components
                     geometry.TopologyVersion;
                 _cachedEdgeIndices = BuildEdges(
                     geometry.IndexArray,
-                    MaxRenderEdges);
+                    MaxRenderEdges,
+                    vertexSelection.SelectedVertices);
                 _edgeDataCache =
                     new EdgeData[_cachedEdgeIndices.Length];
+                _cachedPriorityVertices.Clear();
+                _cachedPriorityVertices.UnionWith(
+                    vertexSelection.SelectedVertices);
 
-                var vertexCount = geometry.VertexCount();
-                vertexSelection.SelectedVertices.RemoveAll(
-                    index => index < 0 || index >= vertexCount);
                 if (vertexSelection.VertexWeights.Count !=
                     vertexCount)
                 {
@@ -650,6 +658,7 @@ namespace Editors.KitbasherEditor.Components
             _cachedEdgeTopologyVersion = -1;
             _cachedEdgeIndices = [];
             _edgeDataCache = [];
+            _cachedPriorityVertices.Clear();
             _edgeDataDirty = true;
 
             if (_edgeQuadRenderItem != null)
@@ -659,50 +668,101 @@ namespace Editors.KitbasherEditor.Components
             }
         }
 
-        private static (int v0, int v1)[] BuildEdges(
+        internal static (int v0, int v1)[] BuildEdges(
             ReadOnlySpan<ushort> indices,
-            int maxEdges)
+            int maxEdges,
+            IReadOnlyCollection<int>? priorityVertices = null)
         {
             var processedEdges =
                 new HashSet<(int v0, int v1)>();
             var edges = new List<(int v0, int v1)>(
                 Math.Min(maxEdges, indices.Length));
+
+            if (priorityVertices is { Count: > 0 })
+            {
+                var prioritySet = priorityVertices as ISet<int> ??
+                    new HashSet<int>(priorityVertices);
+                for (var index = 0;
+                     index + 2 < indices.Length;
+                     index += 3)
+                {
+                    AddPriorityEdge(
+                        indices[index],
+                        indices[index + 1],
+                        prioritySet,
+                        processedEdges,
+                        edges);
+                    AddPriorityEdge(
+                        indices[index + 1],
+                        indices[index + 2],
+                        prioritySet,
+                        processedEdges,
+                        edges);
+                    AddPriorityEdge(
+                        indices[index],
+                        indices[index + 2],
+                        prioritySet,
+                        processedEdges,
+                        edges);
+                }
+            }
+
+            if (edges.Count >= maxEdges)
+                return edges.ToArray();
+
             for (var index = 0;
                  index + 2 < indices.Length;
                  index += 3)
             {
-                if (AddEdge(
-                        indices[index],
-                        indices[index + 1],
-                        processedEdges,
-                        edges,
-                        maxEdges) ||
-                    AddEdge(
-                        indices[index + 1],
-                        indices[index + 2],
-                        processedEdges,
-                        edges,
-                        maxEdges) ||
-                    AddEdge(
-                        indices[index],
-                        indices[index + 2],
-                        processedEdges,
-                        edges,
-                        maxEdges))
-                {
+                AddEdge(
+                    indices[index],
+                    indices[index + 1],
+                    processedEdges,
+                    edges);
+                if (edges.Count >= maxEdges)
                     break;
-                }
+
+                AddEdge(
+                    indices[index + 1],
+                    indices[index + 2],
+                    processedEdges,
+                    edges);
+                if (edges.Count >= maxEdges)
+                    break;
+
+                AddEdge(
+                    indices[index],
+                    indices[index + 2],
+                    processedEdges,
+                    edges);
+                if (edges.Count >= maxEdges)
+                    break;
             }
 
             return edges.ToArray();
+        }
+
+        private static void AddPriorityEdge(
+            int first,
+            int second,
+            ISet<int> priorityVertices,
+            HashSet<(int v0, int v1)> processedEdges,
+            List<(int v0, int v1)> edges)
+        {
+            if (!priorityVertices.Contains(first) &&
+                !priorityVertices.Contains(second))
+            {
+                return;
+            }
+
+            AddEdge(first, second, processedEdges, edges);
         }
 
         private static bool AddEdge(
             int first,
             int second,
             HashSet<(int v0, int v1)> processedEdges,
-            List<(int v0, int v1)> edges,
-            int maxEdges)
+            List<(int v0, int v1)> edges)
         {
             if (first == second)
                 return false;
@@ -710,9 +770,11 @@ namespace Editors.KitbasherEditor.Components
             var edge = first < second
                 ? (first, second)
                 : (second, first);
-            if (processedEdges.Add(edge))
-                edges.Add(edge);
-            return edges.Count == maxEdges;
+            if (!processedEdges.Add(edge))
+                return false;
+
+            edges.Add(edge);
+            return true;
         }
 
         private static void FillEdgeData(

--- a/Editors/Kitbashing/KitbasherEditor/Core/KitbasherViewModel.cs
+++ b/Editors/Kitbashing/KitbasherEditor/Core/KitbasherViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 ﻿using System.IO;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -67,9 +66,7 @@ namespace Editors.KitbasherEditor.ViewModels
             CommandExecutor commandExecutor,
             IComponentInserter componentInserter,
             View3DCoreComponentSet coreComponents,
-            KitbashSelectionOverlayComponent selectionOverlay,
-            KitbashSelectionInputComponent selectionInput,
-            KitbashModelGizmoComponent modelGizmo,
+            KitbashSceneComponentSet kitbashComponents,
             SkeletonChangedHandler skeletonChangedHandler, 
             SceneNodeEditorViewModel sceneNodeEditorView)
         {
@@ -93,9 +90,7 @@ namespace Editors.KitbasherEditor.ViewModels
             // Ensure all game components are added to the editor
             componentInserter.Execute(
                 coreComponents,
-                selectionOverlay,
-                selectionInput,
-                modelGizmo);
+                kitbashComponents.Components);
         }
 
         public void LoadFile(PackFile fileToLoad)

--- a/Editors/Kitbashing/KitbasherEditor/Core/KitbasherViewModel.cs
+++ b/Editors/Kitbashing/KitbasherEditor/Core/KitbasherViewModel.cs
@@ -4,12 +4,12 @@ using System.IO;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Editors.KitbasherEditor.EventHandlers;
+using Editors.KitbasherEditor.Components;
 using Editors.KitbasherEditor.Services;
 using Editors.KitbasherEditor.UiCommands;
 using Editors.KitbasherEditor.ViewModels.SceneExplorer;
 using Editors.KitbasherEditor.ViewModels.SceneNodeEditor;
 using GameWorld.Core.Components;
-using GameWorld.Core.Components.Selection;
 using GameWorld.Core.Services;
 using KitbasherEditor.ViewModels.MenuBarViews;
 using Serilog;
@@ -66,7 +66,10 @@ namespace Editors.KitbasherEditor.ViewModels
             IUiCommandFactory uiCommandFactory,
             CommandExecutor commandExecutor,
             IComponentInserter componentInserter,
-            SelectionManager selectionManager,
+            View3DCoreComponentSet coreComponents,
+            KitbashSelectionOverlayComponent selectionOverlay,
+            KitbashSelectionInputComponent selectionInput,
+            KitbashModelGizmoComponent modelGizmo,
             SkeletonChangedHandler skeletonChangedHandler, 
             SceneNodeEditorViewModel sceneNodeEditorView)
         {
@@ -81,8 +84,6 @@ namespace Editors.KitbasherEditor.ViewModels
             SceneExplorer = sceneExplorerViewModel;
             MenuBar = menuBarViewModel;
             SceneNodeEditor = sceneNodeEditorView;
-            selectionManager.VertexSelectionEdgeGradientEnabled = true;
-            
             // Events
             eventHub.Register<ScopedFileSavedEvent>(this, OnFileSaved);
             eventHub.Register<CommandStackChangedEvent>(this, OnCommandStackChanged);
@@ -90,7 +91,11 @@ namespace Editors.KitbasherEditor.ViewModels
             skeletonChangedHandler.Subscribe(eventHub);
             
             // Ensure all game components are added to the editor
-            componentInserter.Execute();
+            componentInserter.Execute(
+                coreComponents,
+                selectionOverlay,
+                selectionInput,
+                modelGizmo);
         }
 
         public void LoadFile(PackFile fileToLoad)

--- a/Editors/Kitbashing/KitbasherEditor/Core/KitbasherViewModel.cs
+++ b/Editors/Kitbashing/KitbasherEditor/Core/KitbasherViewModel.cs
@@ -9,6 +9,7 @@ using Editors.KitbasherEditor.UiCommands;
 using Editors.KitbasherEditor.ViewModels.SceneExplorer;
 using Editors.KitbasherEditor.ViewModels.SceneNodeEditor;
 using GameWorld.Core.Components;
+using GameWorld.Core.Components.Selection;
 using GameWorld.Core.Services;
 using KitbasherEditor.ViewModels.MenuBarViews;
 using Serilog;
@@ -65,6 +66,7 @@ namespace Editors.KitbasherEditor.ViewModels
             IUiCommandFactory uiCommandFactory,
             CommandExecutor commandExecutor,
             IComponentInserter componentInserter,
+            SelectionManager selectionManager,
             SkeletonChangedHandler skeletonChangedHandler, 
             SceneNodeEditorViewModel sceneNodeEditorView)
         {
@@ -79,6 +81,7 @@ namespace Editors.KitbasherEditor.ViewModels
             SceneExplorer = sceneExplorerViewModel;
             MenuBar = menuBarViewModel;
             SceneNodeEditor = sceneNodeEditorView;
+            selectionManager.VertexSelectionEdgeGradientEnabled = true;
             
             // Events
             eventHub.Register<ScopedFileSavedEvent>(this, OnFileSaved);

--- a/Editors/Kitbashing/KitbasherEditor/Core/SceneNodeEditor/Nodes/MainEditableNode/MainEditableNodeView.xaml
+++ b/Editors/Kitbashing/KitbasherEditor/Core/SceneNodeEditor/Nodes/MainEditableNode/MainEditableNodeView.xaml
@@ -24,16 +24,15 @@
         <Expander IsExpanded="True" Header="{loc:Loc MainNode.General}" DockPanel.Dock="Top">
             <DockPanel DockPanel.Dock="Top">
                 <DockPanel DockPanel.Dock="Top">
-                    <Label Style="{StaticResource AeForm.Label}" Width ="{StaticResource labelWidth}" Content="{loc:Loc MainNode.Skeleton}"/>
                     <filterdialog:CollapsableFilterControl  VerticalContentAlignment="Center"
                                 SelectedItem="{Binding SkeletonName, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                                 SearchItems="{Binding SkeletonNameList, UpdateSourceTrigger=PropertyChanged}"     
                                 OnSearch="{Binding FilterByFullPath, UpdateSourceTrigger=PropertyChanged}"   
                                 IsManipulationEnabled="False"
-                                LabelTotalWidth="0"   
+                                LabelTotalWidth="150"
                                 DockPanel.Dock="top"
                                 MaxHeight="400"
-                                ShowLabel="false"
+                                ShowLabel="true"
                                 LabelText="{loc:Loc MainNode.Skeleton}"/>
                 </DockPanel>
 

--- a/Editors/Kitbashing/KitbasherEditor/DependencyInjectionContainer.cs
+++ b/Editors/Kitbashing/KitbasherEditor/DependencyInjectionContainer.cs
@@ -52,9 +52,7 @@ namespace Editors.KitbasherEditor
         {
             // Creators
             serviceCollection.AddScoped<KitbashSceneCreator>();
-            serviceCollection.AddScoped<KitbashSelectionOverlayComponent>();
-            serviceCollection.AddScoped<KitbashSelectionInputComponent>();
-            serviceCollection.AddScoped<KitbashModelGizmoComponent>();
+            serviceCollection.AddScoped<KitbashSceneComponentSet>();
             serviceCollection.AddScoped<ViewOnlySelectedService>();
             serviceCollection.AddScoped<FaceEditor>();
             serviceCollection.AddScoped<ObjectEditor>();

--- a/Editors/Kitbashing/KitbasherEditor/DependencyInjectionContainer.cs
+++ b/Editors/Kitbashing/KitbasherEditor/DependencyInjectionContainer.cs
@@ -4,6 +4,7 @@ using Editors.KitbasherEditor.ChildEditors.PinTool;
 using Editors.KitbasherEditor.ChildEditors.PinTool.Commands;
 using Editors.KitbasherEditor.ChildEditors.ReRiggingTool;
 using Editors.KitbasherEditor.ChildEditors.VertexDebugger;
+using Editors.KitbasherEditor.Components;
 using Editors.KitbasherEditor.Commands;
 using Editors.KitbasherEditor.Core;
 using Editors.KitbasherEditor.Core.MenuBarViews;
@@ -23,7 +24,21 @@ using KitbasherEditor.ViewModels.SaveDialog;
 using KitbasherEditor.ViewModels.SceneExplorerNodeViews;
 using KitbasherEditor.Views;
 using Microsoft.Extensions.DependencyInjection;
+using GameWorld.Core.Components.Selection;
+using GameWorld.Core.Commands.Edge;
+using GameWorld.Core.Commands.Face;
+using GameWorld.Core.Commands.Object;
+using GameWorld.Core.Commands.Vertex;
+using GameWorld.Core.Services;
 using GameWorld.Core.Rendering.Geometry;
+using GameWorld.Core.Rendering.Materials.Serialization;
+using GameWorld.Core.Services.SceneSaving;
+using GameWorld.Core.Services.SceneSaving.Geometry;
+using GameWorld.Core.Services.SceneSaving.Geometry.Strategies;
+using GameWorld.Core.Services.SceneSaving.Lod;
+using GameWorld.Core.Services.SceneSaving.Lod.Strategies;
+using GameWorld.Core.Services.SceneSaving.Material;
+using GameWorld.Core.Services.SceneSaving.Material.Strategies;
 using Shared.Core.DependencyInjection;
 using Shared.Core.DevConfig;
 using Shared.Core.ToolCreation;
@@ -37,6 +52,68 @@ namespace Editors.KitbasherEditor
         {
             // Creators
             serviceCollection.AddScoped<KitbashSceneCreator>();
+            serviceCollection.AddScoped<KitbashSelectionOverlayComponent>();
+            serviceCollection.AddScoped<KitbashSelectionInputComponent>();
+            serviceCollection.AddScoped<KitbashModelGizmoComponent>();
+            serviceCollection.AddScoped<ViewOnlySelectedService>();
+            serviceCollection.AddScoped<FaceEditor>();
+            serviceCollection.AddScoped<ObjectEditor>();
+            serviceCollection.AddScoped<GeometrySaveSettings>();
+            serviceCollection.AddScoped<MeshBuilderService>();
+            serviceCollection.AddTransient<WsModelGeneratorService>();
+            serviceCollection.AddTransient<MaterialToWsMaterialFactory>();
+            serviceCollection.AddScoped<SaveService>();
+            serviceCollection.AddScoped<NodeToRmvSaveHelper>();
+            serviceCollection.AddScoped<GeometryStrategyProvider>();
+            serviceCollection.AddScoped<IGeometryStrategy, NoMeshStrategy>();
+            serviceCollection.AddScoped<IGeometryStrategy, Rmw6Strategy>();
+            serviceCollection.AddScoped<IGeometryStrategy, Rmw7Strategy>();
+            serviceCollection.AddScoped<IGeometryStrategy, Rmw8Strategy>();
+            serviceCollection.AddScoped<LodStrategyProvider>();
+            serviceCollection.AddScoped<
+                ILodGenerationStrategy,
+                AssetEditorLodGeneration>();
+            serviceCollection.AddScoped<
+                ILodGenerationStrategy,
+                Lod0ForAllLodGeneration>();
+            serviceCollection.AddScoped<
+                ILodGenerationStrategy,
+                NoLodGeneration>();
+            serviceCollection.AddScoped<MaterialStrategyProvider>();
+            serviceCollection.AddScoped<
+                IMaterialStrategy,
+                Warhammer3WsModelStrategy>();
+            serviceCollection.AddScoped<
+                IMaterialStrategy,
+                Warhammer2WsModelStrategy>();
+            serviceCollection.AddScoped<
+                IMaterialStrategy,
+                PharaohWsModelStrategy>();
+            serviceCollection.AddScoped<
+                IMaterialStrategy,
+                NoWsModelStrategy>();
+
+            serviceCollection.AddTransient<ConvertFacesToVertexSelectionCommand>();
+            serviceCollection.AddTransient<FaceSelectionCommand>();
+            serviceCollection.AddTransient<EdgeSelectionCommand>();
+            serviceCollection.AddTransient<DuplicateFacesCommand>();
+            serviceCollection.AddTransient<VertexSelectionCommand>();
+            serviceCollection.AddTransient<DeleteFaceCommand>();
+            serviceCollection.AddTransient<DeleteObjectsCommand>();
+            serviceCollection.AddTransient<MakeNodeEditableCommand>();
+            serviceCollection.AddTransient<SortSceneNodesCommand>();
+            serviceCollection.AddTransient<
+                GameWorld.Core.Commands.Object.ReduceMeshCommand>();
+            serviceCollection.AddTransient<TransformVertexCommand>();
+            serviceCollection.AddTransient<CombineMeshCommand>();
+            serviceCollection.AddTransient<DivideObjectIntoSubmeshesCommand>();
+            serviceCollection.AddTransient<
+                GameWorld.Core.Commands.Object.DuplicateObjectCommand>();
+            serviceCollection.AddTransient<CreateStaticMeshFromAnimationCommand>();
+            serviceCollection.AddTransient<AddObjectsToGroupCommand>();
+            serviceCollection.AddTransient<UnGroupObjectsCommand>();
+            serviceCollection.AddTransient<GroupObjectsCommand>();
+            serviceCollection.AddTransient<GrowMeshCommand>();
 
             // View models 
             serviceCollection.AddScoped<KitbasherView>();

--- a/Editors/Kitbashing/KitbasherEditor/UiCommands/ScaleGizmoCommand.cs
+++ b/Editors/Kitbashing/KitbasherEditor/UiCommands/ScaleGizmoCommand.cs
@@ -1,5 +1,5 @@
 ﻿using Editors.KitbasherEditor.Core.MenuBarViews;
-using GameWorld.Core.Components.Gizmo;
+using Editors.KitbasherEditor.Components;
 using Shared.Ui.Common.MenuSystem;
 using System.Windows.Input;
 
@@ -11,10 +11,11 @@ namespace Editors.KitbasherEditor.UiCommands
         public ActionEnabledRule EnabledRule => ActionEnabledRule.Always;
         public Hotkey? HotKey { get; } = new Hotkey(Key.Add, ModifierKeys.None);
 
-        private readonly GizmoComponent _gizmoComponent;
+        private readonly KitbashModelGizmoComponent _gizmoComponent;
 
 
-        public ScaleGizmoUpCommand(GizmoComponent gizmoComponent)
+        public ScaleGizmoUpCommand(
+            KitbashModelGizmoComponent gizmoComponent)
         {
             _gizmoComponent = gizmoComponent;
         }
@@ -29,10 +30,11 @@ namespace Editors.KitbasherEditor.UiCommands
         public Hotkey HotKey { get; } =
             new Hotkey(Key.Subtract, ModifierKeys.None);
 
-        private readonly GizmoComponent _gizmoComponent;
+        private readonly KitbashModelGizmoComponent _gizmoComponent;
 
 
-        public ScaleGizmoDownCommand(GizmoComponent gizmoComponent)
+        public ScaleGizmoDownCommand(
+            KitbashModelGizmoComponent gizmoComponent)
         {
             _gizmoComponent = gizmoComponent;
         }

--- a/Editors/Kitbashing/KitbasherEditor/UiCommands/ScaleGizmoCommand.cs
+++ b/Editors/Kitbashing/KitbasherEditor/UiCommands/ScaleGizmoCommand.cs
@@ -11,16 +11,17 @@ namespace Editors.KitbasherEditor.UiCommands
         public ActionEnabledRule EnabledRule => ActionEnabledRule.Always;
         public Hotkey? HotKey { get; } = new Hotkey(Key.Add, ModifierKeys.None);
 
-        private readonly KitbashModelGizmoComponent _gizmoComponent;
+        private readonly KitbashSceneComponentSet _components;
 
 
         public ScaleGizmoUpCommand(
-            KitbashModelGizmoComponent gizmoComponent)
+            KitbashSceneComponentSet components)
         {
-            _gizmoComponent = gizmoComponent;
+            _components = components;
         }
 
-        public void Execute() => _gizmoComponent.ModifyGizmoScale(0.5f);
+        public void Execute() =>
+            _components.ModelGizmo.ModifyGizmoScale(0.5f);
     }
 
     internal class ScaleGizmoDownCommand : ITransientKitbasherUiCommand
@@ -30,15 +31,16 @@ namespace Editors.KitbasherEditor.UiCommands
         public Hotkey HotKey { get; } =
             new Hotkey(Key.Subtract, ModifierKeys.None);
 
-        private readonly KitbashModelGizmoComponent _gizmoComponent;
+        private readonly KitbashSceneComponentSet _components;
 
 
         public ScaleGizmoDownCommand(
-            KitbashModelGizmoComponent gizmoComponent)
+            KitbashSceneComponentSet components)
         {
-            _gizmoComponent = gizmoComponent;
+            _components = components;
         }
 
-        public void Execute() => _gizmoComponent.ModifyGizmoScale(-0.5f);
+        public void Execute() =>
+            _components.ModelGizmo.ModifyGizmoScale(-0.5f);
     }
 }

--- a/Editors/Kitbashing/KitbasherEditor/UiCommands/SelectGizmoModeCommand.cs
+++ b/Editors/Kitbashing/KitbasherEditor/UiCommands/SelectGizmoModeCommand.cs
@@ -7,7 +7,7 @@ using System.Windows.Input;
 
 namespace Editors.KitbasherEditor.UiCommands
 {
-    internal class SelectGizmoModeCommand(KitbashModelGizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
+    internal class SelectGizmoModeCommand(KitbashSceneComponentSet components, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
     {
         public string ToolTip { get; set; } = "Select Gizmo";
         public ActionEnabledRule EnabledRule => ActionEnabledRule.Always;
@@ -15,13 +15,13 @@ namespace Editors.KitbasherEditor.UiCommands
 
         public void Execute()
         {
-            gizmoComponent.ResetScale();
+            components.ModelGizmo.ResetScale();
             transformToolViewModel.SetMode(TransformToolViewModel.TransformMode.None);
-            gizmoComponent.Disable();
+            components.ModelGizmo.Disable();
         }
     }
 
-    internal class MoveGizmoModeCommand(KitbashModelGizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
+    internal class MoveGizmoModeCommand(KitbashSceneComponentSet components, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
     {
         public string ToolTip { get; set; } = "Move Gizmo";
         public ActionEnabledRule EnabledRule => ActionEnabledRule.Always;
@@ -29,13 +29,13 @@ namespace Editors.KitbasherEditor.UiCommands
 
         public void Execute()
         {
-            gizmoComponent.ResetScale();
+            components.ModelGizmo.ResetScale();
             transformToolViewModel.SetMode(TransformToolViewModel.TransformMode.Translate);
-            gizmoComponent.SetGizmoMode(GizmoMode.Translate);
+            components.ModelGizmo.SetGizmoMode(GizmoMode.Translate);
         }
     }
 
-    internal class RotateGizmoModeCommand(KitbashModelGizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
+    internal class RotateGizmoModeCommand(KitbashSceneComponentSet components, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
     {
         public string ToolTip { get; set; } = "Rotate Gizmo";
         public ActionEnabledRule EnabledRule => ActionEnabledRule.Always;
@@ -43,13 +43,13 @@ namespace Editors.KitbasherEditor.UiCommands
 
         public void Execute()
         {
-            gizmoComponent.ResetScale();
+            components.ModelGizmo.ResetScale();
             transformToolViewModel.SetMode(TransformToolViewModel.TransformMode.Rotate);
-            gizmoComponent.SetGizmoMode(GizmoMode.Rotate);
+            components.ModelGizmo.SetGizmoMode(GizmoMode.Rotate);
         }
     }
 
-    internal class ScaleGizmoModeCommand(KitbashModelGizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
+    internal class ScaleGizmoModeCommand(KitbashSceneComponentSet components, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
     {
         public string ToolTip { get; set; } = "Scale Gizmo";
         public ActionEnabledRule EnabledRule => ActionEnabledRule.Always;
@@ -57,9 +57,9 @@ namespace Editors.KitbasherEditor.UiCommands
 
         public void Execute()
         {
-            gizmoComponent.ResetScale();
+            components.ModelGizmo.ResetScale();
             transformToolViewModel.SetMode(TransformToolViewModel.TransformMode.Scale);
-            gizmoComponent.SetGizmoMode(GizmoMode.NonUniformScale);
+            components.ModelGizmo.SetGizmoMode(GizmoMode.NonUniformScale);
         }
     }
 }

--- a/Editors/Kitbashing/KitbasherEditor/UiCommands/SelectGizmoModeCommand.cs
+++ b/Editors/Kitbashing/KitbasherEditor/UiCommands/SelectGizmoModeCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Editors.KitbasherEditor.Core.MenuBarViews;
+using Editors.KitbasherEditor.Components;
 using GameWorld.Core.Components.Gizmo;
 using KitbasherEditor.ViewModels.MenuBarViews;
 using Shared.Ui.Common.MenuSystem;
@@ -6,7 +7,7 @@ using System.Windows.Input;
 
 namespace Editors.KitbasherEditor.UiCommands
 {
-    internal class SelectGizmoModeCommand(GizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
+    internal class SelectGizmoModeCommand(KitbashModelGizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
     {
         public string ToolTip { get; set; } = "Select Gizmo";
         public ActionEnabledRule EnabledRule => ActionEnabledRule.Always;
@@ -20,7 +21,7 @@ namespace Editors.KitbasherEditor.UiCommands
         }
     }
 
-    internal class MoveGizmoModeCommand(GizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
+    internal class MoveGizmoModeCommand(KitbashModelGizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
     {
         public string ToolTip { get; set; } = "Move Gizmo";
         public ActionEnabledRule EnabledRule => ActionEnabledRule.Always;
@@ -34,7 +35,7 @@ namespace Editors.KitbasherEditor.UiCommands
         }
     }
 
-    internal class RotateGizmoModeCommand(GizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
+    internal class RotateGizmoModeCommand(KitbashModelGizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
     {
         public string ToolTip { get; set; } = "Rotate Gizmo";
         public ActionEnabledRule EnabledRule => ActionEnabledRule.Always;
@@ -48,7 +49,7 @@ namespace Editors.KitbasherEditor.UiCommands
         }
     }
 
-    internal class ScaleGizmoModeCommand(GizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
+    internal class ScaleGizmoModeCommand(KitbashModelGizmoComponent gizmoComponent, TransformToolViewModel transformToolViewModel) : ITransientKitbasherUiCommand
     {
         public string ToolTip { get; set; } = "Scale Gizmo";
         public ActionEnabledRule EnabledRule => ActionEnabledRule.Always;

--- a/Editors/Kitbashing/KitbasherEditor/UiCommands/SetSelectionModeCommand.cs
+++ b/Editors/Kitbashing/KitbasherEditor/UiCommands/SetSelectionModeCommand.cs
@@ -15,9 +15,9 @@ namespace Editors.KitbasherEditor.UiCommands
         private readonly KitbashSelectionInputComponent _selectionComponent;
 
         protected SetSelectionModeCommand(
-            KitbashSelectionInputComponent selectionComponent)
+            KitbashSceneComponentSet components)
         {
-            _selectionComponent = selectionComponent;
+            _selectionComponent = components.SelectionInput;
         }
 
         protected void UpdateSelectionMode(GeometrySelectionMode mode)
@@ -46,8 +46,8 @@ namespace Editors.KitbasherEditor.UiCommands
         public override Hotkey? HotKey { get; } = null;
 
         public ObjectSelectionModeCommand(
-            KitbashSelectionInputComponent selectionComponent)
-            : base(selectionComponent)
+            KitbashSceneComponentSet components)
+            : base(components)
         {
         }
 
@@ -60,8 +60,8 @@ namespace Editors.KitbasherEditor.UiCommands
         public override Hotkey? HotKey { get; } = null;
 
         public FaceSelectionModeCommand(
-            KitbashSelectionInputComponent selectionComponent)
-            : base(selectionComponent)
+            KitbashSceneComponentSet components)
+            : base(components)
         {
         }
 
@@ -74,8 +74,8 @@ namespace Editors.KitbasherEditor.UiCommands
         public override Hotkey? HotKey { get; } = null;
 
         public VertexSelectionModeCommand(
-            KitbashSelectionInputComponent selectionComponent)
-            : base(selectionComponent)
+            KitbashSceneComponentSet components)
+            : base(components)
         {
         }
 
@@ -88,8 +88,8 @@ namespace Editors.KitbasherEditor.UiCommands
         public override Hotkey? HotKey { get; } = null;
 
         public EdgeSelectionModeCommand(
-            KitbashSelectionInputComponent selectionComponent)
-            : base(selectionComponent)
+            KitbashSceneComponentSet components)
+            : base(components)
         {
         }
 

--- a/Editors/Kitbashing/KitbasherEditor/UiCommands/SetSelectionModeCommand.cs
+++ b/Editors/Kitbashing/KitbasherEditor/UiCommands/SetSelectionModeCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Editors.KitbasherEditor.Core.MenuBarViews;
+using Editors.KitbasherEditor.Components;
 using GameWorld.Core.Components.Selection;
 using Shared.Ui.Common.MenuSystem;
 using System.Windows.Input;
@@ -11,9 +12,10 @@ namespace Editors.KitbasherEditor.UiCommands
         public ActionEnabledRule EnabledRule => ActionEnabledRule.Always;
         public abstract Hotkey? HotKey { get; }
 
-        private readonly SelectionComponent _selectionComponent;
+        private readonly KitbashSelectionInputComponent _selectionComponent;
 
-        protected SetSelectionModeCommand(SelectionComponent selectionComponent)
+        protected SetSelectionModeCommand(
+            KitbashSelectionInputComponent selectionComponent)
         {
             _selectionComponent = selectionComponent;
         }
@@ -43,7 +45,9 @@ namespace Editors.KitbasherEditor.UiCommands
         public override string ToolTip { get; set; } = "Object mode";
         public override Hotkey? HotKey { get; } = null;
 
-        public ObjectSelectionModeCommand(SelectionComponent selectionComponent) : base(selectionComponent)
+        public ObjectSelectionModeCommand(
+            KitbashSelectionInputComponent selectionComponent)
+            : base(selectionComponent)
         {
         }
 
@@ -55,7 +59,9 @@ namespace Editors.KitbasherEditor.UiCommands
         public override string ToolTip { get; set; } = "Face mode";
         public override Hotkey? HotKey { get; } = null;
 
-        public FaceSelectionModeCommand(SelectionComponent selectionComponent) : base(selectionComponent)
+        public FaceSelectionModeCommand(
+            KitbashSelectionInputComponent selectionComponent)
+            : base(selectionComponent)
         {
         }
 
@@ -67,7 +73,9 @@ namespace Editors.KitbasherEditor.UiCommands
         public override string ToolTip { get; set; } = "Vertex mode";
         public override Hotkey? HotKey { get; } = null;
 
-        public VertexSelectionModeCommand(SelectionComponent selectionComponent) : base(selectionComponent)
+        public VertexSelectionModeCommand(
+            KitbashSelectionInputComponent selectionComponent)
+            : base(selectionComponent)
         {
         }
 
@@ -79,7 +87,9 @@ namespace Editors.KitbasherEditor.UiCommands
         public override string ToolTip { get; set; } = "Edge mode";
         public override Hotkey? HotKey { get; } = null;
 
-        public EdgeSelectionModeCommand(SelectionComponent selectionComponent) : base(selectionComponent)
+        public EdgeSelectionModeCommand(
+            KitbashSelectionInputComponent selectionComponent)
+            : base(selectionComponent)
         {
         }
 

--- a/Editors/Kitbashing/Test.KitbashEditor/Commands/ConstructPrimitiveCommandTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/Commands/ConstructPrimitiveCommandTests.cs
@@ -143,7 +143,7 @@ namespace Test.KitbashEditor.Commands
         {
             var eventHub = Mock.Of<IEventHub>();
             var sceneManager = new SceneManager(null!, null!, eventHub);
-            var selectionManager = new SelectionManager(eventHub, null!, null!, null!);
+            var selectionManager = new SelectionManager(eventHub);
             selectionManager.CreateSelectionSate(GeometrySelectionMode.Object, null!, false);
             var mainNode = sceneManager.RootNode.AddObject(
                 new MainEditableNode(

--- a/Editors/Kitbashing/Test.KitbashEditor/Components/Gizmo/TestGeometryGraphicsContextFactory.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/Components/Gizmo/TestGeometryGraphicsContextFactory.cs
@@ -1,0 +1,86 @@
+using GameWorld.Core.Rendering;
+using GameWorld.Core.Rendering.Geometry;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace GameWorld.Core.Test.TestUtility
+{
+    public sealed record PartialUpload(int StartIndex, int Count);
+
+    public class TestGeometryGraphicsContextFactory :
+        IGeometryGraphicsContextFactory
+    {
+        private readonly List<TestGraphicsCardGeometry>
+            _createdContexts = [];
+
+        public IReadOnlyList<TestGraphicsCardGeometry> CreatedContexts =>
+            _createdContexts;
+
+        public IGraphicsCardGeometry Create()
+        {
+            var context = new TestGraphicsCardGeometry();
+            _createdContexts.Add(context);
+            return context;
+        }
+    }
+
+    public class TestGraphicsCardGeometry : IGraphicsCardGeometry
+    {
+        private readonly List<PartialUpload> _partialUploads = [];
+
+        public IndexBuffer IndexBuffer { get; }
+        public VertexBuffer VertexBuffer { get; }
+        public int IndexBufferRebuildCount { get; private set; }
+        public int VertexBufferRebuildCount { get; private set; }
+        public int PartialVertexBufferRebuildCount { get; private set; }
+        public VertexPositionNormalTextureCustom[] UploadedVertexArray
+        {
+            get;
+            private set;
+        }
+        public IReadOnlyList<PartialUpload> PartialUploads =>
+            _partialUploads;
+
+        public void RebuildIndexBuffer(ushort[] indexList) =>
+            IndexBufferRebuildCount++;
+
+        public void RebuildVertexBuffer(
+            VertexPositionNormalTextureCustom[] vertexArray,
+            VertexDeclaration vertexDeclaration)
+        {
+            VertexBufferRebuildCount++;
+            UploadedVertexArray = vertexArray.ToArray();
+        }
+
+        public void RebuildVertexBufferPartial(
+            VertexPositionNormalTextureCustom[] vertexArray,
+            int startIndex,
+            int count,
+            VertexDeclaration vertexDeclaration,
+            int vertexStride)
+        {
+            PartialVertexBufferRebuildCount++;
+            _partialUploads.Add(new PartialUpload(startIndex, count));
+            UploadedVertexArray ??= vertexArray.ToArray();
+            Array.Copy(
+                vertexArray,
+                startIndex,
+                UploadedVertexArray,
+                startIndex,
+                count);
+        }
+
+        public void ResetRebuildCounts()
+        {
+            IndexBufferRebuildCount = 0;
+            VertexBufferRebuildCount = 0;
+            PartialVertexBufferRebuildCount = 0;
+            _partialUploads.Clear();
+        }
+
+        public IGraphicsCardGeometry Clone() => this;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Editors/Kitbashing/Test.KitbashEditor/Components/Gizmo/TransformGestureTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/Components/Gizmo/TransformGestureTests.cs
@@ -6,6 +6,8 @@ using GameWorld.Core.Commands.Bone;
 using GameWorld.Core.Commands.Object;
 using GameWorld.Core.Commands.Vertex;
 using GameWorld.Core.Components.Gizmo;
+using GizmoComponent =
+    Editors.KitbasherEditor.Components.KitbashModelGizmoComponent;
 using GameWorld.Core.Components.Input;
 using GameWorld.Core.Components.Rendering;
 using GameWorld.Core.Components.Selection;
@@ -352,7 +354,7 @@ namespace Testing.GameWorld.Core.Components.Gizmo
         {
             var eventHub = new TestEventHub();
             var commandExecutor = new CommandExecutor(eventHub);
-            var selectionManager = new SelectionManager(eventHub, null, null, null);
+            var selectionManager = new SelectionManager(eventHub);
             var mouse = new Mock<IMouseComponent>();
             mouse.SetupProperty(component => component.MouseOwner);
             var component = new GizmoComponent(
@@ -1518,7 +1520,7 @@ namespace Testing.GameWorld.Core.Components.Gizmo
         {
             var eventHub = new TestEventHub();
             var commandExecutor = new CommandExecutor(eventHub);
-            var selectionManager = new SelectionManager(eventHub, null, null, null);
+            var selectionManager = new SelectionManager(eventHub);
             var serviceProvider = new Mock<IServiceProvider>();
             serviceProvider
                 .Setup(provider => provider.GetService(typeof(TransformVertexCommand)))
@@ -1593,7 +1595,7 @@ namespace Testing.GameWorld.Core.Components.Gizmo
         {
             var eventHub = new TestEventHub();
             var commandExecutor = new CommandExecutor(eventHub);
-            var selectionManager = new SelectionManager(eventHub, null, null, null);
+            var selectionManager = new SelectionManager(eventHub);
             selectionManager.SetState(selection);
             var serviceProvider = new Mock<IServiceProvider>();
             serviceProvider
@@ -1634,7 +1636,7 @@ namespace Testing.GameWorld.Core.Components.Gizmo
 
             var eventHub = new TestEventHub();
             var commandExecutor = new CommandExecutor(eventHub);
-            var selectionManager = new SelectionManager(eventHub, null, null, null);
+            var selectionManager = new SelectionManager(eventHub);
             selectionManager.SetState(selection);
             var serviceProvider = new Mock<IServiceProvider>();
             serviceProvider
@@ -1709,7 +1711,7 @@ namespace Testing.GameWorld.Core.Components.Gizmo
             var scene = CreateBoneScene(initialFrame, [-1], [0]);
             var eventHub = new TestEventHub();
             var commandExecutor = new CommandExecutor(eventHub);
-            var selectionManager = new SelectionManager(eventHub, null, null, null);
+            var selectionManager = new SelectionManager(eventHub);
             var serviceProvider = new Mock<IServiceProvider>();
             serviceProvider
                 .Setup(provider => provider.GetService(typeof(TransformBoneCommand)))

--- a/Editors/Kitbashing/Test.KitbashEditor/Components/Gizmo/TransformUploadTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/Components/Gizmo/TransformUploadTests.cs
@@ -1,6 +1,8 @@
 using GameWorld.Core.Commands;
 using GameWorld.Core.Commands.Vertex;
 using GameWorld.Core.Components.Gizmo;
+using GizmoComponent =
+    Editors.KitbasherEditor.Components.KitbashModelGizmoComponent;
 using GameWorld.Core.Components.Input;
 using GameWorld.Core.Components.Rendering;
 using GameWorld.Core.Components.Selection;
@@ -740,11 +742,7 @@ public class TransformUploadTests
         ISelectionState selection)
     {
         var eventHub = new TestEventHub();
-        var selectionManager = new SelectionManager(
-            eventHub,
-            null,
-            null,
-            null);
+        var selectionManager = new SelectionManager(eventHub);
         var commandExecutor = new CommandExecutor(eventHub);
         var serviceProvider = new Mock<IServiceProvider>();
         serviceProvider
@@ -848,7 +846,7 @@ public class TransformUploadTests
         params MeshObject[] meshes)
     {
         var eventHub = new Mock<IEventHub>();
-        var selectionManager = new SelectionManager(eventHub.Object, null, null, null);
+        var selectionManager = new SelectionManager(eventHub.Object);
         selectionManager.SetState(selection);
         var commandExecutor = new CommandExecutor(eventHub.Object);
         var serviceProvider = new Mock<IServiceProvider>();

--- a/Editors/Kitbashing/Test.KitbashEditor/LoadAndSave/MenuBarIntegrationTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/LoadAndSave/MenuBarIntegrationTests.cs
@@ -36,6 +36,14 @@ internal class MenuBarIntegrationTests : LoadAndSaveBase
     }
 
     [Test]
+    public void Scene_EnablesVertexSelectionEdgeGradient()
+    {
+        Assert.That(
+            SelectionManager.VertexSelectionEdgeGradientEnabled,
+            Is.True);
+    }
+
+    [Test]
     public void GizmoScaleCommands_MatchTheirNames()
     {
         var commandFactory =

--- a/Editors/Kitbashing/Test.KitbashEditor/LoadAndSave/MenuBarIntegrationTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/LoadAndSave/MenuBarIntegrationTests.cs
@@ -63,7 +63,8 @@ internal class MenuBarIntegrationTests : LoadAndSaveBase
             _runner.GetRequiredServiceInCurrentEditorScope<IUiCommandFactory>();
         var gizmoComponent =
             _runner.GetRequiredServiceInCurrentEditorScope<
-                KitbashModelGizmoComponent>();
+                KitbashSceneComponentSet>()
+            .ModelGizmo;
         var initialScale = gizmoComponent.Gizmo.ScaleModifier;
 
         commandFactory.Create<ScaleGizmoUpCommand>().Execute();

--- a/Editors/Kitbashing/Test.KitbashEditor/LoadAndSave/MenuBarIntegrationTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/LoadAndSave/MenuBarIntegrationTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Windows.Input;
+using Editors.KitbasherEditor.Components;
 using Editors.KitbasherEditor.UiCommands;
 using Editors.KitbasherEditor.ViewModels;
 using GameWorld.Core.Components;
-using GameWorld.Core.Components.Gizmo;
 using GameWorld.Core.Components.Rendering;
 using GameWorld.Core.Components.Selection;
 using GameWorld.Core.SceneNodes;
@@ -36,11 +36,24 @@ internal class MenuBarIntegrationTests : LoadAndSaveBase
     }
 
     [Test]
-    public void Scene_EnablesVertexSelectionEdgeGradient()
+    public void Scene_UsesKitbashExclusiveModelEditingComponents()
     {
-        Assert.That(
-            SelectionManager.VertexSelectionEdgeGradientEnabled,
-            Is.True);
+        var scene = (WpfGameMock)_editor.Scene;
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                scene.Components,
+                Has.Exactly(1)
+                    .TypeOf<KitbashSelectionOverlayComponent>());
+            Assert.That(
+                scene.Components,
+                Has.Exactly(1)
+                    .TypeOf<KitbashSelectionInputComponent>());
+            Assert.That(
+                scene.Components,
+                Has.Exactly(1)
+                    .TypeOf<KitbashModelGizmoComponent>());
+        });
     }
 
     [Test]
@@ -49,7 +62,8 @@ internal class MenuBarIntegrationTests : LoadAndSaveBase
         var commandFactory =
             _runner.GetRequiredServiceInCurrentEditorScope<IUiCommandFactory>();
         var gizmoComponent =
-            _runner.GetRequiredServiceInCurrentEditorScope<GizmoComponent>();
+            _runner.GetRequiredServiceInCurrentEditorScope<
+                KitbashModelGizmoComponent>();
         var initialScale = gizmoComponent.Gizmo.ScaleModifier;
 
         commandFactory.Create<ScaleGizmoUpCommand>().Execute();

--- a/Editors/Kitbashing/Test.KitbashEditor/MenuBarRegressionTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/MenuBarRegressionTests.cs
@@ -84,10 +84,7 @@ public class MenuBarRegressionTests
     {
         var eventHub = new Mock<IEventHub>();
         var selectionManager = new SelectionManager(
-            eventHub.Object,
-            null!,
-            null!,
-            null!);
+            eventHub.Object);
         selectionManager.SetState(new ObjectSelectionState());
         var viewModel = new ProportionalEditingViewModel(
             selectionManager,

--- a/Editors/Kitbashing/Test.KitbashEditor/PhotoStudio/PhotoStudioRenderIntegrationTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/PhotoStudio/PhotoStudioRenderIntegrationTests.cs
@@ -1,7 +1,7 @@
 using System.IO;
 using System.Reflection;
+using Editors.KitbasherEditor.Components;
 using GameWorld.Core.Components.Rendering;
-using GameWorld.Core.Components.Selection;
 using GameWorld.Core.Services;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -23,9 +23,9 @@ internal class PhotoStudioRenderIntegrationTests :
         var renderEngine =
             runner.GetRequiredServiceInCurrentEditorScope<
                 RenderEngineComponent>();
-        var selectionManager =
+        var selectionOverlay =
             runner.GetRequiredServiceInCurrentEditorScope<
-                SelectionManager>();
+                KitbashSelectionOverlayComponent>();
         var game =
             runner.GetRequiredServiceInCurrentEditorScope<
                 IWpfGame>();
@@ -46,7 +46,7 @@ internal class PhotoStudioRenderIntegrationTests :
         {
             var oneTimes = Capture(
                 renderEngine,
-                selectionManager,
+                selectionOverlay,
                 editor.SceneExplorer.SceneManager,
                 device,
                 backTarget,
@@ -55,7 +55,7 @@ internal class PhotoStudioRenderIntegrationTests :
                 1.0f);
             var twoTimes = Capture(
                 renderEngine,
-                selectionManager,
+                selectionOverlay,
                 editor.SceneExplorer.SceneManager,
                 device,
                 backTarget,
@@ -124,9 +124,9 @@ internal class PhotoStudioRenderIntegrationTests :
         var renderEngine =
             runner.GetRequiredServiceInCurrentEditorScope<
                 RenderEngineComponent>();
-        var selectionManager =
+        var selectionOverlay =
             runner.GetRequiredServiceInCurrentEditorScope<
-                SelectionManager>();
+                KitbashSelectionOverlayComponent>();
         var game =
             runner.GetRequiredServiceInCurrentEditorScope<
                 IWpfGame>();
@@ -153,7 +153,7 @@ internal class PhotoStudioRenderIntegrationTests :
             var gameTime = new GameTime();
             renderEngine.Update(gameTime);
             editor.SceneExplorer.SceneManager.Draw(gameTime);
-            selectionManager.Draw(gameTime);
+            selectionOverlay.Draw(gameTime);
             renderEngine.SaveNextFrame(
                 new SaveRenderImageSettings(
                     "SaveFailure",
@@ -179,7 +179,7 @@ internal class PhotoStudioRenderIntegrationTests :
 
     private static string Capture(
         RenderEngineComponent renderEngine,
-        SelectionManager selectionManager,
+        KitbashSelectionOverlayComponent selectionOverlay,
         GameWorld.Core.Components.SceneManager sceneManager,
         GraphicsDevice device,
         RenderTarget2D backTarget,
@@ -190,7 +190,7 @@ internal class PhotoStudioRenderIntegrationTests :
         var gameTime = new GameTime();
         renderEngine.Update(gameTime);
         sceneManager.Draw(gameTime);
-        selectionManager.Draw(gameTime);
+        selectionOverlay.Draw(gameTime);
         renderEngine.SaveNextFrame(
             new SaveRenderImageSettings(
                 name,

--- a/Editors/Kitbashing/Test.KitbashEditor/PhotoStudio/PhotoStudioRenderIntegrationTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/PhotoStudio/PhotoStudioRenderIntegrationTests.cs
@@ -25,7 +25,8 @@ internal class PhotoStudioRenderIntegrationTests :
                 RenderEngineComponent>();
         var selectionOverlay =
             runner.GetRequiredServiceInCurrentEditorScope<
-                KitbashSelectionOverlayComponent>();
+                KitbashSceneComponentSet>()
+            .SelectionOverlay;
         var game =
             runner.GetRequiredServiceInCurrentEditorScope<
                 IWpfGame>();
@@ -126,7 +127,8 @@ internal class PhotoStudioRenderIntegrationTests :
                 RenderEngineComponent>();
         var selectionOverlay =
             runner.GetRequiredServiceInCurrentEditorScope<
-                KitbashSelectionOverlayComponent>();
+                KitbashSceneComponentSet>()
+            .SelectionOverlay;
         var game =
             runner.GetRequiredServiceInCurrentEditorScope<
                 IWpfGame>();

--- a/Editors/Kitbashing/Test.KitbashEditor/PinMeshToVertexCommandTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/PinMeshToVertexCommandTests.cs
@@ -17,7 +17,7 @@ namespace Test.KitbashEditor
         [Test]
         public void Undo_RestoresOriginalGeometryAndPivot()
         {
-            var selectionManager = new SelectionManager(Mock.Of<IEventHub>(), null!, null!, null!);
+            var selectionManager = new SelectionManager(Mock.Of<IEventHub>());
             selectionManager.CreateSelectionSate(GeometrySelectionMode.Object, null!, false);
             var source = CreateMesh(UiVertexFormat.Cinematic);
             source.Geometry.VertexArray[0].BlendIndices = new Vector4(4, 3, 2, 1);

--- a/Editors/Kitbashing/Test.KitbashEditor/PinToolViewModelTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/PinToolViewModelTests.cs
@@ -42,7 +42,7 @@ namespace Test.KitbashEditor
 
         static SelectionManager CreateSelectionManager(ObjectSelectionState state)
         {
-            var selectionManager = new SelectionManager(Mock.Of<IEventHub>(), null!, null!, null!);
+            var selectionManager = new SelectionManager(Mock.Of<IEventHub>());
             selectionManager.SetState(state);
             return selectionManager;
         }

--- a/Editors/Kitbashing/Test.KitbashEditor/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
@@ -31,6 +31,32 @@ namespace GameWorld.Core.Test.Rendering;
 [NonParallelizable]
 public class RenderEngineSelectionMaskOffscreenTests
 {
+    [Test]
+    public void DenseStaticOverlay_PrioritizesSelectedVertexEdgesPastRenderLimit()
+    {
+        const int maxEdges = 50000;
+        const int selectedVertex = 50001;
+        var indices = Enumerable.Range(0, 50004)
+            .Select(index => (ushort)index)
+            .ToArray();
+
+        var edges = KitbashSelectionOverlayComponent.BuildEdges(
+            indices,
+            maxEdges,
+            [selectedVertex]);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                edges,
+                Does.Contain((selectedVertex, selectedVertex + 1)));
+            Assert.That(
+                edges,
+                Does.Contain((selectedVertex, selectedVertex + 2)));
+            Assert.That(edges, Has.Length.EqualTo(maxEdges));
+        });
+    }
+
     [TestCase(false, ViewportShadingMode.Wireframe)]
     [TestCase(true, ViewportShadingMode.Wireframe)]
     [TestCase(false, ViewportShadingMode.MaterialPreview)]

--- a/Editors/Kitbashing/Test.KitbashEditor/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Editors.KitbasherEditor.Components;
 using GameWorld.Core.Animation;
 using GameWorld.Core.Components;
 using GameWorld.Core.Components.Input;
@@ -78,12 +79,14 @@ public class RenderEngineSelectionMaskOffscreenTests
             ShadingMode = shadingMode
         };
         renderEngine.Initialize();
-        var selectionManager = new SelectionManager(
-            eventHub.Object,
-            renderEngine,
-            scopedResources,
-            deviceResolver.Object);
-        selectionManager.Initialize();
+        var selectionManager = new SelectionManager(eventHub.Object);
+        using var selectionOverlay =
+            new KitbashSelectionOverlayComponent(
+                selectionManager,
+                renderEngine,
+                scopedResources,
+                deviceResolver.Object);
+        selectionOverlay.Initialize();
         var mesh = CreateMesh(device, animated);
         var rmvMaterial = new Mock<IRmvMaterial>();
         rmvMaterial.SetupGet(value => value.ModelName)
@@ -131,7 +134,7 @@ public class RenderEngineSelectionMaskOffscreenTests
             node,
             onlyRemove: false);
         node.Render(renderEngine, Matrix.Identity);
-        selectionManager.Draw(new GameTime());
+        selectionOverlay.Draw(new GameTime());
         var objectRequestField = typeof(RenderEngineComponent).GetField(
             "_selectionOutlineRequested",
             BindingFlags.Instance | BindingFlags.NonPublic);
@@ -184,7 +187,7 @@ public class RenderEngineSelectionMaskOffscreenTests
         for (var frame = 0; frame < 2; frame++)
         {
             node.Render(renderEngine, Matrix.Identity);
-            selectionManager.Draw(new GameTime());
+            selectionOverlay.Draw(new GameTime());
             device.SetRenderTargets(
                 new RenderTargetBinding(sceneTarget),
                 new RenderTargetBinding(maskTarget));
@@ -363,12 +366,14 @@ public class RenderEngineSelectionMaskOffscreenTests
                 resources,
                 deviceResolver.Object));
         renderEngine.Initialize();
-        var selectionManager = new SelectionManager(
-            eventHub.Object,
-            renderEngine,
-            scopedResources,
-            deviceResolver.Object);
-        selectionManager.Initialize();
+        var selectionManager = new SelectionManager(eventHub.Object);
+        using var selectionOverlay =
+            new KitbashSelectionOverlayComponent(
+                selectionManager,
+                renderEngine,
+                scopedResources,
+                deviceResolver.Object);
+        selectionOverlay.Initialize();
         var mesh = CreateMesh(device, animated: false);
         var material = new Mock<IRmvMaterial>();
         material.SetupGet(value => value.ModelName).Returns("test");
@@ -387,7 +392,7 @@ public class RenderEngineSelectionMaskOffscreenTests
             [(0, 1), (2, 3)],
             onlyRemove: false);
         selectionManager.SetState(selection);
-        selectionManager.Draw(new GameTime());
+        selectionOverlay.Draw(new GameTime());
         using var renderTarget = new RenderTarget2D(
             device,
             size,
@@ -438,7 +443,7 @@ public class RenderEngineSelectionMaskOffscreenTests
             [0, 3],
             onlyRemove: false);
         selectionManager.SetState(faceSelection);
-        selectionManager.Draw(new GameTime());
+        selectionOverlay.Draw(new GameTime());
 
         Assert.That(
             GetRenderItems(
@@ -496,12 +501,14 @@ public class RenderEngineSelectionMaskOffscreenTests
             ShadingMode = ViewportShadingMode.Wireframe
         };
         renderEngine.Initialize();
-        var selectionManager = new SelectionManager(
-            eventHub.Object,
-            renderEngine,
-            scopedResources,
-            deviceResolver.Object);
-        selectionManager.Initialize();
+        var selectionManager = new SelectionManager(eventHub.Object);
+        using var selectionOverlay =
+            new KitbashSelectionOverlayComponent(
+                selectionManager,
+                renderEngine,
+                scopedResources,
+                deviceResolver.Object);
+        selectionOverlay.Initialize();
         var mesh = CreateMesh(device, animated: false);
         var node = new Rmv2MeshNode(
             mesh,
@@ -549,9 +556,8 @@ public class RenderEngineSelectionMaskOffscreenTests
         }
 
         selectionManager.SetState(selectionState);
-        selectionManager.Update(new GameTime());
         renderEngine.Update(new GameTime());
-        selectionManager.Draw(new GameTime());
+        selectionOverlay.Draw(new GameTime());
         using var renderTarget = new RenderTarget2D(
             device,
             size,
@@ -620,16 +626,14 @@ public class RenderEngineSelectionMaskOffscreenTests
                 ShowGrid = false
             });
         renderEngine.Initialize();
-        var selectionManager = new SelectionManager(
-            eventHub.Object,
-            renderEngine,
-            scopedResources,
-            deviceResolver.Object);
-        Assert.That(
-            selectionManager.VertexSelectionEdgeGradientEnabled,
-            Is.False,
-            "Other editors must retain the existing wireframe behaviour unless they opt in.");
-        selectionManager.Initialize();
+        var selectionManager = new SelectionManager(eventHub.Object);
+        using var selectionOverlay =
+            new KitbashSelectionOverlayComponent(
+                selectionManager,
+                renderEngine,
+                scopedResources,
+                deviceResolver.Object);
+        selectionOverlay.Initialize();
         var mesh = CreateMesh(device, animated: true);
         var node = new Rmv2MeshNode(
             mesh,
@@ -637,7 +641,6 @@ public class RenderEngineSelectionMaskOffscreenTests
             null!,
             CreateAnimationPlayer());
         var selection = new VertexSelectionState(node, 0);
-        selection.ModifySelection([0], onlyRemove: false);
         selection.ActiveVertex = null;
 
         selectionManager.SetState(selection);
@@ -665,7 +668,7 @@ public class RenderEngineSelectionMaskOffscreenTests
         Color[] DrawCurrentWireframe()
         {
             renderEngine.Update(new GameTime());
-            selectionManager.Draw(new GameTime());
+            selectionOverlay.Draw(new GameTime());
             var wireframe = GetRenderItems(
                     renderEngine,
                     RenderBuckedId.Wireframe)
@@ -698,7 +701,7 @@ public class RenderEngineSelectionMaskOffscreenTests
         }
 
         var defaultPixels = DrawCurrentWireframe();
-        selectionManager.VertexSelectionEdgeGradientEnabled = true;
+        selection.ModifySelection([0], onlyRemove: false);
         var pixels = DrawCurrentWireframe();
         selectionManager.SetState(new EdgeSelectionState
         {
@@ -735,11 +738,11 @@ public class RenderEngineSelectionMaskOffscreenTests
             Assert.That(
                 defaultPixels.Count(IsSelectedOrange),
                 Is.EqualTo(0),
-                "Editors that do not opt in must keep the existing uniform wireframe colour.");
+                "Kitbash vertex mode must keep an unselected wireframe neutral.");
             Assert.That(
                 edgeModePixels.Count(IsSelectedOrange),
                 Is.EqualTo(0),
-                "Leaving vertex mode must clear the vertex-edge gradient from the shared wireframe item.");
+                "Leaving vertex mode must clear the Kitbash vertex-edge gradient.");
             Assert.That(
                 connectedHighlight,
                 Is.GreaterThan(0),
@@ -801,12 +804,14 @@ public class RenderEngineSelectionMaskOffscreenTests
             eventHub.Object,
             grid);
         renderEngine.Initialize();
-        var selectionManager = new SelectionManager(
-            eventHub.Object,
-            renderEngine,
-            scopedResources,
-            deviceResolver.Object);
-        selectionManager.Initialize();
+        var selectionManager = new SelectionManager(eventHub.Object);
+        using var selectionOverlay =
+            new KitbashSelectionOverlayComponent(
+                selectionManager,
+                renderEngine,
+                scopedResources,
+                deviceResolver.Object);
+        selectionOverlay.Initialize();
         var mesh = CreateMesh(device, animated);
         var material = new Mock<IRmvMaterial>();
         material.SetupGet(value => value.ModelName).Returns("test");
@@ -829,7 +834,7 @@ public class RenderEngineSelectionMaskOffscreenTests
         renderEngine.AddRenderItem(
             RenderBuckedId.Normal,
             surface);
-        selectionManager.Draw(new GameTime());
+        selectionOverlay.Draw(new GameTime());
         var selectionRenderItems = GetRenderItems(
             renderEngine,
             RenderBuckedId.Selection);
@@ -887,7 +892,7 @@ public class RenderEngineSelectionMaskOffscreenTests
         renderEngine.AddRenderItem(
             RenderBuckedId.Normal,
             surface);
-        selectionManager.Draw(new GameTime());
+        selectionOverlay.Draw(new GameTime());
 
         device.SetRenderTarget(renderTarget);
         device.Clear(

--- a/Editors/Kitbashing/Test.KitbashEditor/TransformToolViewModelTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/TransformToolViewModelTests.cs
@@ -139,7 +139,7 @@ public class TransformToolViewModelTests
     {
         var eventHub = new TestEventHub();
         var commandExecutor = new CommandExecutor(eventHub);
-        var selectionManager = new SelectionManager(eventHub, null, null, null);
+        var selectionManager = new SelectionManager(eventHub);
         var serviceProvider = new Mock<IServiceProvider>();
         serviceProvider
             .Setup(provider => provider.GetService(typeof(TransformBoneCommand)))

--- a/Editors/MetaDataEditor/AnimationMeta/DependencyInjectionContainer.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/DependencyInjectionContainer.cs
@@ -23,7 +23,7 @@ namespace Editors.AnimationMeta
             serviceCollection.AddScoped<EditorHost<SuperViewViewModel>>();
             serviceCollection.AddScoped<SuperViewViewModel>();
             serviceCollection.AddScoped<CombatMetaDataEditSession>();
-            RegisterGameComponent<CombatMetaDataGizmoComponent>(serviceCollection);
+            serviceCollection.AddScoped<CombatMetaDataGizmoComponent>();
 
             serviceCollection.AddScoped<IMetaDataBuilder, MetaDataBuilder>(); // Needs heavy refactorying!
 

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/SuperViewViewModel.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/SuperViewViewModel.cs
@@ -387,6 +387,7 @@ namespace Editors.AnimationMeta.SuperView
             _metaDataFactory = metaDataFactory;
             _combatEditSession = combatEditSession;
             _combatGizmo = combatGizmo;
+            GameWorld!.AddComponent(combatGizmo);
             _combatEditSession.ValueChanged += OnCombatMetaDataValueChanged;
             _combatEditSession.HistoryChanged += OnCombatHistoryChanged;
             Initialize();

--- a/Editors/Shared/Editors.Shared.Core/Common/BaseControl/EditorHost.cs
+++ b/Editors/Shared/Editors.Shared.Core/Common/BaseControl/EditorHost.cs
@@ -41,6 +41,7 @@ namespace Editors.Shared.Core.Common.BaseControl
 
         public EditorHost(IEditorDatabase toolFactory,
             IComponentInserter componentInserter,
+            View3DCoreComponentSet coreComponents,
             AnimationPlayerViewModel animationPlayerViewModel,
             IWpfGame gameWorld,
             FocusSelectableObjectService focusSelectableObjectService,
@@ -60,7 +61,7 @@ namespace Editors.Shared.Core.Common.BaseControl
             OpenFactionColourSettingsCommand = new RelayCommand(
                 factionColourSettingsDialog.ShowDialog);
 
-            componentInserter.Execute();
+            componentInserter.Execute(coreComponents);
 
             eventHub.Register<SceneInitializedEvent>(this, Initialize);
 

--- a/Editors/Shared/Editors.Shared.Core/Common/BaseControl/EditorHostBase.cs
+++ b/Editors/Shared/Editors.Shared.Core/Common/BaseControl/EditorHostBase.cs
@@ -46,7 +46,8 @@ namespace Editors.Shared.Core.Common.BaseControl
             _factionColourSettingsDialog =
                 inputParams.FactionColourSettingsDialog;
 
-            inputParams.ComponentInserter.Execute();
+            inputParams.ComponentInserter.Execute(
+                inputParams.CoreComponents);
         }
 
         [RelayCommand] void ResetCamera() => _focusSelectableObjectService.ResetCamera();

--- a/Editors/Shared/Editors.Shared.Core/Common/BaseControl/IEditorHostParameters.cs
+++ b/Editors/Shared/Editors.Shared.Core/Common/BaseControl/IEditorHostParameters.cs
@@ -10,6 +10,7 @@ namespace Editors.Shared.Core.Common.BaseControl
     {
         AnimationPlayerViewModel AnimationPlayerViewModel { get; }
         IComponentInserter ComponentInserter { get; }
+        View3DCoreComponentSet CoreComponents { get; }
         FocusSelectableObjectService FocusSelectableObjectService { get; }
         IWpfGame GameWorld { get; }
         SceneObjectViewModelBuilder SceneObjectViewModelBuilder { get; }
@@ -21,6 +22,7 @@ namespace Editors.Shared.Core.Common.BaseControl
     {
         public EditorHostParameters(
             IComponentInserter componentInserter,
+            View3DCoreComponentSet coreComponents,
             AnimationPlayerViewModel animationPlayerViewModel,
             IWpfGame gameWorld,
             FocusSelectableObjectService focusSelectableObjectService,
@@ -29,6 +31,7 @@ namespace Editors.Shared.Core.Common.BaseControl
             IFactionColourSettingsDialogService factionColourSettingsDialog)
         {
             ComponentInserter = componentInserter;
+            CoreComponents = coreComponents;
             AnimationPlayerViewModel = animationPlayerViewModel;
             GameWorld = gameWorld;
             FocusSelectableObjectService = focusSelectableObjectService;
@@ -38,6 +41,7 @@ namespace Editors.Shared.Core.Common.BaseControl
         }
 
         public IComponentInserter ComponentInserter { get; }
+        public View3DCoreComponentSet CoreComponents { get; }
         public AnimationPlayerViewModel AnimationPlayerViewModel { get; }
         public IWpfGame GameWorld { get; }
         public FocusSelectableObjectService FocusSelectableObjectService { get; }

--- a/Editors/Shared/Editors.Shared.Core/Editors/TextEditor/TextEditorView.xaml
+++ b/Editors/Shared/Editors.Shared.Core/Editors/TextEditor/TextEditorView.xaml
@@ -39,6 +39,7 @@
             <Separator/>
             <ComboBox Name="highlightingComboBox"   
                       Width="200"
+                      Style="{StaticResource AeInput.ComboBox}"
 				SelectedItem="{Binding SyntaxHighlighting, ElementName=textEditor}"
 				ItemsSource="{Binding Source={x:Static avalonEdit:HighlightingManager.Instance}, Path=HighlightingDefinitions}"
                 SelectionChanged="HighlightingComboBox_SelectionChanged"/>

--- a/Editors/Shared/Editors.Shared.Core/Editors/TextEditor/TextEditorView.xaml.cs
+++ b/Editors/Shared/Editors.Shared.Core/Editors/TextEditor/TextEditorView.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Threading;
 using ICSharpCode.AvalonEdit.Folding;
 using ICSharpCode.AvalonEdit.Highlighting;
 using ICSharpCode.AvalonEdit.Search;
+using Shared.Core.Settings;
 using Shared.Ui.Editors.TextEditor;
 
 namespace CommonControls.Editors.TextEditor
@@ -31,6 +32,7 @@ namespace CommonControls.Editors.TextEditor
         FoldingManager _foldingManager;
         object _foldingStrategy;
         private readonly DispatcherTimer _foldingUpdateTimer;
+        private ThemeAwareHighlightingColorizer? _themeHighlightingColorizer;
 
         internal bool IsFoldingTimerEnabled => _foldingUpdateTimer.IsEnabled;
 
@@ -44,6 +46,7 @@ namespace CommonControls.Editors.TextEditor
 
             SetValue(TextOptions.TextFormattingModeProperty, TextFormattingMode.Display);
             SearchPanel.Install(textEditor);
+            UseThemeAwareSyntaxColorizer(textEditor.SyntaxHighlighting);
 
             _foldingUpdateTimer = new DispatcherTimer
             {
@@ -55,11 +58,23 @@ namespace CommonControls.Editors.TextEditor
         private void TextEditorView_Loaded(object sender, RoutedEventArgs e)
         {
             _foldingUpdateTimer.Start();
+            ThemesController.ThemeChanged -= TextEditorView_ThemeChanged;
+            ThemesController.ThemeChanged += TextEditorView_ThemeChanged;
         }
 
         private void TextEditorView_Unloaded(object sender, RoutedEventArgs e)
         {
             _foldingUpdateTimer.Stop();
+            ThemesController.ThemeChanged -= TextEditorView_ThemeChanged;
+        }
+
+        private void TextEditorView_ThemeChanged(ThemeType theme)
+        {
+            if (Dispatcher.CheckAccess())
+                textEditor.TextArea.TextView.Redraw();
+            else
+                Dispatcher.BeginInvoke(
+                    textEditor.TextArea.TextView.Redraw);
         }
 
         private void FoldingUpdateTimer_Tick(object? sender, EventArgs e)
@@ -75,7 +90,7 @@ namespace CommonControls.Editors.TextEditor
         public void SetSyntaxHighlighting(string type)
         {
             var xmlHightlight = HighlightingManager.Instance.HighlightingDefinitions.FirstOrDefault(x => x.Name == type);
-            highlightingComboBox.SelectedValue = xmlHightlight;
+            highlightingComboBox.SelectedItem = xmlHightlight;
         }
 
         public void ShowLineNumbers(bool value)
@@ -101,6 +116,7 @@ namespace CommonControls.Editors.TextEditor
         void HighlightingComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             textEditor.SyntaxHighlighting = highlightingComboBox.SelectedValue as IHighlightingDefinition;
+            UseThemeAwareSyntaxColorizer(textEditor.SyntaxHighlighting);
             if (textEditor.SyntaxHighlighting == null)
             {
                 _foldingStrategy = null;
@@ -140,6 +156,24 @@ namespace CommonControls.Editors.TextEditor
                     _foldingManager = null;
                 }
             }
+        }
+
+        private void UseThemeAwareSyntaxColorizer(
+            IHighlightingDefinition? definition)
+        {
+            var transformers = textEditor.TextArea.TextView.LineTransformers;
+            foreach (var colorizer in transformers
+                         .OfType<HighlightingColorizer>()
+                         .ToArray())
+            {
+                transformers.Remove(colorizer);
+            }
+
+            _themeHighlightingColorizer = definition == null
+                ? null
+                : new ThemeAwareHighlightingColorizer(definition);
+            if (_themeHighlightingColorizer != null)
+                transformers.Add(_themeHighlightingColorizer);
         }
 
         void UpdateFoldings()

--- a/Editors/Shared/Editors.Shared.Core/Editors/TextEditor/ThemeAwareHighlightingColorizer.cs
+++ b/Editors/Shared/Editors.Shared.Core/Editors/TextEditor/ThemeAwareHighlightingColorizer.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Windows;
+using System.Windows.Media;
+using ICSharpCode.AvalonEdit.Highlighting;
+using ICSharpCode.AvalonEdit.Rendering;
+
+namespace CommonControls.Editors.TextEditor;
+
+internal sealed class ThemeAwareHighlightingColorizer(
+    IHighlightingDefinition definition) : HighlightingColorizer(definition)
+{
+    protected override void ApplyColorToElement(
+        VisualLineElement element,
+        HighlightingColor color)
+    {
+        if (color.Foreground == null)
+        {
+            base.ApplyColorToElement(element, color);
+            return;
+        }
+
+        var themedColor = color.Clone();
+        themedColor.Foreground = new ThemeResourceHighlightingBrush(
+            GetForegroundResourceKey(color.Name));
+        base.ApplyColorToElement(element, themedColor);
+    }
+
+    internal static string GetForegroundResourceKey(string? colorName)
+    {
+        var name = colorName ?? string.Empty;
+        if (ContainsAny(name,
+                "Broken", "Removed", "Error", "Invalid"))
+        {
+            return "AeBrush.Danger";
+        }
+
+        if (ContainsAny(name,
+                "Comment", "DocComment", "Unchanged", "LineBreak"))
+        {
+            return "AeBrush.TextMuted";
+        }
+
+        if (ContainsAny(name,
+                "String", "Char", "Regex", "CData", "Added",
+                "FileName", "Image", "AttributeValue"))
+        {
+            return "AeBrush.Success";
+        }
+
+        if (ContainsAny(name,
+                "Number", "Digit", "Literal", "Constant", "TrueFalse",
+                "Bool", "Null", "Value", "Entity", "Date"))
+        {
+            return "AeBrush.Warning";
+        }
+
+        if (ContainsAny(name,
+                "Punctuation", "Slash", "Assignment", "Operator",
+                "Brace", "Colon"))
+        {
+            return "AeBrush.TextSecondary";
+        }
+
+        return "AeBrush.Accent";
+    }
+
+    private static bool ContainsAny(string value, params string[] terms)
+    {
+        foreach (var term in terms)
+        {
+            if (value.Contains(term, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private sealed class ThemeResourceHighlightingBrush(string resourceKey) :
+        HighlightingBrush
+    {
+        public override Brush GetBrush(ITextRunConstructionContext context) =>
+            Application.Current?.TryFindResource(resourceKey) as Brush ??
+            SystemColors.ControlTextBrush;
+    }
+}

--- a/Editors/SkeletonEditor/Editor.VisualSkeletonEditor/SkeletonEditor/SkeletonEditorViewModel.cs
+++ b/Editors/SkeletonEditor/Editor.VisualSkeletonEditor/SkeletonEditor/SkeletonEditorViewModel.cs
@@ -6,6 +6,7 @@ using Editors.Shared.Core.Common;
 using Editors.Shared.Core.Common.BaseControl;
 using Editors.Shared.Core.Common.ReferenceModel;
 using GameWorld.Core.Animation;
+using GameWorld.Core.Components.Selection;
 using Microsoft.Xna.Framework;
 using Shared.Core.Misc;
 using Shared.Core.PackFiles;
@@ -48,9 +49,13 @@ namespace Editor.VisualSkeletonEditor.SkeletonEditor
             CopyPasteManager copyPasteManager,
             IEditorHostParameters editorHostParameters,
             IStandardDialogs packFileUiProvider,
-            IFileSaveService packFileSaveService)
+            IFileSaveService packFileSaveService,
+            ReferenceObjectSelectionComponent objectSelection,
+            ReferenceObjectSelectionOutlineComponent selectionOutline)
             : base(editorHostParameters)
         {
+            GameWorld!.AddComponent(objectSelection);
+            GameWorld.AddComponent(selectionOutline);
             DisplayName = LocalizationManager.Instance.Get("DisplayName.SkeletonEditor");
 
             _packFileService = pfs;

--- a/GameWorld/ContentProject/Content/Shaders/EdgeQuadShader.fx
+++ b/GameWorld/ContentProject/Content/Shaders/EdgeQuadShader.fx
@@ -18,7 +18,6 @@ float OverlayOpacity = 1.0;
 float BaseOpacity = 1.0;
 float EdgeDepthBias = 0.0;
 float EdgeHalfWidth = 1.0;
-float3 OverlayColor;
 bool CapabilityFlag_ApplyAnimation = false;
 float4x4 Animation_Tranforms[256];
 int Animation_WeightCount = 0;
@@ -40,6 +39,8 @@ struct VSAnimatedInstanceInput
     float3 BindP1 : POSITION2;
     float4 Weights1 : COLOR2;
     float4 BoneIndices1 : BLENDINDICES2;
+    float3 Colour0 : NORMAL5;
+    float3 Colour1 : NORMAL6;
 };
 
 struct VSInput
@@ -171,8 +172,8 @@ VSOutput AnimatedEdgeQuadVS(
         input,
         mul(worldP0, ViewProjection),
         mul(worldP1, ViewProjection),
-        OverlayColor,
-        OverlayColor,
+        instance.Colour0,
+        instance.Colour1,
         EdgeHalfWidth);
 }
 

--- a/GameWorld/View3D/Components/ComponentInserter.cs
+++ b/GameWorld/View3D/Components/ComponentInserter.cs
@@ -6,24 +6,27 @@ namespace GameWorld.Core.Components
 {
     public interface IComponentInserter
     {
-        void Execute();
+        void Execute(
+            View3DCoreComponentSet coreComponents,
+            params IGameComponent[] editorComponents);
     }
 
     public class ComponentInserter : IComponentInserter
     {
         private readonly IWpfGame _wpfGame;
-        private readonly IEnumerable<IGameComponent> _components;
-
-        public ComponentInserter(IWpfGame wpfGame, IEnumerable<IGameComponent> components)
+        public ComponentInserter(IWpfGame wpfGame)
         {
             _wpfGame = wpfGame;
-            _components = components;
         }
 
-        public void Execute()
+        public void Execute(
+            View3DCoreComponentSet coreComponents,
+            params IGameComponent[] editorComponents)
         {
             _wpfGame.ForceEnsureCreated();
-            foreach (var component in _components)
+            foreach (var component in coreComponents.Components)
+                _wpfGame.AddComponent(component);
+            foreach (var component in editorComponents)
                 _wpfGame.AddComponent(component);
         }
     }

--- a/GameWorld/View3D/Components/Gizmo/Gizmo.cs
+++ b/GameWorld/View3D/Components/Gizmo/Gizmo.cs
@@ -111,7 +111,7 @@ namespace GameWorld.Core.Components.Gizmo
 
         /// <summary>
         /// Flag to indicate that modal transform just finished.
-        /// SelectionComponent should check this to prevent selecting other objects.
+        /// The active selection input component should check this to prevent selecting other objects.
         /// </summary>
         public bool JustFinishedModalTransform { get; private set; } = false;
 
@@ -307,7 +307,7 @@ namespace GameWorld.Core.Components.Gizmo
         }
 
         /// <summary>
-        /// Clear the JustFinishedModalTransform flag after SelectionComponent has checked it.
+        /// Clear the JustFinishedModalTransform flag after the active selection input component has checked it.
         /// </summary>
         public void ClearJustFinishedFlag()
         {
@@ -1610,7 +1610,7 @@ namespace GameWorld.Core.Components.Gizmo
         public event TransformationStartDelegate StartEvent;
         public event TransformationStopDelegate StopEvent;
 
-        internal event Action<ModalPreviewReplacement>
+        public event Action<ModalPreviewReplacement>
             ReplacePreviewFromInitialRequested;
 
         private void OnTranslateEvent(ITransformable transformable, Vector3 delta)
@@ -1649,7 +1649,7 @@ namespace GameWorld.Core.Components.Gizmo
 
     #region Gizmo EventHandlers
 
-    internal enum ModalPreviewReplacementKind
+    public enum ModalPreviewReplacementKind
     {
         RestoreOnly,
         Translate,
@@ -1657,7 +1657,7 @@ namespace GameWorld.Core.Components.Gizmo
         Scale
     }
 
-    internal readonly record struct ModalPreviewReplacement
+    public readonly record struct ModalPreviewReplacement
     {
         public ModalPreviewReplacementKind Kind { get; }
         public Vector3 VectorValue { get; }

--- a/GameWorld/View3D/Components/Gizmo/TransformGizmoWrapper.cs
+++ b/GameWorld/View3D/Components/Gizmo/TransformGizmoWrapper.cs
@@ -415,7 +415,7 @@ namespace GameWorld.Core.Components.Gizmo
             }
         }
 
-        internal void ReplaceInitialPreview(
+        public void ReplaceInitialPreview(
             ModalPreviewReplacement replacement)
         {
             if (_activeCommand is TransformBoneCommand transformBoneCommand)
@@ -1403,7 +1403,8 @@ namespace GameWorld.Core.Components.Gizmo
         /// </summary>
         public bool HasBackup => _hasBackup;
 
-        internal bool IsTransformActive => _activeCommand != null || _hasBackup;
+        public bool IsTransformActive =>
+            _activeCommand != null || _hasBackup;
 
         /// <summary>
         /// Set falloff distance for face/edge mode proportional editing
@@ -1546,7 +1547,7 @@ namespace GameWorld.Core.Components.Gizmo
             RememberAnimationDisplayState();
         }
 
-        internal void RefreshDisplayForAnimationState()
+        public void RefreshDisplayForAnimationState()
         {
             if (_effectedMeshNodes == null ||
                 _hasBackup)

--- a/GameWorld/View3D/Components/Navigation/NavigationGizmoComponent.cs
+++ b/GameWorld/View3D/Components/Navigation/NavigationGizmoComponent.cs
@@ -1,4 +1,3 @@
-using GameWorld.Core.Components.Gizmo;
 using GameWorld.Core.Components.Input;
 using GameWorld.Core.Components.Rendering;
 using GameWorld.Core.Services;
@@ -20,7 +19,6 @@ namespace GameWorld.Core.Components.Navigation
         private readonly RenderEngineComponent _renderEngine;
         private readonly IDeviceResolver _deviceResolver;
         private readonly FocusSelectableObjectService _focusService;
-        private readonly GizmoComponent _gizmoComponent;
 
         private NavigationGizmo _navigationGizmo;
         private CameraTransition _cameraTransition;
@@ -40,8 +38,7 @@ namespace GameWorld.Core.Components.Navigation
             IMouseComponent mouse,
             RenderEngineComponent renderEngine,
             IDeviceResolver deviceResolver,
-            FocusSelectableObjectService focusService,
-            GizmoComponent gizmoComponent)
+            FocusSelectableObjectService focusService)
         {
             _camera = camera;
             _keyboard = keyboard;
@@ -49,7 +46,6 @@ namespace GameWorld.Core.Components.Navigation
             _renderEngine = renderEngine;
             _deviceResolver = deviceResolver;
             _focusService = focusService;
-            _gizmoComponent = gizmoComponent;
 
             UpdateOrder = (int)ComponentUpdateOrderEnum.NavigationGizmo;
             DrawOrder = (int)ComponentDrawOrderEnum.NavigationGizmo;
@@ -104,7 +100,8 @@ namespace GameWorld.Core.Components.Navigation
             }
 
             // Handle numpad shortcuts
-            if (_gizmoComponent.Gizmo?.IsInModalTransform != true)
+            if (_mouse.MouseOwner == null ||
+                _mouse.MouseOwner == this)
                 HandleNumpadShortcuts();
 
             // Update gizmo hover state

--- a/GameWorld/View3D/Components/Rendering/ViewportShadingPolicy.cs
+++ b/GameWorld/View3D/Components/Rendering/ViewportShadingPolicy.cs
@@ -2,12 +2,12 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace GameWorld.Core.Components.Rendering;
 
-internal readonly record struct ViewportShadingPipeline(
+public readonly record struct ViewportShadingPipeline(
     RenderingTechnique SurfaceTechnique,
     FillMode FillMode,
     bool EnableBloom);
 
-internal static class ViewportShadingPolicy
+public static class ViewportShadingPolicy
 {
     public static ViewportShadingPipeline Resolve(
         ViewportShadingMode mode)

--- a/GameWorld/View3D/Components/Selection/BoneSelectionHighlightComponent.cs
+++ b/GameWorld/View3D/Components/Selection/BoneSelectionHighlightComponent.cs
@@ -1,0 +1,50 @@
+using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.Rendering;
+using GameWorld.Core.SceneNodes;
+using Microsoft.Xna.Framework;
+
+namespace GameWorld.Core.Components.Selection
+{
+    public sealed class BoneSelectionHighlightComponent : BaseComponent
+    {
+        private readonly SelectionManager _selectionManager;
+        private readonly RenderEngineComponent _renderEngine;
+
+        public BoneSelectionHighlightComponent(
+            SelectionManager selectionManager,
+            RenderEngineComponent renderEngine)
+        {
+            _selectionManager = selectionManager;
+            _renderEngine = renderEngine;
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            if (_selectionManager.GetState() is not
+                    BoneSelectionState selection ||
+                selection.RenderObject is not Rmv2MeshNode mesh ||
+                selection.Skeleton == null)
+            {
+                return;
+            }
+
+            var frame = mesh.AnimationPlayer
+                ?.GetCurrentAnimationFrame();
+            if (frame == null)
+                return;
+
+            foreach (var boneIndex in selection.SelectedBones)
+            {
+                var bone = frame.GetSkeletonAnimatedWorld(
+                    selection.Skeleton,
+                    boneIndex);
+                _renderEngine.AddRenderLines(
+                    LineHelper.CreateCube(
+                        Matrix.CreateScale(0.06f) *
+                        bone *
+                        mesh.RenderMatrix,
+                        Color.Red));
+            }
+        }
+    }
+}

--- a/GameWorld/View3D/Components/Selection/ReferenceObjectSelectionComponent.cs
+++ b/GameWorld/View3D/Components/Selection/ReferenceObjectSelectionComponent.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using GameWorld.Core.Commands;
+using GameWorld.Core.Commands.Object;
+using GameWorld.Core.Components.Input;
+using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.SceneNodes;
+using GameWorld.Core.Services;
+using GameWorld.Core.Utility;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Keys = Microsoft.Xna.Framework.Input.Keys;
+using MouseButton = GameWorld.Core.Components.Input.MouseButton;
+
+namespace GameWorld.Core.Components.Selection
+{
+    public sealed class ReferenceObjectSelectionComponent :
+        BaseComponent,
+        IDisposable
+    {
+        private readonly IMouseComponent _mouse;
+        private readonly IKeyboardComponent _keyboard;
+        private readonly ArcBallCamera _camera;
+        private readonly SelectionManager _selectionManager;
+        private readonly CommandFactory _commandFactory;
+        private readonly SceneManager _sceneManager;
+        private readonly RenderEngineComponent _renderEngine;
+        private readonly IDeviceResolver _deviceResolver;
+        private Texture2D? _selectionTexture;
+        private bool _isMouseDown;
+        private Vector2 _startDrag;
+        private Vector2 _currentMousePosition;
+
+        public ReferenceObjectSelectionComponent(
+            IMouseComponent mouse,
+            IKeyboardComponent keyboard,
+            ArcBallCamera camera,
+            SelectionManager selectionManager,
+            CommandFactory commandFactory,
+            SceneManager sceneManager,
+            RenderEngineComponent renderEngine,
+            IDeviceResolver deviceResolver)
+        {
+            _mouse = mouse;
+            _keyboard = keyboard;
+            _camera = camera;
+            _selectionManager = selectionManager;
+            _commandFactory = commandFactory;
+            _sceneManager = sceneManager;
+            _renderEngine = renderEngine;
+            _deviceResolver = deviceResolver;
+            UpdateOrder = (int)ComponentUpdateOrderEnum.SelectionComponent;
+            DrawOrder = (int)ComponentDrawOrderEnum.SelectionComponent;
+        }
+
+        public override void Initialize()
+        {
+            if (_selectionManager.GetState() == null)
+            {
+                _selectionManager.CreateSelectionSate(
+                    GeometrySelectionMode.Object,
+                    null,
+                    false);
+            }
+
+            _selectionTexture = new Texture2D(
+                _deviceResolver.Device,
+                1,
+                1);
+            _selectionTexture.SetData([Color.White]);
+            base.Initialize();
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            if (_selectionManager.GetState()?.Mode !=
+                GeometrySelectionMode.Object)
+            {
+                return;
+            }
+
+            if (!_mouse.IsMouseOwner(this))
+                return;
+
+            _currentMousePosition = _mouse.Position();
+            if (_mouse.IsMouseButtonPressed(MouseButton.Left))
+            {
+                _startDrag = _currentMousePosition;
+                _isMouseDown = true;
+                if (_mouse.MouseOwner != this)
+                    _mouse.MouseOwner = this;
+            }
+
+            if (_mouse.IsMouseButtonReleased(MouseButton.Left))
+            {
+                var rectangle = CreateSelectionRectangle(
+                    _startDrag,
+                    _currentMousePosition);
+                var isModification =
+                    _keyboard.IsKeyDown(Keys.LeftShift);
+                var removeSelection =
+                    _keyboard.IsKeyDown(Keys.LeftControl);
+                if (_isMouseDown && rectangle.Width * rectangle.Height >= 10)
+                {
+                    SelectFromRectangle(
+                        rectangle,
+                        isModification,
+                        removeSelection);
+                }
+                else
+                {
+                    SelectFromPoint(
+                        _currentMousePosition,
+                        isModification,
+                        removeSelection);
+                }
+
+                _isMouseDown = false;
+            }
+
+            if (!_isMouseDown && _mouse.MouseOwner == this)
+            {
+                _mouse.MouseOwner = null;
+                _mouse.ClearStates();
+            }
+        }
+
+        public void SelectFromIndex(int index)
+        {
+            var selectable = _sceneManager.GetByIndex(index);
+            if (selectable != null)
+                SelectObjects([selectable], false, false);
+        }
+
+        private void SelectFromRectangle(
+            Rectangle screenRectangle,
+            bool isModification,
+            bool removeSelection)
+        {
+            var frustum = _camera.UnprojectRectangle(screenRectangle);
+            SelectObjects(
+                _sceneManager.SelectObjects(frustum),
+                isModification,
+                removeSelection);
+        }
+
+        private void SelectFromPoint(
+            Vector2 mousePosition,
+            bool isModification,
+            bool removeSelection)
+        {
+            var selectedObject = _sceneManager.SelectObject(
+                _camera.CreateCameraRay(mousePosition));
+            SelectObjects(
+                selectedObject == null ? [] : [selectedObject],
+                isModification,
+                removeSelection);
+        }
+
+        private void SelectObjects(
+            IEnumerable<ISelectable> selectedObjects,
+            bool isModification,
+            bool removeSelection)
+        {
+            _commandFactory.Create<ObjectSelectionCommand>()
+                .Configure(command => command.Configure(
+                    new List<ISelectable>(selectedObjects),
+                    isModification,
+                    removeSelection))
+                .BuildAndExecute();
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            if (!_isMouseDown || _selectionTexture == null)
+                return;
+
+            var destination = CreateSelectionRectangle(
+                _startDrag,
+                _currentMousePosition);
+            const int lineWidth = 2;
+            var top = new Rectangle(
+                destination.X,
+                destination.Y,
+                destination.Width,
+                lineWidth);
+            var bottom = new Rectangle(
+                destination.X,
+                destination.Y + destination.Height,
+                destination.Width + lineWidth,
+                lineWidth);
+            var left = new Rectangle(
+                destination.X,
+                destination.Y,
+                lineWidth,
+                destination.Height);
+            var right = new Rectangle(
+                destination.X + destination.Width,
+                destination.Y,
+                lineWidth,
+                destination.Height);
+
+            _renderEngine.CommonSpriteBatch.Begin(
+                SpriteSortMode.Deferred,
+                BlendState.AlphaBlend);
+            _renderEngine.CommonSpriteBatch.Draw(
+                _selectionTexture,
+                destination,
+                Color.White * 0.35f);
+            _renderEngine.CommonSpriteBatch.Draw(
+                _selectionTexture,
+                top,
+                Color.White * 0.75f);
+            _renderEngine.CommonSpriteBatch.Draw(
+                _selectionTexture,
+                bottom,
+                Color.White * 0.75f);
+            _renderEngine.CommonSpriteBatch.Draw(
+                _selectionTexture,
+                left,
+                Color.White * 0.75f);
+            _renderEngine.CommonSpriteBatch.Draw(
+                _selectionTexture,
+                right,
+                Color.White * 0.75f);
+            _renderEngine.CommonSpriteBatch.End();
+        }
+
+        private static Rectangle CreateSelectionRectangle(
+            Vector2 start,
+            Vector2 stop)
+        {
+            return new Rectangle(
+                (int)Math.Min(start.X, stop.X),
+                (int)Math.Min(start.Y, stop.Y),
+                Math.Abs((int)(stop.X - start.X)),
+                Math.Abs((int)(stop.Y - start.Y)));
+        }
+
+        public void Dispose()
+        {
+            _selectionTexture?.Dispose();
+            _selectionTexture = null;
+        }
+    }
+}

--- a/GameWorld/View3D/Components/Selection/ReferenceObjectSelectionOutlineComponent.cs
+++ b/GameWorld/View3D/Components/Selection/ReferenceObjectSelectionOutlineComponent.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.SceneNodes;
+using Microsoft.Xna.Framework;
+
+namespace GameWorld.Core.Components.Selection
+{
+    public sealed class ReferenceObjectSelectionOutlineComponent :
+        BaseComponent,
+        IDisposable
+    {
+        private readonly SelectionManager _selectionManager;
+        private readonly RenderEngineComponent _renderEngine;
+        private readonly HashSet<Rmv2MeshNode> _outlinedMeshes = [];
+
+        public ReferenceObjectSelectionOutlineComponent(
+            SelectionManager selectionManager,
+            RenderEngineComponent renderEngine)
+        {
+            _selectionManager = selectionManager;
+            _renderEngine = renderEngine;
+        }
+
+        public override void Draw(GameTime gameTime)
+        {
+            ClearOutlines();
+            if (_selectionManager.GetState() is not
+                ObjectSelectionState objectSelection)
+            {
+                return;
+            }
+
+            foreach (var item in objectSelection.CurrentSelection())
+            {
+                if (item is not Rmv2MeshNode mesh)
+                    continue;
+
+                mesh.SetSelectionOutline(true);
+                _outlinedMeshes.Add(mesh);
+            }
+
+            if (_outlinedMeshes.Count > 0)
+                _renderEngine.RequestSelectionOutline();
+        }
+
+        private void ClearOutlines()
+        {
+            foreach (var mesh in _outlinedMeshes)
+                mesh.SetSelectionOutline(false);
+            _outlinedMeshes.Clear();
+        }
+
+        public void Dispose() => ClearOutlines();
+    }
+}

--- a/GameWorld/View3D/Components/Selection/SelectionManager.cs
+++ b/GameWorld/View3D/Components/Selection/SelectionManager.cs
@@ -1,14 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using GameWorld.Core.Animation;
-using GameWorld.Core.Components.Rendering;
-using GameWorld.Core.Rendering;
-using GameWorld.Core.Rendering.Geometry;
-using GameWorld.Core.Rendering.RenderItems;
+using System;
 using GameWorld.Core.SceneNodes;
-using GameWorld.Core.Services;
-using GameWorld.Core.Utility;
-using Microsoft.Xna.Framework;
 using Shared.Core.Events;
 
 namespace GameWorld.Core.Components.Selection
@@ -18,856 +9,135 @@ namespace GameWorld.Core.Components.Selection
         public ISelectionState NewState { get; internal set; }
     }
 
-    public class SelectionManager : BaseComponent, IDisposable
+    public sealed class SelectionManager : IDisposable
     {
-        ISelectionState _currentState;
-        public event Action<ISelectionState>? StateChanged;
+        private ISelectionState _currentState;
         private readonly IEventHub _eventHub;
-        private readonly RenderEngineComponent _renderEngine;
-        VertexInstanceMesh _vertexRenderer;
-        EdgeQuadInstanceMesh _edgeQuadRenderer;
-        EdgeQuadRenderItem _edgeQuadRenderItem;
-        VertexRenderItem _vertexRenderItem;
-        float _vertexSelectionFalloff = 0;
-        private readonly IScopedResourceLibrary _resourceLib;
-        private readonly IDeviceResolver _deviceResolverComponent;
-        private readonly MeshPoseRenderCache _poseRenderCache = new();
-        private readonly HashSet<Rmv2MeshNode>
-            _outlinedMeshes = [];
-        private Rmv2MeshNode? _wireframeMesh;
-        private AnimatedWireframeRenderItem?
-            _wireframeRenderItem;
-        private Rmv2MeshNode? _selectedEdgeWireframeMesh;
-        private AnimatedWireframeRenderItem?
-            _selectedEdgeWireframeRenderItem;
-        private Rmv2MeshNode? _activeEdgeWireframeMesh;
-        private AnimatedWireframeRenderItem?
-            _activeEdgeWireframeRenderItem;
-        private AnimatedSelectionRenderItem?
-            _faceSelectionRenderItem;
-        private AnimatedSelectionRenderItem?
-            _activeFaceSelectionRenderItem;
+        private float _vertexSelectionFalloff;
 
-        // Cached edge topology for current mesh (avoids per-frame recomputation)
-        private (int v0, int v1)[] _cachedEdgeIndices = Array.Empty<(int, int)>();
-        private Rmv2MeshNode _cachedEdgeMesh;
-        private MeshObject _cachedEdgeGeometry;
-        private ushort[] _cachedEdgeIndexArray;
-        private int _cachedEdgeIndexLength = -1;
-        private int _cachedEdgeTopologyVersion = -1;
-        private Matrix _cachedEdgeRenderMatrix;
-        private bool _edgeDataDirty = true;
-        private Vector3[] _cachedVertexWorldPositions =
-            Array.Empty<Vector3>();
-        private AnimationPlayer? _cachedVertexAnimationPlayer;
-        private long _cachedVertexAnimationTimeUs =
-            long.MinValue;
+        public event Action<ISelectionState>? StateChanged;
+        public event Action<ISelectionState>? SelectionChanged;
 
-        // Sample vertex positions to detect vertex transformation without full iteration
-        private Vector3 _samplePos0, _samplePos1;
-        private int _sampleIdx0 = 0;
-        private int _sampleIdx1 = 1;
-
-        const int MaxRenderEdges = 50000;
-        private EdgeData[] _edgeDataCache = Array.Empty<EdgeData>();
-        private bool _selectedEdgeDataDirty = true;
-        private bool _activeEdgeDataDirty = true;
-        private bool _vertexWireframeSelectionDirty = true;
-        private bool _vertexSelectionEdgeGradientEnabled;
-
-        public bool VertexSelectionEdgeGradientEnabled
-        {
-            get => _vertexSelectionEdgeGradientEnabled;
-            set
-            {
-                if (_vertexSelectionEdgeGradientEnabled == value)
-                    return;
-
-                _vertexSelectionEdgeGradientEnabled = value;
-                _vertexWireframeSelectionDirty = true;
-            }
-        }
-
-        public SelectionManager(IEventHub eventHub, RenderEngineComponent renderEngine, IScopedResourceLibrary resourceLib, IDeviceResolver deviceResolverComponent)
+        public SelectionManager(IEventHub eventHub)
         {
             _eventHub = eventHub;
-            _renderEngine = renderEngine;
-            _resourceLib = resourceLib;
-            _deviceResolverComponent = deviceResolverComponent;
+            _currentState = new ObjectSelectionState();
+            _currentState.SelectionChanged +=
+                SelectionManager_SelectionChanged;
         }
 
-        public override void Initialize()
+        public ISelectionState CreateSelectionSate(
+            GeometrySelectionMode mode,
+            ISelectable selectedObj,
+            bool sendEvent = true)
         {
-            CreateSelectionSate(GeometrySelectionMode.Object, null, false);
+            _currentState.Clear();
+            _currentState.SelectionChanged -=
+                SelectionManager_SelectionChanged;
 
-            _vertexRenderer = new VertexInstanceMesh(_deviceResolverComponent, _resourceLib);
-            if (VertexSelectionEdgeGradientEnabled)
-                _vertexRenderer.SelectedColour =
-                    EditOverlayStyle.KitbashSelectedColour;
-            _edgeQuadRenderer = new EdgeQuadInstanceMesh(_deviceResolverComponent, _resourceLib);
-            _edgeQuadRenderItem = new EdgeQuadRenderItem { EdgeQuadRenderer = _edgeQuadRenderer };
-            _vertexRenderItem = new VertexRenderItem { VertexRenderer = _vertexRenderer };
-
-            base.Initialize();
-        }
-
-
-        public ISelectionState CreateSelectionSate(GeometrySelectionMode mode, ISelectable selectedObj, bool sendEvent = true)
-        {
-            if (_currentState != null)
+            _currentState = mode switch
             {
-                _currentState.Clear();
-                _currentState.SelectionChanged -= SelectionManager_SelectionChanged;
-            }
+                GeometrySelectionMode.Object =>
+                    new ObjectSelectionState(),
+                GeometrySelectionMode.Face =>
+                    new FaceSelectionState(),
+                GeometrySelectionMode.Edge =>
+                    new EdgeSelectionState(),
+                GeometrySelectionMode.Vertex =>
+                    new VertexSelectionState(
+                        selectedObj,
+                        _vertexSelectionFalloff),
+                GeometrySelectionMode.Bone =>
+                    new BoneSelectionState(selectedObj),
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(mode),
+                    mode,
+                    null)
+            };
 
-            switch (mode)
-            {
-                case GeometrySelectionMode.Object:
-                    _currentState = new ObjectSelectionState();
-                    break;
-
-                case GeometrySelectionMode.Face:
-                    _currentState = new FaceSelectionState();
-                    break;
-
-                case GeometrySelectionMode.Edge:
-                    _currentState = new EdgeSelectionState();
-                    break;
-
-                case GeometrySelectionMode.Vertex:
-                    _currentState = new VertexSelectionState(selectedObj, _vertexSelectionFalloff);
-                    break;
-                case GeometrySelectionMode.Bone:
-                    _currentState = new BoneSelectionState(selectedObj);
-                    break;
-
-                default:
-                    throw new Exception();
-            }
-
-            _currentState.SelectionChanged += SelectionManager_SelectionChanged;
-            SelectionManager_SelectionChanged(_currentState, sendEvent);
+            _currentState.SelectionChanged +=
+                SelectionManager_SelectionChanged;
+            SelectionManager_SelectionChanged(
+                _currentState,
+                sendEvent);
             StateChanged?.Invoke(_currentState);
             return _currentState;
         }
 
         public ISelectionState GetState() => _currentState;
-        public State GetState<State>() where State : class, ISelectionState => _currentState as State;
-        public ISelectionState GetStateCopy() => _currentState.Clone();
-        public State GetStateCopy<State>() where State : class, ISelectionState => GetState<State>().Clone() as State;
+
+        public State GetState<State>()
+            where State : class, ISelectionState =>
+            _currentState as State;
+
+        public ISelectionState GetStateCopy() =>
+            _currentState.Clone();
+
+        public State GetStateCopy<State>()
+            where State : class, ISelectionState =>
+            GetState<State>().Clone() as State;
 
         public void SetState(ISelectionState state)
         {
             if (state == null)
                 return;
 
-            if (_currentState != null)
-                _currentState.SelectionChanged -= SelectionManager_SelectionChanged;
-
+            _currentState.SelectionChanged -=
+                SelectionManager_SelectionChanged;
             _currentState = state;
-            _currentState.SelectionChanged -= SelectionManager_SelectionChanged;
-            _currentState.SelectionChanged += SelectionManager_SelectionChanged;
-            SelectionManager_SelectionChanged(_currentState, true);
+            _currentState.SelectionChanged -=
+                SelectionManager_SelectionChanged;
+            _currentState.SelectionChanged +=
+                SelectionManager_SelectionChanged;
+            SelectionManager_SelectionChanged(
+                _currentState,
+                true);
             StateChanged?.Invoke(_currentState);
         }
 
-        private void SelectionManager_SelectionChanged(ISelectionState state, bool sendEvent)
+        private void SelectionManager_SelectionChanged(
+            ISelectionState state,
+            bool sendEvent)
         {
-            _edgeDataDirty = true;
-            _selectedEdgeDataDirty = true;
-            _activeEdgeDataDirty = true;
-            _vertexWireframeSelectionDirty = true;
-            _poseRenderCache.Clear();
-            ClearObjectOutlines();
-            _vertexRenderItem?.MarkDirty();
-            _eventHub.Publish(new SelectionChangedEvent { NewState = state });
-        }
-
-        public override void Update(GameTime gameTime)
-        {
-            if (_currentState != null)
-                ClearVertexModeOutline(_currentState);
-
-            base.Update(gameTime);
-        }
-
-        public override void Draw(GameTime gameTime)
-        {
-            var selectionState = GetState();
-            ClearVertexModeOutline(selectionState);
-
-            if (selectionState is ObjectSelectionState objectSelectionState)
-            {
-                var outlineRequested = false;
-                foreach (var item in objectSelectionState.CurrentSelection())
+            SelectionChanged?.Invoke(state);
+            _eventHub.Publish(
+                new SelectionChangedEvent
                 {
-                    if (item is Rmv2MeshNode mesh)
-                    {
-                        mesh.SetSelectionOutline(true);
-                        _outlinedMeshes.Add(mesh);
-                        outlineRequested = true;
-                    }
-                }
-
-                if (outlineRequested)
-                    _renderEngine.RequestSelectionOutline();
-            }
-            else if (selectionState.Mode is
-                         GeometrySelectionMode.Edge or
-                         GeometrySelectionMode.Face &&
-                     selectionState.GetSingleSelectedObject() is
-                         Rmv2MeshNode editMesh)
-            {
-                editMesh.SetSelectionOutline(true);
-                _outlinedMeshes.Add(editMesh);
-                _renderEngine.RequestSelectionOutline();
-            }
-
-            if (selectionState is FaceSelectionState selectionFaceState && selectionFaceState.RenderObject is Rmv2MeshNode meshNode)
-            {
-                var pose =
-                    _poseRenderCache.Capture(meshNode);
-                _renderEngine.AddRenderItem(
-                    RenderBuckedId.Selection,
-                    GetFaceSelectionRenderItem(
-                        pose,
-                        selectionFaceState.SelectedFaces));
-                if (selectionFaceState.ActiveFace is { } activeFace &&
-                    selectionFaceState.SelectedFaces.Contains(activeFace))
-                {
-                    _renderEngine.AddRenderItem(
-                        RenderBuckedId.Selection,
-                        GetActiveFaceSelectionRenderItem(
-                            pose,
-                            activeFace));
-                }
-                _renderEngine.AddRenderItem(
-                    RenderBuckedId.Wireframe,
-                    GetWireframeRenderItem(meshNode, pose));
-            }
-
-            if (selectionState is VertexSelectionState selectionVertexState &&
-                selectionVertexState.RenderObject is
-                    Rmv2MeshNode vertexObject)
-            {
-                var pose =
-                    _poseRenderCache.Capture(vertexObject);
-                if (!ShouldRenderDenseEditOverlay(
-                        vertexObject,
-                        pose))
-                {
-                    _edgeDataDirty = true;
-                    _renderEngine.AddRenderItem(
-                        RenderBuckedId.Wireframe,
-                        GetWireframeRenderItem(
-                            vertexObject,
-                            pose,
-                            VertexSelectionEdgeGradientEnabled
-                                ? selectionVertexState.SelectedVertices
-                                : null));
-                    _vertexRenderItem.Node =
-                        vertexObject;
-                    _vertexRenderItem.Pose = pose;
-                    _vertexRenderItem.WorldPositions = null;
-                    _vertexRenderItem.SelectedVertices =
-                        selectionVertexState;
-                    _renderEngine.AddRenderItem(
-                        RenderBuckedId.Normal,
-                        _vertexRenderItem);
-                }
-                else
-                {
-                    var geo = vertexObject.Geometry;
-                    var topologyChanged =
-                        _cachedEdgeMesh != vertexObject ||
-                        _cachedEdgeGeometry != geo ||
-                        !ReferenceEquals(
-                            _cachedEdgeIndexArray,
-                            geo.IndexArray) ||
-                        _cachedEdgeIndexLength !=
-                            geo.IndexArray.Length ||
-                        _cachedEdgeTopologyVersion !=
-                            geo.TopologyVersion;
-
-                    // Index mutation paths replace the array. Rebuild when that identity changes.
-                    if (topologyChanged)
-                    {
-                        _cachedEdgeMesh = vertexObject;
-                        _cachedEdgeGeometry = geo;
-                        _cachedEdgeIndexArray =
-                            geo.IndexArray;
-                        _cachedEdgeIndexLength =
-                            geo.IndexArray.Length;
-                        _cachedEdgeTopologyVersion =
-                            geo.TopologyVersion;
-                        _cachedEdgeIndices =
-                            EdgeIndexCacheBuilder.Build(
-                                geo.IndexArray,
-                                MaxRenderEdges);
-                        _edgeDataCache =
-                            new EdgeData[
-                                _cachedEdgeIndices.Length];
-
-                        var topologyVertexCount =
-                            geo.VertexCount();
-                        selectionVertexState
-                            .SelectedVertices
-                            .RemoveAll(
-                                index =>
-                                    index < 0 ||
-                                    index >=
-                                        topologyVertexCount);
-                        if (selectionVertexState
-                                .VertexWeights.Count !=
-                            topologyVertexCount)
-                        {
-                            selectionVertexState
-                                .VertexWeights =
-                                new List<float>(
-                                    new float[
-                                        topologyVertexCount]);
-                        }
-                        selectionVertexState.UpdateWeights(
-                            _vertexSelectionFalloff);
-
-                        _edgeDataDirty = true;
-                    }
-
-                    var vertexCount = geo.VertexCount();
-                    var firstSelectedVertex = -1;
-                    var secondSelectedVertex = -1;
-                    for (var i = 0;
-                         i < selectionVertexState
-                             .SelectedVertices.Count;
-                         i++)
-                    {
-                        var index = selectionVertexState
-                            .SelectedVertices[i];
-                        if (index < 0 ||
-                            index >= vertexCount)
-                        {
-                            continue;
-                        }
-
-                        if (firstSelectedVertex == -1)
-                        {
-                            firstSelectedVertex = index;
-                        }
-                        else
-                        {
-                            secondSelectedVertex = index;
-                            break;
-                        }
-                    }
-
-                    // Use selected vertices as sample targets (fixes edge freeze during transform).
-                    if (secondSelectedVertex != -1)
-                    {
-                        _sampleIdx0 =
-                            firstSelectedVertex;
-                        _sampleIdx1 =
-                            secondSelectedVertex;
-                    }
-                    else if (firstSelectedVertex != -1)
-                    {
-                        _sampleIdx0 =
-                            firstSelectedVertex;
-                        _sampleIdx1 =
-                            _sampleIdx0 < vertexCount - 1
-                                ? _sampleIdx0 + 1
-                                : 0;
-                    }
-                    else
-                    {
-                        _sampleIdx0 = 0;
-                        _sampleIdx1 =
-                            vertexCount > 1 ? 1 : 0;
-                    }
-
-                    // Detect vertex position changes during transformation by sampling selected vertices.
-                    if (!_edgeDataDirty &&
-                        vertexCount > 0)
-                    {
-                        var p0 = geo.GetVertexById(
-                            _sampleIdx0);
-                        var p1 = geo.GetVertexById(
-                            _sampleIdx1);
-                        if (p0 != _samplePos0 ||
-                            p1 != _samplePos1)
-                        {
-                            _edgeDataDirty = true;
-                        }
-                    }
-
-                    if (!_edgeDataDirty &&
-                        _cachedEdgeRenderMatrix !=
-                            pose.WorldTransform)
-                    {
-                        _edgeDataDirty = true;
-                    }
-
-                    var animationTimeUs =
-                        GetAnimationTimeUs(
-                            vertexObject,
-                            pose);
-                    if (!_edgeDataDirty &&
-                        (!ReferenceEquals(
-                             _cachedVertexAnimationPlayer,
-                             vertexObject
-                                 .AnimationPlayer) ||
-                         _cachedVertexAnimationTimeUs !=
-                             animationTimeUs))
-                    {
-                        _edgeDataDirty = true;
-                    }
-
-                    // Only rebuild animated positions and edge data when the paused pose or geometry changes.
-                    if (_edgeDataDirty)
-                    {
-                        if (_cachedVertexWorldPositions
-                                .Length != vertexCount)
-                        {
-                            _cachedVertexWorldPositions =
-                                new Vector3[vertexCount];
-                        }
-                        pose.FillWorldPositions(
-                            _cachedVertexWorldPositions);
-                        _vertexRenderItem.MarkDirty();
-                        UpdateEdgeQuadData(
-                            pose,
-                            _cachedVertexWorldPositions,
-                            selectionVertexState);
-                        _edgeDataDirty = false;
-                        _cachedVertexAnimationPlayer =
-                            vertexObject.AnimationPlayer;
-                        _cachedVertexAnimationTimeUs =
-                            animationTimeUs;
-
-                        // Cache sample positions for next frame comparison.
-                        if (vertexCount > 0)
-                        {
-                            _samplePos0 =
-                                geo.GetVertexById(
-                                    _sampleIdx0);
-                            _samplePos1 =
-                                geo.GetVertexById(
-                                    _sampleIdx1);
-                        }
-                    }
-
-                    _renderEngine.AddRenderItem(
-                        RenderBuckedId.Normal,
-                        _edgeQuadRenderItem);
-                    _vertexRenderItem.Node =
-                        vertexObject;
-                    _vertexRenderItem.ModelMatrix =
-                        pose.WorldTransform;
-                    _vertexRenderItem.Pose = null;
-                    _vertexRenderItem.WorldPositions =
-                        _cachedVertexWorldPositions;
-                    _vertexRenderItem.SelectedVertices =
-                        selectionVertexState;
-                    _renderEngine.AddRenderItem(
-                        RenderBuckedId.Normal,
-                        _vertexRenderItem);
-                }
-            }
-            else
-            {
-                ResetEdgeCache();
-            }
-
-            if (selectionState is EdgeSelectionState selectionEdgeState && selectionEdgeState.RenderObject is Rmv2MeshNode edgeNode)
-            {
-                var pose =
-                    _poseRenderCache.Capture(edgeNode);
-                _renderEngine.AddRenderItem(
-                    RenderBuckedId.Wireframe,
-                    GetWireframeRenderItem(edgeNode, pose));
-
-                if (selectionEdgeState
-                        .SelectedEdges.Count > 0)
-                {
-                    _renderEngine.AddRenderItem(
-                        RenderBuckedId.Selection,
-                        GetSelectedEdgeWireframeRenderItem(
-                            edgeNode,
-                            pose,
-                            selectionEdgeState
-                                .SelectedEdges));
-                }
-                if (selectionEdgeState.ActiveEdge is { } activeEdge &&
-                    selectionEdgeState.SelectedEdges.Contains(activeEdge))
-                {
-                    _renderEngine.AddRenderItem(
-                        RenderBuckedId.Selection,
-                        GetActiveEdgeWireframeRenderItem(
-                            edgeNode,
-                            pose,
-                            activeEdge));
-                }
-            }
-
-            if (selectionState is BoneSelectionState selectionBoneState && selectionBoneState.RenderObject != null)
-            {
-                var sceneNode = selectionBoneState.RenderObject as Rmv2MeshNode;
-                var animPlayer = sceneNode.AnimationPlayer;
-                var currentFrame = animPlayer.GetCurrentAnimationFrame();
-                var skeleton = selectionBoneState.Skeleton;
-
-                if (currentFrame != null && skeleton != null)
-                {
-                    var bones = selectionBoneState.CurrentSelection();
-                    var renderMatrix = sceneNode.RenderMatrix;
-                    var parentWorld = Matrix.Identity;
-                    foreach (var boneIdx in bones)
-                    {
-                        //var currentBoneMatrix = boneMatrix * Matrix.CreateScale(ScaleMult);
-                        //var parentBoneMatrix = Skeleton.GetAnimatedWorldTranform(parentIndex) * Matrix.CreateScale(ScaleMult);
-                        //_lineRenderer.AddLine(Vector3.Transform(currentBoneMatrix.Translation, parentWorld), Vector3.Transform(parentBoneMatrix.Translation, parentWorld));
-                        var bone = currentFrame.GetSkeletonAnimatedWorld(skeleton, boneIdx);
-                        bone.Decompose(out var _, out var _, out var trans);
-                        _renderEngine.AddRenderLines(LineHelper.CreateCube(Matrix.CreateScale(0.06f) * bone * renderMatrix * parentWorld, Color.Red));
-                    }
-                }
-            }
-
-            base.Draw(gameTime);
-        }
-
-        public void Dispose()
-        {
-            _eventHub?.UnRegister(this);
-
-            if(_currentState != null)
-                _currentState.SelectionChanged -= SelectionManager_SelectionChanged;
-
-            if (_vertexRenderer != null)
-            {
-                _vertexRenderer.Dispose();
-                _vertexRenderer = null;
-            }
-
-            if (_edgeQuadRenderer != null)
-            {
-                _edgeQuadRenderer.Dispose();
-                _edgeQuadRenderer = null;
-            }
-
-            ClearObjectOutlines();
-            _wireframeRenderItem?.Dispose();
-            _wireframeRenderItem = null;
-            _wireframeMesh = null;
-            _selectedEdgeWireframeRenderItem?.Dispose();
-            _selectedEdgeWireframeRenderItem = null;
-            _selectedEdgeWireframeMesh = null;
-            _activeEdgeWireframeRenderItem?.Dispose();
-            _activeEdgeWireframeRenderItem = null;
-            _activeEdgeWireframeMesh = null;
-            _poseRenderCache.Clear();
-            _currentState?.Clear();
-            _currentState = null;
+                    NewState = state
+                });
         }
 
         public void UpdateVertexSelectionFallof(float newValue)
         {
-            var clampedValue = Math.Clamp(newValue, 0, float.MaxValue);
+            var clampedValue = Math.Clamp(
+                newValue,
+                0,
+                float.MaxValue);
             if (_vertexSelectionFalloff == clampedValue)
                 return;
 
             _vertexSelectionFalloff = clampedValue;
-            var vertexSelectionState = GetState<VertexSelectionState>();
-            if (vertexSelectionState != null)
-            {
-                vertexSelectionState.UpdateWeights(_vertexSelectionFalloff);
-                _edgeDataDirty = true;
-            }
-        }
-
-        public float VertexSelectionFalloff => _vertexSelectionFalloff;
-
-        private AnimatedWireframeRenderItem
-            GetWireframeRenderItem(
-                Rmv2MeshNode meshNode,
-                MeshPoseSnapshot pose,
-                IReadOnlyCollection<int>? selectedVertices = null)
-        {
-            var created = false;
-            if (_wireframeRenderItem == null ||
-                _wireframeMesh != meshNode)
-            {
-                _wireframeRenderItem?.Dispose();
-                _wireframeMesh = meshNode;
-                _wireframeRenderItem =
-                    new AnimatedWireframeRenderItem(
-                        pose,
-                        _resourceLib,
-                        new Vector4(
-                            EditOverlayStyle.WireColour,
-                            1))
-                    {
-                        DepthBias =
-                            EditOverlayStyle.WireDepthBias,
-                        EdgeHalfWidth =
-                            EditOverlayStyle.WireHalfWidth
-                    };
-                created = true;
-            }
-            else
-            {
-                _wireframeRenderItem.UpdatePose(pose);
-            }
-
-            if (selectedVertices == null)
-            {
-                _wireframeRenderItem.ClearSelectedVertices();
-            }
-            else if (created || _vertexWireframeSelectionDirty)
-            {
-                _wireframeRenderItem.UpdateSelectedVertices(
-                    selectedVertices);
-                _vertexWireframeSelectionDirty = false;
-            }
-
-            return _wireframeRenderItem;
-        }
-
-        private AnimatedWireframeRenderItem
-            GetSelectedEdgeWireframeRenderItem(
-                Rmv2MeshNode meshNode,
-                MeshPoseSnapshot pose,
-                IEnumerable<(int v0, int v1)> selectedEdges)
-        {
-            if (_selectedEdgeWireframeRenderItem == null ||
-                _selectedEdgeWireframeMesh != meshNode)
-            {
-                _selectedEdgeWireframeRenderItem?.Dispose();
-                _selectedEdgeWireframeMesh = meshNode;
-                _selectedEdgeWireframeRenderItem =
-                    new AnimatedWireframeRenderItem(
-                        pose,
-                        _resourceLib,
-                        new Vector4(
-                            EditOverlayStyle.SelectedColour,
-                            1),
-                        0)
-                    {
-                        DepthBias =
-                            EditOverlayStyle.SelectedEdgeDepthBias,
-                        EdgeHalfWidth =
-                            EditOverlayStyle.SelectedEdgeHalfWidth
-                    };
-                _selectedEdgeDataDirty = true;
-            }
-            else
-            {
-                _selectedEdgeWireframeRenderItem.UpdatePose(
-                    pose);
-            }
-
-            if (_selectedEdgeDataDirty)
-            {
-                _selectedEdgeWireframeRenderItem.UpdateEdges(
-                    selectedEdges);
-                _selectedEdgeDataDirty = false;
-            }
-
-            return _selectedEdgeWireframeRenderItem;
-        }
-
-        private AnimatedWireframeRenderItem
-            GetActiveEdgeWireframeRenderItem(
-                Rmv2MeshNode meshNode,
-                MeshPoseSnapshot pose,
-                (int v0, int v1) activeEdge)
-        {
-            if (_activeEdgeWireframeRenderItem == null ||
-                _activeEdgeWireframeMesh != meshNode)
-            {
-                _activeEdgeWireframeRenderItem?.Dispose();
-                _activeEdgeWireframeMesh = meshNode;
-                _activeEdgeWireframeRenderItem =
-                    new AnimatedWireframeRenderItem(
-                        pose,
-                        _resourceLib,
-                        new Vector4(
-                            EditOverlayStyle.ActiveColour,
-                            1),
-                        0)
-                    {
-                        DepthBias =
-                            EditOverlayStyle.ActiveEdgeDepthBias,
-                        EdgeHalfWidth =
-                            EditOverlayStyle.ActiveEdgeHalfWidth
-                    };
-                _activeEdgeDataDirty = true;
-            }
-            else
-            {
-                _activeEdgeWireframeRenderItem.UpdatePose(pose);
-            }
-
-            if (_activeEdgeDataDirty)
-            {
-                _activeEdgeWireframeRenderItem.UpdateEdges(
-                    [activeEdge]);
-                _activeEdgeDataDirty = false;
-            }
-
-            return _activeEdgeWireframeRenderItem;
-        }
-
-        private AnimatedSelectionRenderItem
-            GetFaceSelectionRenderItem(
-                MeshPoseSnapshot pose,
-                IReadOnlyList<int> selectedFaces)
-        {
-            if (_faceSelectionRenderItem == null)
-            {
-                _faceSelectionRenderItem =
-                    new AnimatedSelectionRenderItem(
-                        pose,
-                        _resourceLib,
-                        new Vector4(
-                            EditOverlayStyle.SelectedColour,
-                            EditOverlayStyle.SelectedFaceOpacity),
-                        selectedFaces)
-                    {
-                        DepthBias =
-                            EditOverlayStyle.SelectedFaceDepthBias
-                    };
-            }
-            else
-            {
-                _faceSelectionRenderItem.UpdatePose(pose);
-                _faceSelectionRenderItem
-                    .UpdateSelectedFaces(selectedFaces);
-            }
-
-            return _faceSelectionRenderItem;
-        }
-
-        private AnimatedSelectionRenderItem
-            GetActiveFaceSelectionRenderItem(
-                MeshPoseSnapshot pose,
-                int activeFace)
-        {
-            if (_activeFaceSelectionRenderItem == null)
-            {
-                _activeFaceSelectionRenderItem =
-                    new AnimatedSelectionRenderItem(
-                        pose,
-                        _resourceLib,
-                        new Vector4(
-                            EditOverlayStyle.ActiveColour,
-                            EditOverlayStyle.ActiveFaceOpacity),
-                        [activeFace])
-                    {
-                        DepthBias =
-                            EditOverlayStyle.ActiveFaceDepthBias
-                    };
-            }
-            else
-            {
-                _activeFaceSelectionRenderItem.UpdatePose(pose);
-                _activeFaceSelectionRenderItem
-                    .UpdateSelectedFaces([activeFace]);
-            }
-
-            return _activeFaceSelectionRenderItem;
-        }
-
-        private void ClearObjectOutlines()
-        {
-            foreach (var mesh in _outlinedMeshes)
-                mesh.SetSelectionOutline(false);
-            _outlinedMeshes.Clear();
-        }
-
-        private void ClearVertexModeOutline(
-            ISelectionState selectionState)
-        {
-            if (selectionState.Mode !=
-                    GeometrySelectionMode.Vertex ||
-                selectionState.GetSingleSelectedObject() is not
-                    Rmv2MeshNode editMesh)
-            {
+            var vertexSelectionState =
+                GetState<VertexSelectionState>();
+            if (vertexSelectionState == null)
                 return;
-            }
 
-            editMesh.SetSelectionOutline(false);
-            _outlinedMeshes.Remove(editMesh);
+            vertexSelectionState.UpdateWeights(
+                _vertexSelectionFalloff);
+            SelectionManager_SelectionChanged(
+                vertexSelectionState,
+                true);
         }
 
-        internal static bool ShouldRenderDenseEditOverlay(
-            Rmv2MeshNode meshNode,
-            MeshPoseSnapshot pose)
+        public float VertexSelectionFalloff =>
+            _vertexSelectionFalloff;
+
+        public void Dispose()
         {
-            return !pose.ApplyAnimation;
-        }
-
-        private static long GetAnimationTimeUs(
-            Rmv2MeshNode meshNode,
-            MeshPoseSnapshot pose)
-        {
-            return pose.ApplyAnimation
-                ? meshNode.AnimationPlayer
-                    ?.GetTimeUs() ?? -1
-                : -1;
-        }
-
-        /// <summary>
-        /// Update edge quad instance data (positions + colors).
-        /// Only called when dirty (mesh changed or selection changed).
-        /// </summary>
-        private void UpdateEdgeQuadData(
-            MeshPoseSnapshot pose,
-            IReadOnlyList<Vector3> worldPositions,
-            VertexSelectionState selectionState)
-        {
-            EdgeOverlayDataBuilder.Fill(
-                _edgeDataCache,
-                worldPositions,
-                _cachedEdgeIndices,
-                selectionState.VertexWeights);
-            _cachedEdgeRenderMatrix =
-                pose.WorldTransform;
-
-            _edgeQuadRenderItem.Edges = _edgeDataCache;
-            _edgeQuadRenderItem.MarkDirty();
-        }
-
-        private void ResetEdgeCache()
-        {
-            _cachedVertexWorldPositions =
-                Array.Empty<Vector3>();
-            _cachedVertexAnimationPlayer = null;
-            _cachedVertexAnimationTimeUs =
-                long.MinValue;
-
-            if (_cachedEdgeMesh == null &&
-                _cachedEdgeIndices.Length == 0 &&
-                _edgeDataCache.Length == 0)
-            {
-                _edgeDataDirty = true;
-                return;
-            }
-
-            _cachedEdgeMesh = null;
-            _cachedEdgeGeometry = null;
-            _cachedEdgeIndexArray = null;
-            _cachedEdgeIndexLength = -1;
-            _cachedEdgeTopologyVersion = -1;
-            _cachedEdgeIndices = Array.Empty<(int, int)>();
-            _edgeDataCache = Array.Empty<EdgeData>();
-            _edgeDataDirty = true;
-
-            if (_edgeQuadRenderItem != null)
-            {
-                _edgeQuadRenderItem.Edges = _edgeDataCache;
-                _edgeQuadRenderItem.MarkDirty();
-            }
+            _eventHub.UnRegister(this);
+            _currentState.SelectionChanged -=
+                SelectionManager_SelectionChanged;
+            _currentState.Clear();
         }
     }
 }
-

--- a/GameWorld/View3D/Components/Selection/SelectionManager.cs
+++ b/GameWorld/View3D/Components/Selection/SelectionManager.cs
@@ -72,6 +72,21 @@ namespace GameWorld.Core.Components.Selection
         private EdgeData[] _edgeDataCache = Array.Empty<EdgeData>();
         private bool _selectedEdgeDataDirty = true;
         private bool _activeEdgeDataDirty = true;
+        private bool _vertexWireframeSelectionDirty = true;
+        private bool _vertexSelectionEdgeGradientEnabled;
+
+        public bool VertexSelectionEdgeGradientEnabled
+        {
+            get => _vertexSelectionEdgeGradientEnabled;
+            set
+            {
+                if (_vertexSelectionEdgeGradientEnabled == value)
+                    return;
+
+                _vertexSelectionEdgeGradientEnabled = value;
+                _vertexWireframeSelectionDirty = true;
+            }
+        }
 
         public SelectionManager(IEventHub eventHub, RenderEngineComponent renderEngine, IScopedResourceLibrary resourceLib, IDeviceResolver deviceResolverComponent)
         {
@@ -86,6 +101,9 @@ namespace GameWorld.Core.Components.Selection
             CreateSelectionSate(GeometrySelectionMode.Object, null, false);
 
             _vertexRenderer = new VertexInstanceMesh(_deviceResolverComponent, _resourceLib);
+            if (VertexSelectionEdgeGradientEnabled)
+                _vertexRenderer.SelectedColour =
+                    EditOverlayStyle.KitbashSelectedColour;
             _edgeQuadRenderer = new EdgeQuadInstanceMesh(_deviceResolverComponent, _resourceLib);
             _edgeQuadRenderItem = new EdgeQuadRenderItem { EdgeQuadRenderer = _edgeQuadRenderer };
             _vertexRenderItem = new VertexRenderItem { VertexRenderer = _vertexRenderer };
@@ -158,6 +176,7 @@ namespace GameWorld.Core.Components.Selection
             _edgeDataDirty = true;
             _selectedEdgeDataDirty = true;
             _activeEdgeDataDirty = true;
+            _vertexWireframeSelectionDirty = true;
             _poseRenderCache.Clear();
             ClearObjectOutlines();
             _vertexRenderItem?.MarkDirty();
@@ -242,7 +261,10 @@ namespace GameWorld.Core.Components.Selection
                         RenderBuckedId.Wireframe,
                         GetWireframeRenderItem(
                             vertexObject,
-                            pose));
+                            pose,
+                            VertexSelectionEdgeGradientEnabled
+                                ? selectionVertexState.SelectedVertices
+                                : null));
                     _vertexRenderItem.Node =
                         vertexObject;
                     _vertexRenderItem.Pose = pose;
@@ -567,8 +589,10 @@ namespace GameWorld.Core.Components.Selection
         private AnimatedWireframeRenderItem
             GetWireframeRenderItem(
                 Rmv2MeshNode meshNode,
-                MeshPoseSnapshot pose)
+                MeshPoseSnapshot pose,
+                IReadOnlyCollection<int>? selectedVertices = null)
         {
+            var created = false;
             if (_wireframeRenderItem == null ||
                 _wireframeMesh != meshNode)
             {
@@ -587,10 +611,22 @@ namespace GameWorld.Core.Components.Selection
                         EdgeHalfWidth =
                             EditOverlayStyle.WireHalfWidth
                     };
+                created = true;
             }
             else
             {
                 _wireframeRenderItem.UpdatePose(pose);
+            }
+
+            if (selectedVertices == null)
+            {
+                _wireframeRenderItem.ClearSelectedVertices();
+            }
+            else if (created || _vertexWireframeSelectionDirty)
+            {
+                _wireframeRenderItem.UpdateSelectedVertices(
+                    selectedVertices);
+                _vertexWireframeSelectionDirty = false;
             }
 
             return _wireframeRenderItem;

--- a/GameWorld/View3D/Components/View3DCoreComponentSet.cs
+++ b/GameWorld/View3D/Components/View3DCoreComponentSet.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using GameWorld.Core.Components.Input;
+using GameWorld.Core.Components.Navigation;
+using GameWorld.Core.Components.Rendering;
+using Microsoft.Xna.Framework;
+
+namespace GameWorld.Core.Components
+{
+    public sealed class View3DCoreComponentSet
+    {
+        public View3DCoreComponentSet(
+            CommandStackRenderer commandStackRenderer,
+            IKeyboardComponent keyboard,
+            IMouseComponent mouse,
+            FpsComponent fps,
+            ArcBallCamera camera,
+            NavigationGizmoComponent navigationGizmo,
+            SceneManager sceneManager,
+            RenderEngineComponent renderEngine,
+            GridComponent grid,
+            AnimationsContainerComponent animations,
+            LightControllerComponent lightController)
+        {
+            Components =
+            [
+                commandStackRenderer,
+                keyboard,
+                mouse,
+                fps,
+                camera,
+                navigationGizmo,
+                sceneManager,
+                renderEngine,
+                grid,
+                animations,
+                lightController,
+            ];
+        }
+
+        public IReadOnlyList<IGameComponent> Components { get; }
+    }
+}

--- a/GameWorld/View3D/DependencyInjectionContainer.cs
+++ b/GameWorld/View3D/DependencyInjectionContainer.cs
@@ -1,28 +1,16 @@
 ﻿using GameWorld.Core.Commands;
 using GameWorld.Core.Commands.Bone;
 using GameWorld.Core.Commands.Bone.Clipboard;
-using GameWorld.Core.Commands.Edge;
-using GameWorld.Core.Commands.Face;
 using GameWorld.Core.Commands.Object;
-using GameWorld.Core.Commands.Vertex;
 using GameWorld.Core.Components;
-using GameWorld.Core.Components.Gizmo;
 using GameWorld.Core.Components.Input;
 using GameWorld.Core.Components.Navigation;
 using GameWorld.Core.Components.Rendering;
 using GameWorld.Core.Components.Selection;
 using GameWorld.Core.Rendering.Geometry;
 using GameWorld.Core.Rendering.Materials;
-using GameWorld.Core.Rendering.Materials.Serialization;
 using GameWorld.Core.SceneNodes;
 using GameWorld.Core.Services;
-using GameWorld.Core.Services.SceneSaving;
-using GameWorld.Core.Services.SceneSaving.Geometry;
-using GameWorld.Core.Services.SceneSaving.Geometry.Strategies;
-using GameWorld.Core.Services.SceneSaving.Lod;
-using GameWorld.Core.Services.SceneSaving.Lod.Strategies;
-using GameWorld.Core.Services.SceneSaving.Material;
-using GameWorld.Core.Services.SceneSaving.Material.Strategies;
 using GameWorld.Core.Utility;
 using GameWorld.Core.WpfWindow;
 using GameWorld.Core.WpfWindow.FactionColourSettings;
@@ -44,7 +32,6 @@ namespace GameWorld.Core
             serviceCollection.AddSingleton<ResourceLibrary>();
 
             // Settings
-            serviceCollection.AddScoped<GeometrySaveSettings>();
             serviceCollection.AddScoped<SceneRenderParametersStore>();
             serviceCollection.AddSingleton<FactionColourSettingsService>();
             serviceCollection.AddTransient<
@@ -53,38 +40,9 @@ namespace GameWorld.Core
 
             // Services
             serviceCollection.AddSingleton<ISkeletonAnimationLookUpHelper, SkeletonAnimationLookUpHelper>();
-            serviceCollection.AddScoped<MeshBuilderService>();
-            serviceCollection.AddScoped<ViewOnlySelectedService>();
             serviceCollection.AddScoped<FocusSelectableObjectService>();
             serviceCollection.AddScoped<ComplexMeshLoader>();
-            serviceCollection.AddTransient<WsModelGeneratorService>();
-            serviceCollection.AddTransient<MaterialToWsMaterialFactory>();
-            
-            serviceCollection.AddScoped<FaceEditor>();
-            serviceCollection.AddScoped<ObjectEditor>();
             serviceCollection.AddScoped<Rmv2ModelNodeLoader>();
-
-            serviceCollection.AddScoped<SaveService>();
-            serviceCollection.AddScoped<NodeToRmvSaveHelper>();
-
-            serviceCollection.AddScoped<GeometryStrategyProvider>();
-            serviceCollection.AddScoped<IGeometryStrategy, NoMeshStrategy>();
-            serviceCollection.AddScoped<IGeometryStrategy, Rmw6Strategy>();
-            serviceCollection.AddScoped<IGeometryStrategy, Rmw7Strategy>();
-            serviceCollection.AddScoped<IGeometryStrategy, Rmw8Strategy>();
-
-            serviceCollection.AddScoped<LodStrategyProvider>();
-            serviceCollection.AddScoped<ILodGenerationStrategy, AssetEditorLodGeneration>();
-            serviceCollection.AddScoped<ILodGenerationStrategy, Lod0ForAllLodGeneration>();
-            serviceCollection.AddScoped<ILodGenerationStrategy, NoLodGeneration>();
-            
-            //serviceCollection.AddScoped<ILodGenerationStrategy, SimplygonLodGeneration>();
-
-            serviceCollection.AddScoped<MaterialStrategyProvider>();
-            serviceCollection.AddScoped<IMaterialStrategy, Warhammer3WsModelStrategy>();
-            serviceCollection.AddScoped<IMaterialStrategy, Warhammer2WsModelStrategy>();
-            serviceCollection.AddScoped<IMaterialStrategy, PharaohWsModelStrategy>();
-            serviceCollection.AddScoped<IMaterialStrategy, NoWsModelStrategy>();
 
             // Shader
             serviceCollection.AddScoped<CapabilityMaterialFactory>(); 
@@ -102,21 +60,23 @@ namespace GameWorld.Core
         void RegisterComponents(IServiceCollection serviceCollection)
         {
             serviceCollection.AddScoped<IComponentInserter, ComponentInserter>();
-            RegisterGameComponent<CommandStackRenderer>(serviceCollection);
-            RegisterGameComponent<IKeyboardComponent, KeyboardComponent>(serviceCollection);
-            RegisterGameComponent<IMouseComponent, MouseComponent>(serviceCollection);
+            serviceCollection.AddScoped<View3DCoreComponentSet>();
+            serviceCollection.AddScoped<CommandStackRenderer>();
+            serviceCollection.AddScoped<IKeyboardComponent, KeyboardComponent>();
+            serviceCollection.AddScoped<IMouseComponent, MouseComponent>();
 
-            RegisterGameComponent<FpsComponent>(serviceCollection);
-            RegisterGameComponent<ArcBallCamera>(serviceCollection);
-            RegisterGameComponent<NavigationGizmoComponent>(serviceCollection);
-            RegisterGameComponent<SceneManager>(serviceCollection);
-            RegisterGameComponent<GizmoComponent>(serviceCollection);
-            RegisterGameComponent<SelectionManager>(serviceCollection);
-            RegisterGameComponent<SelectionComponent>(serviceCollection);
-            RegisterGameComponent<RenderEngineComponent>(serviceCollection);
-            RegisterGameComponent<GridComponent>(serviceCollection);
-            RegisterGameComponent<AnimationsContainerComponent>(serviceCollection);
-            RegisterGameComponent<LightControllerComponent>(serviceCollection);
+            serviceCollection.AddScoped<FpsComponent>();
+            serviceCollection.AddScoped<ArcBallCamera>();
+            serviceCollection.AddScoped<NavigationGizmoComponent>();
+            serviceCollection.AddScoped<SceneManager>();
+            serviceCollection.AddScoped<SelectionManager>();
+            serviceCollection.AddScoped<ReferenceObjectSelectionComponent>();
+            serviceCollection.AddScoped<ReferenceObjectSelectionOutlineComponent>();
+            serviceCollection.AddScoped<BoneSelectionHighlightComponent>();
+            serviceCollection.AddScoped<RenderEngineComponent>();
+            serviceCollection.AddScoped<GridComponent>();
+            serviceCollection.AddScoped<AnimationsContainerComponent>();
+            serviceCollection.AddScoped<LightControllerComponent>();
 
             //serviceCollection.AddScoped<ISceneLightParameters>(x => x.GetRequiredService<LightControllerComponent>());
         }
@@ -126,27 +86,8 @@ namespace GameWorld.Core
             serviceCollection.AddScoped<CommandExecutor>();
             serviceCollection.AddScoped<CommandFactory>();
 
-            serviceCollection.AddTransient<ConvertFacesToVertexSelectionCommand>();
-            serviceCollection.AddTransient<FaceSelectionCommand>();
-            serviceCollection.AddTransient<EdgeSelectionCommand>();
-            serviceCollection.AddTransient<DuplicateFacesCommand>();
-            serviceCollection.AddTransient<VertexSelectionCommand>();
             serviceCollection.AddTransient<ObjectSelectionCommand>();
-            serviceCollection.AddTransient<DeleteFaceCommand>();
-            serviceCollection.AddTransient<DeleteObjectsCommand>();
-            serviceCollection.AddTransient<MakeNodeEditableCommand>();
-            serviceCollection.AddTransient<SortSceneNodesCommand>();
-            serviceCollection.AddTransient<ReduceMeshCommand>();
-            serviceCollection.AddTransient<TransformVertexCommand>();
-            serviceCollection.AddTransient<CombineMeshCommand>();
             serviceCollection.AddTransient<CreateAnimatedMeshPoseCommand>();
-            serviceCollection.AddTransient<CreateStaticMeshFromAnimationCommand>();
-            serviceCollection.AddTransient<DivideObjectIntoSubmeshesCommand>();
-            serviceCollection.AddTransient<DuplicateObjectCommand>();
-            serviceCollection.AddTransient<AddObjectsToGroupCommand>();
-            serviceCollection.AddTransient<UnGroupObjectsCommand>();
-            serviceCollection.AddTransient<GroupObjectsCommand>();
-            serviceCollection.AddTransient<GrowMeshCommand>();
             serviceCollection.AddTransient<ObjectSelectionModeCommand>();
 
             serviceCollection.AddTransient<BoneSelectionCommand>();

--- a/GameWorld/View3D/Rendering/EditOverlayStyle.cs
+++ b/GameWorld/View3D/Rendering/EditOverlayStyle.cs
@@ -13,10 +13,6 @@ internal static class EditOverlayStyle
         1.0f,
         0.47f,
         0.0f);
-    public static readonly Vector3 KitbashSelectedColour = new(
-        2.0f,
-        0.65f,
-        0.0f);
     public static readonly Vector3 ActiveColour = Vector3.One;
 
     public const float VertexDiameter = 4.5f;

--- a/GameWorld/View3D/Rendering/EditOverlayStyle.cs
+++ b/GameWorld/View3D/Rendering/EditOverlayStyle.cs
@@ -13,6 +13,10 @@ internal static class EditOverlayStyle
         1.0f,
         0.47f,
         0.0f);
+    public static readonly Vector3 KitbashSelectedColour = new(
+        2.0f,
+        0.65f,
+        0.0f);
     public static readonly Vector3 ActiveColour = Vector3.One;
 
     public const float VertexDiameter = 4.5f;

--- a/GameWorld/View3D/Rendering/RenderItems/AnimatedWireframeRenderItem.cs
+++ b/GameWorld/View3D/Rendering/RenderItems/AnimatedWireframeRenderItem.cs
@@ -88,6 +88,7 @@ namespace GameWorld.Core.Rendering.RenderItems
         int _vertexDataVersion = -1;
         bool _instanceDataDirty = true;
         HashSet<int>? _selectedVertices;
+        Vector3 _selectedVertexColour;
 
         public float DepthBias { get; set; } =
             EditOverlayStyle.WireDepthBias;
@@ -174,15 +175,17 @@ namespace GameWorld.Core.Rendering.RenderItems
             UpdateSelectedEdgeTopology();
         }
 
-        internal void UpdateSelectedVertices(
-            IEnumerable<int> selectedVertices)
+        public void UpdateSelectedVertices(
+            IEnumerable<int> selectedVertices,
+            Vector3 selectedColour)
         {
             ArgumentNullException.ThrowIfNull(selectedVertices);
             _selectedVertices = selectedVertices.ToHashSet();
+            _selectedVertexColour = selectedColour;
             _instanceDataDirty = true;
         }
 
-        internal void ClearSelectedVertices()
+        public void ClearSelectedVertices()
         {
             if (_selectedVertices == null)
                 return;
@@ -398,7 +401,7 @@ namespace GameWorld.Core.Rendering.RenderItems
         private Vector3 GetEndpointColour(int vertexIndex)
         {
             if (_selectedVertices?.Contains(vertexIndex) == true)
-                return EditOverlayStyle.KitbashSelectedColour;
+                return _selectedVertexColour;
 
             return new Vector3(_colour.X, _colour.Y, _colour.Z);
         }

--- a/GameWorld/View3D/Rendering/RenderItems/AnimatedWireframeRenderItem.cs
+++ b/GameWorld/View3D/Rendering/RenderItems/AnimatedWireframeRenderItem.cs
@@ -17,6 +17,8 @@ namespace GameWorld.Core.Rendering.RenderItems
         public Vector3 BindP1;
         public Vector4 Weights1;
         public Vector4 BoneIndices1;
+        public Vector3 Colour0;
+        public Vector3 Colour1;
 
         public static readonly VertexDeclaration VertexDeclaration =
             new(
@@ -49,7 +51,17 @@ namespace GameWorld.Core.Rendering.RenderItems
                     72,
                     VertexElementFormat.Vector4,
                     VertexElementUsage.BlendIndices,
-                    2));
+                    2),
+                new VertexElement(
+                    88,
+                    VertexElementFormat.Vector3,
+                    VertexElementUsage.Normal,
+                    5),
+                new VertexElement(
+                    100,
+                    VertexElementFormat.Vector3,
+                    VertexElementUsage.Normal,
+                    6));
 
         VertexDeclaration IVertexType.VertexDeclaration =>
             VertexDeclaration;
@@ -75,6 +87,7 @@ namespace GameWorld.Core.Rendering.RenderItems
         VertexBufferBinding[] _bindings = [];
         int _vertexDataVersion = -1;
         bool _instanceDataDirty = true;
+        HashSet<int>? _selectedVertices;
 
         public float DepthBias { get; set; } =
             EditOverlayStyle.WireDepthBias;
@@ -161,6 +174,23 @@ namespace GameWorld.Core.Rendering.RenderItems
             UpdateSelectedEdgeTopology();
         }
 
+        internal void UpdateSelectedVertices(
+            IEnumerable<int> selectedVertices)
+        {
+            ArgumentNullException.ThrowIfNull(selectedVertices);
+            _selectedVertices = selectedVertices.ToHashSet();
+            _instanceDataDirty = true;
+        }
+
+        internal void ClearSelectedVertices()
+        {
+            if (_selectedVertices == null)
+                return;
+
+            _selectedVertices = null;
+            _instanceDataDirty = true;
+        }
+
         public bool SupportsTechnique(
             RenderingTechnique technique)
         {
@@ -193,11 +223,6 @@ namespace GameWorld.Core.Rendering.RenderItems
                 (float)viewportWidth);
             effect.Parameters["ViewportHeight"].SetValue(
                 (float)viewportHeight);
-            effect.Parameters["OverlayColor"].SetValue(
-                new Vector3(
-                    _colour.X,
-                    _colour.Y,
-                    _colour.Z));
             effect.Parameters["BaseOpacity"].SetValue(
                 _colour.W);
             effect.Parameters["EdgeDepthBias"].SetValue(
@@ -349,10 +374,10 @@ namespace GameWorld.Core.Rendering.RenderItems
                  edgeIndex < _instanceData.Length;
                  edgeIndex++)
             {
-                var first = _pose.Geometry.VertexArray[
-                    _lineIndices[edgeIndex * 2]];
-                var second = _pose.Geometry.VertexArray[
-                    _lineIndices[edgeIndex * 2 + 1]];
+                var firstIndex = _lineIndices[edgeIndex * 2];
+                var secondIndex = _lineIndices[edgeIndex * 2 + 1];
+                var first = _pose.Geometry.VertexArray[firstIndex];
+                var second = _pose.Geometry.VertexArray[secondIndex];
                 _instanceData[edgeIndex] =
                     new AnimatedEdgeQuadInstanceData
                     {
@@ -361,11 +386,21 @@ namespace GameWorld.Core.Rendering.RenderItems
                         BoneIndices0 = first.BlendIndices,
                         BindP1 = second.Position3(),
                         Weights1 = second.BlendWeights,
-                        BoneIndices1 = second.BlendIndices
+                        BoneIndices1 = second.BlendIndices,
+                        Colour0 = GetEndpointColour(firstIndex),
+                        Colour1 = GetEndpointColour(secondIndex)
                     };
             }
 
             return _instanceData;
+        }
+
+        private Vector3 GetEndpointColour(int vertexIndex)
+        {
+            if (_selectedVertices?.Contains(vertexIndex) == true)
+                return EditOverlayStyle.KitbashSelectedColour;
+
+            return new Vector3(_colour.X, _colour.Y, _colour.Z);
         }
 
         void CreateQuadBuffers(GraphicsDevice device)

--- a/GameWorld/View3D/Rendering/VertexInstanceMesh.cs
+++ b/GameWorld/View3D/Rendering/VertexInstanceMesh.cs
@@ -64,10 +64,11 @@ namespace GameWorld.Core.Rendering
         Matrix _overlayBoundsWorld = Matrix.Identity;
         internal int InstanceUploadCount { get; private set; }
 
-        readonly Vector3 _selectedColour =
-            EditOverlayStyle.SelectedColour;
         readonly Vector3 _deselectedColour =
             EditOverlayStyle.VertexColour;
+
+        public Vector3 SelectedColour { get; set; } =
+            EditOverlayStyle.SelectedColour;
 
         // Screen-space vertex diameter remains stable across mesh types.
         public float VertexPixelSize { get; set; } =
@@ -271,7 +272,7 @@ namespace GameWorld.Core.Rendering
 
             return Vector3.Lerp(
                 _deselectedColour,
-                _selectedColour,
+                SelectedColour,
                 selectionWeight);
         }
 

--- a/GameWorld/View3D/SceneNodes/Rmv2MeshNode.cs
+++ b/GameWorld/View3D/SceneNodes/Rmv2MeshNode.cs
@@ -137,7 +137,7 @@ namespace GameWorld.Core.SceneNodes
                 renderEngine.AddRenderLines(LineHelper.AddBoundingBox(Geometry.BoundingBox, Color.Red, PivotPoint));
         }
 
-        internal void SetSelectionOutline(bool enabled)
+        public void SetSelectionOutline(bool enabled)
         {
             _selectionOutlineEnabled = enabled;
             _pooledRenderItem?.SetSelectionMask(

--- a/GameWorld/View3D/Services/SceneSaving/Material/Strategies/PharaohWsModelStrategy.cs
+++ b/GameWorld/View3D/Services/SceneSaving/Material/Strategies/PharaohWsModelStrategy.cs
@@ -4,7 +4,7 @@ using Shared.Core.Settings;
 
 namespace GameWorld.Core.Services.SceneSaving.Material.Strategies
 {
-    internal class PharaohWsModelStrategy : IMaterialStrategy
+    public class PharaohWsModelStrategy : IMaterialStrategy
     {
         private readonly WsModelGeneratorService _wsModelGeneratorService;
         private readonly MaterialToWsMaterialFactory _wsMaterialGeneratorFactory;

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/CreateFolderCommand.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/CreateFolderCommand.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.IO;
 using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
 using Shared.Core.Services;
 
 namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.Commands
@@ -30,7 +31,14 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.Commands
                 packFileService.CreateFolder(
                     _selectedNode.FileOwner,
                     folderPath);
-                _selectedNode.Children.Add(new TreeNode(folderName, NodeType.Directory, _selectedNode.FileOwner, _selectedNode));
+                if (_selectedNode.FileOwner is not FolderProjectContainer)
+                {
+                    _selectedNode.Children.Add(new TreeNode(
+                        folderName,
+                        NodeType.Directory,
+                        _selectedNode.FileOwner,
+                        _selectedNode));
+                }
             }
         }
     }

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/SearchFilter.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/SearchFilter.cs
@@ -127,6 +127,10 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
             if (isFolderMatch)
                 matches.Add(node);
 
+            var isEmptyDirectory =
+                hasSearchText == false &&
+                node.NodeType == NodeType.Directory &&
+                node.Children.Count == 0;
             var isVisible = node.Children.Count == 0 &&
                 node.NodeType == NodeType.Root
                 ? true
@@ -134,7 +138,7 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
                     ? hasSearchText == false ||
                         isFolderMatch ||
                         hasChildMatch
-                    : hasChildMatch;
+                    : hasChildMatch || isEmptyDirectory;
             node.IsVisible = isVisible;
             return isVisible;
         }

--- a/Testing/AssetEditorTests/AnimationKeyframeEditorSaveTests.cs
+++ b/Testing/AssetEditorTests/AnimationKeyframeEditorSaveTests.cs
@@ -78,7 +78,6 @@ namespace AssetEditorTests
         private static EditorHarness CreateHarness()
         {
             var fileSaveService = new Mock<IFileSaveService>();
-            var standardDialogs = new Mock<IStandardDialogs>();
             var editor = new AnimationKeyframeEditorViewModel(
                 new Mock<IPackFileService>().Object,
                 new Mock<ISkeletonAnimationLookUpHelper>().Object,
@@ -90,8 +89,9 @@ namespace AssetEditorTests
                 null!,
                 null!,
                 null!,
+                null!,
                 fileSaveService.Object,
-                standardDialogs.Object);
+                Mock.Of<IStandardDialogs>());
 
             var rider = new SceneObject("rider")
             {

--- a/Testing/AssetEditorTests/GizmoToolboxSubscriptionTests.cs
+++ b/Testing/AssetEditorTests/GizmoToolboxSubscriptionTests.cs
@@ -110,10 +110,7 @@ namespace AssetEditorTests
         {
             var eventHub = new Mock<IEventHub>();
             var selectionManager = new SelectionManager(
-                eventHub.Object,
-                null!,
-                null!,
-                null!);
+                eventHub.Object);
             var commandExecutor = new CommandExecutor(eventHub.Object);
 
             var services = new ServiceCollection();
@@ -126,7 +123,7 @@ namespace AssetEditorTests
 
             var serviceProvider = services.BuildServiceProvider();
             var commandFactory = new CommandFactory(serviceProvider, commandExecutor);
-            var gizmoComponent = new GizmoComponent(
+            var gizmoComponent = new AnimationBoneGizmoComponent(
                 eventHub.Object,
                 null!,
                 null!,
@@ -136,16 +133,19 @@ namespace AssetEditorTests
                 null!,
                 commandFactory,
                 selectionManager);
-            var selectionComponent = new SelectionComponent(
+            var selectionComponent = new AnimationBoneSelectionComponent(
                 null!,
                 null!,
                 null!,
                 selectionManager,
-                null!,
                 commandFactory,
                 null!,
                 null!,
-                gizmoComponent);
+                null!);
+            var boneSelectionHighlight =
+                new BoneSelectionHighlightComponent(
+                    selectionManager,
+                    null!);
 
             var editor = new AnimationKeyframeEditorViewModel(
                 new Mock<IPackFileService>().Object,
@@ -157,9 +157,10 @@ namespace AssetEditorTests
                 commandFactory,
                 selectionManager,
                 gizmoComponent,
+                boneSelectionHighlight,
                 commandExecutor,
                 new Mock<IFileSaveService>().Object,
-                new Mock<IStandardDialogs>().Object);
+                Mock.Of<IStandardDialogs>());
 
             var root = new GroupNode("rider");
             root.AddObject(new GroupNode("placeholder"));

--- a/Testing/AssetEditorTests/PackFileSearchFilterTests.cs
+++ b/Testing/AssetEditorTests/PackFileSearchFilterTests.cs
@@ -195,6 +195,31 @@ public class PackFileSearchFilterTests
         NUnitAssert.That(matchingFolder.IsNodeExpanded, Is.False);
     }
 
+    [Test]
+    public void EmptyFolder_RemainsVisibleWhenSearchIsClear()
+    {
+        var owner = new PackFileContainer("test.pack");
+        var root = new TreeNode("test.pack", NodeType.Root, owner, null);
+        var emptyFolder = new TreeNode(
+            "empty",
+            NodeType.Directory,
+            owner,
+            root);
+        root.Children.Add(emptyFolder);
+        var filter = new SearchFilter(new ObservableCollection<TreeNode>
+        {
+            root,
+        });
+
+        filter.Refresh();
+
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(root.IsVisible, Is.True);
+            NUnitAssert.That(emptyFolder.IsVisible, Is.True);
+        });
+    }
+
     private static TreeNode AddFile(
         TreeNode root,
         PackFileContainer owner,

--- a/Testing/AssetEditorTests/TextEditorViewLifecycleTests.cs
+++ b/Testing/AssetEditorTests/TextEditorViewLifecycleTests.cs
@@ -1,61 +1,156 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using CommonControls.Editors.TextEditor;
+using ICSharpCode.AvalonEdit;
+using ICSharpCode.AvalonEdit.Highlighting;
 
 namespace AssetEditorTests;
 
 public class TextEditorViewLifecycleTests
 {
     [NUnit.Framework.Test]
+    public void SyntaxSelector_UsesThemeStyleAndThemeAwareColorizer()
+    {
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () =>
+            {
+                var view = new TextEditorView();
+                var window = new Window
+                {
+                    Content = view,
+                    Width = 900,
+                    Height = 600,
+                    ShowActivated = false,
+                    ShowInTaskbar = false,
+                };
+                try
+                {
+                    window.Show();
+                    window.UpdateLayout();
+
+                    var selector = FindVisualDescendants<ComboBox>(view)
+                        .Single(comboBox =>
+                            comboBox.Name == "highlightingComboBox");
+                    var editor = FindVisualDescendants<TextEditor>(view)
+                        .Single();
+                    selector.SelectedItem = HighlightingManager.Instance
+                        .GetDefinition("XML");
+                    editor.Text =
+                        "<SLOT name=\"value\" probability=\"0.0\" />";
+                    window.UpdateLayout();
+                    editor.TextArea.TextView.Redraw();
+                    window.UpdateLayout();
+                    editor.TextArea.TextView.EnsureVisualLines();
+
+                    var colorizers = editor.TextArea.TextView
+                        .LineTransformers
+                        .OfType<HighlightingColorizer>()
+                        .ToArray();
+                    var foregroundBrushes = editor.TextArea.TextView.VisualLines
+                        .SelectMany(line => line.Elements)
+                        .Select(element =>
+                            element.TextRunProperties.ForegroundBrush)
+                        .Where(brush => brush != null)
+                        .ToArray();
+                    NUnit.Framework.Assert.Multiple(() =>
+                    {
+                        NUnit.Framework.Assert.That(
+                            selector.Style,
+                            NUnit.Framework.Is.SameAs(
+                                Application.Current.FindResource(
+                                    "AeInput.ComboBox")));
+                        NUnit.Framework.Assert.That(
+                            colorizers.Select(colorizer =>
+                                colorizer.GetType().Name),
+                            NUnit.Framework.Does.Contain(
+                                "ThemeAwareHighlightingColorizer"));
+                        NUnit.Framework.Assert.That(
+                            colorizers.Any(colorizer =>
+                                colorizer.GetType() ==
+                                typeof(HighlightingColorizer)),
+                            NUnit.Framework.Is.False);
+                        NUnit.Framework.Assert.That(
+                            foregroundBrushes,
+                            NUnit.Framework.Does.Contain(
+                                Application.Current.FindResource(
+                                    "AeBrush.Accent")));
+                        NUnit.Framework.Assert.That(
+                            foregroundBrushes,
+                            NUnit.Framework.Does.Contain(
+                                Application.Current.FindResource(
+                                    "AeBrush.Success")));
+                    });
+                }
+                finally
+                {
+                    window.Close();
+                }
+            });
+    }
+
+    [NUnit.Framework.Test]
     public void FoldingTimer_FollowsLoadedAndUnloadedLifecycle()
     {
-        WpfTestApplicationHost.Invoke(application =>
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () =>
+            {
+                TextEditorView? view = null;
+                try
+                {
+                    view = new TextEditorView();
+                    NUnit.Framework.Assert.That(
+                        view.IsFoldingTimerEnabled,
+                        NUnit.Framework.Is.False);
+
+                    view.RaiseEvent(new RoutedEventArgs(
+                        FrameworkElement.LoadedEvent));
+                    NUnit.Framework.Assert.That(
+                        view.IsFoldingTimerEnabled,
+                        NUnit.Framework.Is.True);
+
+                    view.RaiseEvent(new RoutedEventArgs(
+                        FrameworkElement.LoadedEvent));
+                    NUnit.Framework.Assert.That(
+                        view.IsFoldingTimerEnabled,
+                        NUnit.Framework.Is.True);
+
+                    view.RaiseEvent(new RoutedEventArgs(
+                        FrameworkElement.UnloadedEvent));
+                    NUnit.Framework.Assert.That(
+                        view.IsFoldingTimerEnabled,
+                        NUnit.Framework.Is.False);
+
+                    view.RaiseEvent(new RoutedEventArgs(
+                        FrameworkElement.LoadedEvent));
+                    NUnit.Framework.Assert.That(
+                        view.IsFoldingTimerEnabled,
+                        NUnit.Framework.Is.True);
+                }
+                finally
+                {
+                    view?.RaiseEvent(new RoutedEventArgs(
+                        FrameworkElement.UnloadedEvent));
+                }
+            });
+    }
+
+    private static IEnumerable<T> FindVisualDescendants<T>(
+        DependencyObject root)
+        where T : DependencyObject
+    {
+        for (var index = 0;
+             index < VisualTreeHelper.GetChildrenCount(root);
+             index++)
         {
-            const string resourceKey = "ComboBoxTemplate";
-            var hadExistingTemplate = application.Resources.Contains(resourceKey);
-            var existingTemplate = hadExistingTemplate
-                ? application.Resources[resourceKey]
-                : null;
-            application.Resources[resourceKey] =
-                new ControlTemplate(typeof(ComboBox));
+            var child = VisualTreeHelper.GetChild(root, index);
+            if (child is T match)
+                yield return match;
 
-            TextEditorView? view = null;
-            try
-            {
-                view = new TextEditorView();
-                NUnit.Framework.Assert.That(
-                    view.IsFoldingTimerEnabled,
-                    NUnit.Framework.Is.False);
-
-                view.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
-                NUnit.Framework.Assert.That(
-                    view.IsFoldingTimerEnabled,
-                    NUnit.Framework.Is.True);
-
-                view.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
-                NUnit.Framework.Assert.That(
-                    view.IsFoldingTimerEnabled,
-                    NUnit.Framework.Is.True);
-
-                view.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
-                NUnit.Framework.Assert.That(
-                    view.IsFoldingTimerEnabled,
-                    NUnit.Framework.Is.False);
-
-                view.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
-                NUnit.Framework.Assert.That(
-                    view.IsFoldingTimerEnabled,
-                    NUnit.Framework.Is.True);
-            }
-            finally
-            {
-                view?.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
-
-                if (hadExistingTemplate)
-                    application.Resources[resourceKey] = existingTemplate;
-                else
-                    application.Resources.Remove(resourceKey);
-            }
-        });
+            foreach (var descendant in FindVisualDescendants<T>(child))
+                yield return descendant;
+        }
     }
 }

--- a/Testing/AssetEditorTests/UiModelKitbashFamilyGallery.cs
+++ b/Testing/AssetEditorTests/UiModelKitbashFamilyGallery.cs
@@ -6,6 +6,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using AssetEditor.Services.Settings;
+using CommonControls.FilterDialog;
 using Editor.VisualSkeletonEditor.SkeletonEditor;
 using Editors.KitbasherEditor.ChildEditors.MeshFitter;
 using Editors.KitbasherEditor.ChildEditors.PhotoStudio;
@@ -121,6 +122,17 @@ public class UiModelKitbashFamilyGallery
             {
                 window.Show();
                 window.UpdateLayout();
+                if (variant == "main-editable-node")
+                {
+                    var selector = FindVisualDescendants<
+                            CollapsableFilterControl>(window)
+                        .Single();
+                    var browseButton = FindVisualDescendants<Button>(selector)
+                        .First(button => button.Name == "BrowseButton");
+                    browseButton.RaiseEvent(new RoutedEventArgs(
+                        Button.ClickEvent));
+                    window.UpdateLayout();
+                }
                 AssertVisualContracts(window, variant);
                 Capture(window, theme, variant);
             }

--- a/Testing/AssetEditorTests/UiModelKitbashFamilyTests.cs
+++ b/Testing/AssetEditorTests/UiModelKitbashFamilyTests.cs
@@ -790,6 +790,92 @@ public class UiModelKitbashFamilyTests
         });
     }
 
+    [Test]
+    public void MainEditableSkeletonSelector_KeepsLabelOnTheInputRowWhenExpanded()
+    {
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () =>
+            {
+                const string converterKey = "BoolToCollapsedConverter";
+                var resources = Application.Current.Resources;
+                var hadConverter = resources.Contains(converterKey);
+                var previousConverter = hadConverter
+                    ? resources[converterKey]
+                    : null;
+                resources[converterKey] = new BoolToVisibilityConverter
+                {
+                    TrueValue = Visibility.Visible,
+                    FalseValue = Visibility.Collapsed,
+                };
+                try
+                {
+                    var view = new MainEditableNodeView();
+                    var window = new Window
+                    {
+                        Content = view,
+                        Width = 640,
+                        Height = 720,
+                        ShowActivated = false,
+                        ShowInTaskbar = false,
+                    };
+                    try
+                    {
+                        window.Show();
+                        window.UpdateLayout();
+
+                        var selector = FindVisualDescendants<
+                                CollapsableFilterControl>(view)
+                            .Single();
+                        var browseButton = FindVisualDescendants<Button>(selector)
+                            .First(button => button.Name == "BrowseButton");
+                        browseButton.RaiseEvent(new RoutedEventArgs(
+                            Button.ClickEvent));
+                        window.UpdateLayout();
+
+                        var visibleLabels = FindVisualDescendants<Label>(view)
+                            .Where(label =>
+                                label.Visibility == Visibility.Visible &&
+                                Equals(label.Content, selector.LabelText))
+                            .ToArray();
+                        var selectorLabel = FindVisualDescendants<Label>(selector)
+                            .Single(label =>
+                                Equals(label.Content, selector.LabelText));
+                        var selectedFileName = FindVisualDescendants<TextBox>(selector)
+                            .Single(textBox => textBox.Name == "SelectedFileName");
+                        var labelTop = selectorLabel.TransformToAncestor(selector)
+                            .Transform(new Point()).Y;
+                        var inputTop = selectedFileName.TransformToAncestor(selector)
+                            .Transform(new Point()).Y;
+
+                        NUnitAssert.Multiple(() =>
+                        {
+                            NUnitAssert.That(selector.ShowLabel, Is.True);
+                            NUnitAssert.That(selector.LabelTotalWidth,
+                                Is.EqualTo(150));
+                            NUnitAssert.That(visibleLabels,
+                                Has.Length.EqualTo(1));
+                            NUnitAssert.That(selectorLabel.Visibility,
+                                Is.EqualTo(Visibility.Visible));
+                            NUnitAssert.That(labelTop,
+                                Is.EqualTo(inputTop).Within(1));
+                        });
+                    }
+                    finally
+                    {
+                        window.Close();
+                    }
+                }
+                finally
+                {
+                    if (hadConverter)
+                        resources[converterKey] = previousConverter!;
+                    else
+                        resources.Remove(converterKey);
+                }
+            });
+    }
+
     private static IReadOnlyList<string> ReadProductSources()
     {
         var root = FindSolutionRoot();

--- a/Testing/AssetEditorTests/View3DComponentIsolationTests.cs
+++ b/Testing/AssetEditorTests/View3DComponentIsolationTests.cs
@@ -62,9 +62,6 @@ public class View3DComponentIsolationTests
             game.AddedComponents);
         Assert.IsFalse(
             game.AddedComponents.Any(
-                component => component is SelectionManager));
-        Assert.IsFalse(
-            game.AddedComponents.Any(
                 component => component is KitbashSelectionInputComponent));
         Assert.IsFalse(
             game.AddedComponents.Any(
@@ -87,6 +84,15 @@ public class View3DComponentIsolationTests
                 scope.ServiceProvider
                     .GetServices<IGameComponent>()
                     .Count());
+            Assert.IsNull(
+                scope.ServiceProvider
+                    .GetService<KitbashSelectionInputComponent>());
+            Assert.IsNull(
+                scope.ServiceProvider
+                    .GetService<KitbashSelectionOverlayComponent>());
+            Assert.IsNull(
+                scope.ServiceProvider
+                    .GetService<KitbashModelGizmoComponent>());
         }
         finally
         {

--- a/Testing/AssetEditorTests/View3DComponentIsolationTests.cs
+++ b/Testing/AssetEditorTests/View3DComponentIsolationTests.cs
@@ -1,0 +1,154 @@
+using System.Runtime.CompilerServices;
+using System.Windows;
+using AssetEditor.Services;
+using Editors.KitbasherEditor.Components;
+using GameWorld.Core.Components;
+using GameWorld.Core.Components.Input;
+using GameWorld.Core.Components.Navigation;
+using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.Components.Selection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+using Shared.Core.Services;
+
+namespace AssetEditorTests;
+
+[TestClass]
+public class View3DComponentIsolationTests
+{
+    [TestMethod]
+    public void ComponentInserter_AddsOnlyCoreAndExplicitEditorComponents()
+    {
+        var game = new RecordingWpfGame();
+        var coreComponents = CreateCoreComponentSet();
+        var editorComponents = new IGameComponent[]
+        {
+            new TestGameComponent(),
+            new TestGameComponent(),
+        };
+
+        new ComponentInserter(game).Execute(
+            coreComponents,
+            editorComponents);
+
+        Assert.AreEqual(1, game.ForceEnsureCreatedCallCount);
+        CollectionAssert.AreEqual(
+            coreComponents.Components
+                .Concat(editorComponents)
+                .ToArray(),
+            game.AddedComponents);
+    }
+
+    [TestMethod]
+    public void ComponentInserter_WithReferenceSelection_DoesNotAddKitbashEditingComponents()
+    {
+        var game = new RecordingWpfGame();
+        var coreComponents = CreateCoreComponentSet();
+        var referenceComponents = new IGameComponent[]
+        {
+            CreateUninitialized<ReferenceObjectSelectionComponent>(),
+            CreateUninitialized<ReferenceObjectSelectionOutlineComponent>(),
+        };
+
+        new ComponentInserter(game).Execute(
+            coreComponents,
+            referenceComponents);
+
+        CollectionAssert.IsSubsetOf(
+            referenceComponents,
+            game.AddedComponents);
+        Assert.IsFalse(
+            game.AddedComponents.Any(
+                component => component is SelectionManager));
+        Assert.IsFalse(
+            game.AddedComponents.Any(
+                component => component is KitbashSelectionInputComponent));
+        Assert.IsFalse(
+            game.AddedComponents.Any(
+                component => component is KitbashSelectionOverlayComponent));
+        Assert.IsFalse(
+            game.AddedComponents.Any(
+                component => component is KitbashModelGizmoComponent));
+    }
+
+    [TestMethod]
+    public void ApplicationComposition_DoesNotRegisterGlobalGameComponents()
+    {
+        var provider = new DependencyInjectionConfig(false).Build(true);
+        try
+        {
+            using var scope = provider.CreateScope();
+
+            Assert.AreEqual(
+                0,
+                scope.ServiceProvider
+                    .GetServices<IGameComponent>()
+                    .Count());
+        }
+        finally
+        {
+            (provider as IDisposable)?.Dispose();
+        }
+    }
+
+    private static View3DCoreComponentSet CreateCoreComponentSet()
+    {
+        return new View3DCoreComponentSet(
+            CreateUninitialized<CommandStackRenderer>(),
+            Mock.Of<IKeyboardComponent>(),
+            Mock.Of<IMouseComponent>(),
+            CreateUninitialized<FpsComponent>(),
+            CreateUninitialized<ArcBallCamera>(),
+            CreateUninitialized<NavigationGizmoComponent>(),
+            CreateUninitialized<SceneManager>(),
+            CreateUninitialized<RenderEngineComponent>(),
+            CreateUninitialized<GridComponent>(),
+            new AnimationsContainerComponent(),
+            CreateUninitialized<LightControllerComponent>());
+    }
+
+    private static T CreateUninitialized<T>() where T : class
+    {
+        return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
+    }
+
+    private sealed class TestGameComponent : IGameComponent
+    {
+        public void Initialize()
+        {
+        }
+    }
+
+    private sealed class RecordingWpfGame : IWpfGame
+    {
+        public List<IGameComponent> AddedComponents { get; } = [];
+        public int ForceEnsureCreatedCallCount { get; private set; }
+        public ContentManager Content { get; set; } = null!;
+        public GraphicsDevice GraphicsDevice => null!;
+
+        public T AddComponent<T>(T component)
+            where T : IGameComponent
+        {
+            AddedComponents.Add(component);
+            return component;
+        }
+
+        public void ForceEnsureCreated()
+        {
+            ForceEnsureCreatedCallCount++;
+        }
+
+        public FrameworkElement GetFocusElement()
+        {
+            return null!;
+        }
+
+        public void RemoveComponent<T>(T component)
+            where T : IGameComponent
+        {
+        }
+    }
+}

--- a/Testing/GameWorld.Core.Test/Animation/MeshPoseSnapshotTests.cs
+++ b/Testing/GameWorld.Core.Test/Animation/MeshPoseSnapshotTests.cs
@@ -405,15 +405,10 @@ public class MeshPoseSnapshotTests
         var node = CreatePausedAnimatedNode();
         var pausedPose = MeshPoseSnapshot.Capture(node);
 
-        var whilePaused =
-            SelectionManager.ShouldRenderDenseEditOverlay(
-                node,
-                pausedPose);
+        var whilePaused = !pausedPose.ApplyAnimation;
         node.AnimationPlayer!.Play();
         var whilePlaying =
-            SelectionManager.ShouldRenderDenseEditOverlay(
-                node,
-                MeshPoseSnapshot.Capture(node));
+            !MeshPoseSnapshot.Capture(node).ApplyAnimation;
 
         Assert.Multiple(() =>
         {
@@ -640,10 +635,7 @@ public class MeshPoseSnapshotTests
         var selection = CreateVertexSelection(node);
         var eventHub = new Mock<IEventHub>();
         var selectionManager = new SelectionManager(
-            eventHub.Object,
-            null!,
-            null!,
-            null!);
+            eventHub.Object);
         selectionManager.SetState(selection);
         var commandExecutor = new CommandExecutor(eventHub.Object);
         var services = new Mock<IServiceProvider>();
@@ -724,10 +716,7 @@ public class MeshPoseSnapshotTests
         var selection = CreateVertexSelection(node);
         var eventHub = new Mock<IEventHub>();
         var selectionManager = new SelectionManager(
-            eventHub.Object,
-            null!,
-            null!,
-            null!);
+            eventHub.Object);
         selectionManager.SetState(selection);
         var commandExecutor = new CommandExecutor(eventHub.Object);
         var services = new Mock<IServiceProvider>();

--- a/Testing/GameWorld.Core.Test/Commands/SceneMutationCommandTests.cs
+++ b/Testing/GameWorld.Core.Test/Commands/SceneMutationCommandTests.cs
@@ -190,10 +190,7 @@ namespace Testing.GameWorld.Core.Commands
         private static SelectionManager CreateSelectionManager()
         {
             var selectionManager = new SelectionManager(
-                Mock.Of<IEventHub>(),
-                null!,
-                null!,
-                null!);
+                Mock.Of<IEventHub>());
             selectionManager.CreateSelectionSate(
                 GeometrySelectionMode.Object,
                 null!,

--- a/Testing/GameWorld.Core.Test/Commands/TransformBoneCommandTests.cs
+++ b/Testing/GameWorld.Core.Test/Commands/TransformBoneCommandTests.cs
@@ -232,7 +232,7 @@ namespace Testing.GameWorld.Core.Commands
         private static TransformContext CreateContext()
         {
             var eventHub = new Mock<IEventHub>();
-            var selectionManager = new SelectionManager(eventHub.Object, null, null, null);
+            var selectionManager = new SelectionManager(eventHub.Object);
             var animation = CreateAnimation();
             var selection = new BoneSelectionState(null)
             {

--- a/Testing/GameWorld.Core.Test/Commands/TransformVertexCommandTests.cs
+++ b/Testing/GameWorld.Core.Test/Commands/TransformVertexCommandTests.cs
@@ -1138,7 +1138,7 @@ namespace Testing.GameWorld.Core.Commands
         static (SelectionManager SelectionManager, CommandExecutor CommandExecutor) CreateCommandContext(ISelectionState selection)
         {
             var eventHub = new Mock<IEventHub>();
-            var selectionManager = new SelectionManager(eventHub.Object, null, null, null);
+            var selectionManager = new SelectionManager(eventHub.Object);
             selectionManager.SetState(selection);
             return (selectionManager, new CommandExecutor(eventHub.Object));
         }

--- a/Testing/GameWorld.Core.Test/Components/Navigation/NavigationGizmoComponentTests.cs
+++ b/Testing/GameWorld.Core.Test/Components/Navigation/NavigationGizmoComponentTests.cs
@@ -25,7 +25,6 @@ public class NavigationGizmoComponentTests
             mouse.Object,
             null!,
             null!,
-            null!,
             null!);
         var transition = new CameraTransition(camera);
         transition.StartTransition(ViewPresetType.Front);

--- a/Testing/GameWorld.Core.Test/Rendering/EdgeQuadOffscreenTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/EdgeQuadOffscreenTests.cs
@@ -79,6 +79,79 @@ public class EdgeQuadOffscreenTests
     }
 
     [Test]
+    public void Draw_PreviewShapeWireframeKeepsItsOwnColour()
+    {
+        var game = new WpfGameMock();
+        var device = game.GraphicsDevice;
+        var effect = game.Content.Load<Effect>("Shaders\\EdgeQuadShader");
+        var deviceResolver = new Mock<IDeviceResolver>();
+        deviceResolver.SetupGet(x => x.Device).Returns(device);
+        var resourceLibrary = new Mock<IScopedResourceLibrary>();
+        resourceLibrary
+            .Setup(x => x.GetStaticEffect(ShaderTypes.EdgeQuad))
+            .Returns(effect);
+        using var renderer = new EdgeQuadInstanceMesh(
+            deviceResolver.Object,
+            resourceLibrary.Object);
+        using var renderTarget = new RenderTarget2D(
+            device,
+            64,
+            64,
+            false,
+            SurfaceFormat.Color,
+            DepthFormat.Depth24);
+        var shape = PreviewShapeGeometry.CreateBoxMarker(
+            Vector3.Zero,
+            0.65f,
+            Color.Transparent,
+            new Color(50, 190, 220),
+            0.75f);
+        renderer.Update(shape.Edges);
+
+        try
+        {
+            device.SetRenderTarget(renderTarget);
+            device.Clear(
+                ClearOptions.Target | ClearOptions.DepthBuffer,
+                Color.Transparent,
+                1.0f,
+                0);
+            device.DepthStencilState = DepthStencilState.Default;
+            device.RasterizerState = RasterizerState.CullNone;
+            renderer.Draw(
+                Matrix.Identity,
+                Matrix.Identity,
+                64.0f,
+                64.0f,
+                device);
+        }
+        finally
+        {
+            device.SetRenderTarget(null);
+        }
+
+        var pixels = new Color[64 * 64];
+        renderTarget.GetData(pixels);
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                pixels.Count(pixel =>
+                    pixel.A > 0 &&
+                    pixel.B > pixel.R * 2 &&
+                    pixel.G > pixel.R * 2),
+                Is.GreaterThan(0),
+                "SuperView preview shapes must keep their own edge colour.");
+            Assert.That(
+                pixels.Count(pixel =>
+                    pixel.A > 0 &&
+                    pixel.R > pixel.G * 1.5f &&
+                    pixel.G > pixel.B + 5),
+                Is.EqualTo(0),
+                "Kitbash vertex selection colours must not leak into preview shape wireframes.");
+        });
+    }
+
+    [Test]
     public void Draw_AntialiasedEdgeUsesPremultipliedCoverage()
     {
         var pixels = RenderEdge(

--- a/Testing/GameWorld.Core.Test/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
@@ -581,6 +581,183 @@ public class RenderEngineSelectionMaskOffscreenTests
         mesh.Dispose();
     }
 
+    [Test]
+    public void AnimatedVertexSelection_OnlyHighlightsConnectedEdgeEnds()
+    {
+        const int size = 128;
+        var game = new WpfGameMock();
+        var device = game.GraphicsDevice;
+        var deviceResolver = new Mock<IDeviceResolver>();
+        deviceResolver
+            .SetupGet(resolver => resolver.Device)
+            .Returns(device);
+        var camera = new ArcBallCamera(
+            deviceResolver.Object,
+            Mock.Of<IKeyboardComponent>(),
+            Mock.Of<IMouseComponent>());
+        camera.Initialize();
+        var resources = new ResourceLibrary(
+            Mock.Of<IPackFileService>());
+        resources.Initialize(device, game.Content);
+        var eventHub = new Mock<IEventHub>();
+        using var scopedResources = new ScopedResourceLibrary(
+            resources,
+            eventHub.Object,
+            Mock.Of<IStandardDialogs>());
+        var renderEngine = new RenderEngineComponent(
+            game,
+            resources,
+            camera,
+            deviceResolver.Object,
+            new ApplicationSettingsService(),
+            new SceneRenderParametersStore(),
+            eventHub.Object,
+            new GridComponent(
+                camera,
+                resources,
+                deviceResolver.Object)
+            {
+                ShowGrid = false
+            });
+        renderEngine.Initialize();
+        var selectionManager = new SelectionManager(
+            eventHub.Object,
+            renderEngine,
+            scopedResources,
+            deviceResolver.Object);
+        Assert.That(
+            selectionManager.VertexSelectionEdgeGradientEnabled,
+            Is.False,
+            "Other editors must retain the existing wireframe behaviour unless they opt in.");
+        selectionManager.Initialize();
+        var mesh = CreateMesh(device, animated: true);
+        var node = new Rmv2MeshNode(
+            mesh,
+            Mock.Of<IRmvMaterial>(),
+            null!,
+            CreateAnimationPlayer());
+        var selection = new VertexSelectionState(node, 0);
+        selection.ModifySelection([0], onlyRemove: false);
+        selection.ActiveVertex = null;
+
+        selectionManager.SetState(selection);
+        using var renderTarget = new RenderTarget2D(
+            device,
+            size,
+            size,
+            false,
+            SurfaceFormat.Color,
+            DepthFormat.Depth24);
+        var parameters = new CommonShaderParameters(
+            Matrix.Identity,
+            Matrix.Identity,
+            Vector3.Zero,
+            Vector3.Forward,
+            0,
+            0,
+            0,
+            1,
+            Vector3.One,
+            [],
+            size,
+            size);
+
+        Color[] DrawCurrentWireframe()
+        {
+            renderEngine.Update(new GameTime());
+            selectionManager.Draw(new GameTime());
+            var wireframe = GetRenderItems(
+                    renderEngine,
+                    RenderBuckedId.Wireframe)
+                .OfType<AnimatedWireframeRenderItem>()
+                .Single();
+            try
+            {
+                device.SetRenderTarget(renderTarget);
+                device.Clear(
+                    ClearOptions.Target | ClearOptions.DepthBuffer,
+                    Color.Transparent,
+                    1,
+                    0);
+                device.BlendState = BlendState.Opaque;
+                device.DepthStencilState = DepthStencilState.Default;
+                device.RasterizerState = RasterizerState.CullNone;
+                wireframe.Draw(
+                    device,
+                    parameters,
+                    RenderingTechnique.Normal);
+            }
+            finally
+            {
+                device.SetRenderTarget(null);
+            }
+
+            var framePixels = new Color[size * size];
+            renderTarget.GetData(framePixels);
+            return framePixels;
+        }
+
+        var defaultPixels = DrawCurrentWireframe();
+        selectionManager.VertexSelectionEdgeGradientEnabled = true;
+        var pixels = DrawCurrentWireframe();
+        selectionManager.SetState(new EdgeSelectionState
+        {
+            RenderObject = node
+        });
+        var edgeModePixels = DrawCurrentWireframe();
+        var connectedHighlight = CountPixels(
+            pixels,
+            size,
+            8,
+            46,
+            44,
+            84,
+            IsSelectedOrange);
+        var remoteTopologyHighlight = CountPixels(
+            pixels,
+            size,
+            48,
+            120,
+            46,
+            58,
+            IsSelectedOrange);
+        var farEndpointHighlight = CountPixels(
+            pixels,
+            size,
+            98,
+            120,
+            70,
+            84,
+            IsSelectedOrange);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                defaultPixels.Count(IsSelectedOrange),
+                Is.EqualTo(0),
+                "Editors that do not opt in must keep the existing uniform wireframe colour.");
+            Assert.That(
+                edgeModePixels.Count(IsSelectedOrange),
+                Is.EqualTo(0),
+                "Leaving vertex mode must clear the vertex-edge gradient from the shared wireframe item.");
+            Assert.That(
+                connectedHighlight,
+                Is.GreaterThan(0),
+                "The selected vertex must send a fading orange highlight into its connected edges.");
+            Assert.That(
+                remoteTopologyHighlight,
+                Is.EqualTo(0),
+                "Edges that are not connected to the selected vertex must keep the normal wire colour.");
+            Assert.That(
+                farEndpointHighlight,
+                Is.EqualTo(0),
+                "The highlight must fade before reaching an unselected endpoint.");
+        });
+
+        selectionManager.Dispose();
+        mesh.Dispose();
+    }
+
     [TestCase(false)]
     [TestCase(true)]
     public void Render3DObjects_SelectedEdgeRemainsOrangeOverWireframe(
@@ -1203,6 +1380,28 @@ public class RenderEngineSelectionMaskOffscreenTests
         return pixel.A > 0 &&
                pixel.R > pixel.G * 1.5f &&
                pixel.G > pixel.B + 5;
+    }
+
+    private static int CountPixels(
+        IReadOnlyList<Color> pixels,
+        int width,
+        int startX,
+        int endX,
+        int startY,
+        int endY,
+        Func<Color, bool> predicate)
+    {
+        var count = 0;
+        for (var y = startY; y < endY; y++)
+        {
+            for (var x = startX; x < endX; x++)
+            {
+                if (predicate(pixels[y * width + x]))
+                    count++;
+            }
+        }
+
+        return count;
     }
 
     private static double GetAverageOrangeRow(

--- a/Testing/GameWorld.Core.Test/Services/FocusSelectableObjectServiceTests.cs
+++ b/Testing/GameWorld.Core.Test/Services/FocusSelectableObjectServiceTests.cs
@@ -23,11 +23,7 @@ public class FocusSelectableObjectServiceTests
     public void FocusSelection_BoneModeCentersSelectedBone()
     {
         var eventHub = Mock.Of<IEventHub>();
-        var selectionManager = new SelectionManager(
-            eventHub,
-            null!,
-            null!,
-            null!);
+        var selectionManager = new SelectionManager(eventHub);
         var camera = new ArcBallCamera(
             null!,
             Mock.Of<IKeyboardComponent>(),
@@ -57,11 +53,7 @@ public class FocusSelectableObjectServiceTests
     public void FocusSelection_BoneModeWithoutAnimationCentersObject()
     {
         var eventHub = Mock.Of<IEventHub>();
-        var selectionManager = new SelectionManager(
-            eventHub,
-            null!,
-            null!,
-            null!);
+        var selectionManager = new SelectionManager(eventHub);
         var camera = new ArcBallCamera(
             null!,
             Mock.Of<IKeyboardComponent>(),

--- a/Testing/Shared/Shared/WpfGameMock.cs
+++ b/Testing/Shared/Shared/WpfGameMock.cs
@@ -14,6 +14,7 @@ namespace Test.TestingUtility.Shared
 
         public ContentManager Content { get; set; }
         public GraphicsDevice GraphicsDevice { get; private set; }
+        public List<IGameComponent> Components { get; } = [];
 
         public WpfGameMock()
         {
@@ -40,6 +41,7 @@ namespace Test.TestingUtility.Shared
 
         public T AddComponent<T>(T comp) where T : IGameComponent
         {
+            Components.Add(comp);
             comp.Initialize();
             return comp;
         }


### PR DESCRIPTION
## 变更内容

- 修复文件夹工程中新建空文件夹后资源树根节点消失，以及重复加载误判。
- 修复文本编辑器格式下拉菜单未跟随主题、文本配色刺眼，以及 Kitbash 骨架浏览布局回归。
- 为 Kitbash 顶点模式实现 Blender 风格的选中顶点与相邻边渐变高亮，避免未选中顶点和拓扑线全局高亮。
- 审查全部 3D 编辑器能力后，将网格编辑输入、Gizmo 和选择覆盖层收敛为 Kitbash 专属组件；保留其他编辑器实际需要的对象、骨骼、顶点和元数据选择高亮能力。
- 修复密集网格超过 50,000 条显示边时，选中顶点邻边可能被截断的问题，并增加隔离与密集网格回归门禁。
- 将 Kitbash 3D 场景独占边界写入项目规则。

## 根因

- 空目录过滤错误地把空文件夹工程根节点一并隐藏。
- 文本格式控件和语法颜色使用了未接入主题的固定颜色。
- 统一服务容器把各模块的 `IGameComponent` 全部暴露给每个 3D 编辑器作用域，缺少按编辑器显式插入的边界。
- 静态线框缓存按索引顺序截取前 50,000 条边，没有优先保留选中顶点的邻边。

## 验证

- 用户已完成实际界面与 3D 编辑器手动验收。
- `dotnet restore AssetEditor.CN.sln`
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore -m:1 -v:minimal`：成功，0 错误。
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity minimal`：2860 通过，6 跳过，0 失败。
- Kitbash 密集网格、场景组合、Gizmo、Photo Studio 定向测试：6/6 通过。
- View3D 组件隔离门禁：3/3 通过。
- 两条独立只读复核确认：选中邻边截断和全局 DI 泄漏均已解决，未发现可证明的剩余硬性架构问题。