### PR TITLE
Document KitbashEditor and SuperView architecture boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,8 @@
 
 - 代码、项目引用和测试是当前实现的事实来源；仓库文档只补充代码不能稳定表达的约束、术语、入口和设计取舍。
 - 不要默认通读全部文档。领域词汇消歧读取 `CONTEXT.md`；跨模块定位读取 `docs/architecture.md`；文件夹工程或本地 Git 读取 `docs/folder-project-version-control.md`；IPC 读取 `docs/asseteditor-ipc.md`。完整路由见 `docs/README.md`。
+- 新增、修改、审查或验收 KitbashEditor、模型选择/变换/覆盖层、场景树、保存或 Kitbash 子工具前，必须完整读取并遵循 `docs/kitbash-editor.md`。
+- 新增、修改、审查或验收超级视图（SuperView）、Animation META 预览、元数据时间/空间编辑或其双文档保存前，必须完整读取并遵循 `docs/superview.md`。
 - 新增、修改、审查或验收任何用户界面、窗口、控件、主题、图标、动画或加载进度前，必须完整读取并遵循 `docs/ui-design-system.md`；该文件是本仓库唯一长期 UI 规范。特别必须执行其中的“Agent 公共组件复用协议”：先搜索、再复用，未满足准入条件不得新增公共控件。
 - 只有稳定契约、领域含义、关键入口或已知限制改变时才同步更新文档；内部重构、测试数量、性能快照、分支名和提交 SHA 不写入长期上下文。
 - 文档结论必须用当前代码或测试核验；历史对话、记忆、提交标题、PR 描述和上游文档只能用于定位，不能直接证明当前行为。
@@ -106,9 +108,6 @@
 - `Shared/SharedCore` 放置无 WPF 业务界面的核心服务与模型，`Shared/GameFiles` 放置游戏格式，`Shared/SharedUI` 放置跨模块、无业务含义的通用 WPF 组件。
 - `Shared.Ui` 只能引用 `Shared/` 内项目，不得反向依赖 `AssetEditor`、`Editors` 或具体业务编辑器；已有 `SharedUiArchitectureTests` 是这条边界的自动门禁。
 - 只有被多个模块真实复用、无业务含义且可独立验证的 UI 才进入 `Shared.Ui`；对话框等通用依赖优先走 `IStandardDialogs` 等现有抽象。
-- `KitbashEditor` 是唯一承担模型编辑的编辑器；其他编辑器中的模型只用于参考、预览或辅助展示，不得把它们视为模型编辑入口。
-- 其他编辑器可以共用公共 View3D 场景组件；`KitbashEditor` 的模型选择、变换、编辑覆盖层及专属三维场景效果必须由 `Editors/Kitbashing/KitbasherEditor` 内的独立组件实现，并且只允许由 Kitbash 编辑器的组成入口创建和插入。不得把这些专属组件注册为所有编辑器作用域都能解析的服务，也不得通过共享组件中的模式开关、编辑器类型判断或共享默认值实现 Kitbash 专属行为。
-- Kitbash 独立组件可以复用无编辑器语义的底层数据结构、数学、设备和绘制原语，但不得改变其他编辑器使用的共享场景组件行为。修改 `GameWorld/View3D` 中的共享选择、Gizmo、输入或渲染组件前，必须先证明该行为对所有使用者都成立；仅服务 Kitbash 的需求应留在 Kitbash 模块。
 - 比较上游 `D:\TheAssetEditor` 时必须实时核对两边 HEAD、分支、工作区、行为、项目引用、本地化和测试；文件名相同或旧记忆不能证明功能等价。
 
 ## Pack 与文件夹工程

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@
 | --- | --- | --- |
 | 产品身份、Pack、文件夹工程术语可能混淆 | [`../CONTEXT.md`](../CONTEXT.md) | 统一词义 |
 | 跨模块定位、依赖注入、Pack 生命周期、共享 UI、更新器或测试路由 | [`architecture.md`](architecture.md) | 入口、边界、验证定位 |
+| KitbashEditor、模型选择/变换/覆盖层、场景树、保存或 Kitbash 子工具 | [`kitbash-editor.md`](kitbash-editor.md) | 模型编辑架构、状态所有权、实现边界和验证门禁 |
+| 超级视图、SuperView、Animation META 预览、元数据时间/空间编辑或双文档保存 | [`superview.md`](superview.md) | 元数据预览/编辑数据流、双文档所有权和模型编辑隔离 |
 | 新增、修改、审查或验收任何 WPF 界面、窗口、控件、主题、图标、动画或加载进度 | [`ui-design-system.md`](ui-design-system.md) | 唯一长期 UI 规范与实施门禁 |
 | 文件夹工程、本地 Git、状态语义、路径安全或大型工程性能 | [`folder-project-version-control.md`](folder-project-version-control.md) | 非显然状态模型和高风险契约 |
 | 外部进程通过命名管道打开资源 | [`asseteditor-ipc.md`](asseteditor-ipc.md) | IPC 协议和限制 |

--- a/docs/kitbash-editor.md
+++ b/docs/kitbash-editor.md
@@ -1,0 +1,373 @@
+# KitbashEditor 技术上下文
+
+> 面向修改、审查和验收 KitbashEditor 的 AI。本文记录稳定架构、状态所有权、关键调用链、实现边界和验证路由，不替代当前代码。涉及界面时还必须阅读 [`ui-design-system.md`](ui-design-system.md)。
+
+## 1. 阅读触发与事实优先级
+
+出现下列任一范围时，开始工作前完整阅读本文：
+
+- Kitbash、模型编辑、`.rigid_model_v2`、`.variantmeshdefinition`、`.wsmodel`；
+- 对象/面/边/顶点/骨骼选择、Gizmo、比例编辑、橙色轮廓、编辑覆盖层；
+- Scene Explorer、节点属性、材质、LOD、动画或骨架；
+- Kitbash 保存、子工具、离屏渲染、截图或 Photo Studio；
+- 计划修改 `GameWorld/View3D` 中会被 Kitbash 使用的共享输入、选择、变换或渲染代码。
+
+事实发生冲突时按以下顺序处理：
+
+1. 当前代码、项目引用和测试；
+2. 本文记录的稳定契约与边界；
+3. 其他仓库文档；
+4. 历史提交、PR、对话和上游实现。
+
+本文不记录当前测试总数、分支名或提交 SHA。新增类型后不要机械地把每个类抄进本文；只有所有权、入口、状态含义、跨模块契约或高风险边界变化时才更新。
+
+## 2. 编辑器身份与硬边界
+
+KitbashEditor 是本仓库唯一承担模型编辑的编辑器。其职责包括：
+
+- 从 Pack 资源加载可编辑模型、骨架、动画和参考模型；
+- 编辑对象层级、网格几何、材质、骨骼和附着点；
+- 提供对象、面、边、顶点和骨骼五种选择语义；
+- 预览并提交平移、旋转、缩放和比例编辑；
+- 通过统一命令历史提供撤销、重做和未保存状态；
+- 按游戏和输出格式策略保存几何、材质、LOD 与 `.wsmodel`。
+
+硬边界：
+
+- 其他编辑器中的模型只用于参考、预览或辅助展示，不因此获得模型编辑能力。
+- Kitbash 专属的选择输入、选择覆盖层和 Gizmo 编排必须留在 `Editors/Kitbashing/KitbasherEditor/`。
+- 不得把 Kitbash 专属组件注册为全局或所有编辑器作用域都能解析的 `IGameComponent`。
+- 不得在共享 View3D 组件中通过 `IsKitbash`、编辑器类型判断、模式开关或 Kitbash 默认值实现专属行为。
+- 只有对所有真实调用者都成立的行为才能下沉到 `GameWorld/View3D`；仅服务 Kitbash 的策略必须由 Kitbash 组合层持有。
+
+## 3. 模块、注册与组成
+
+### 3.1 主要位置
+
+| 范围 | 位置 | 所有权 |
+| --- | --- | --- |
+| Kitbash 主模块 | `Editors/Kitbashing/KitbasherEditor/` | 编辑器入口、界面、专属交互、子工具 |
+| Kitbash 测试 | `Editors/Kitbashing/Test.KitbashEditor/` | 模块级行为、保存、渲染、子工具 |
+| 共享 View3D | `GameWorld/View3D/` | 中性场景、输入原语、选择状态、Gizmo 原语、渲染和保存策略 |
+| 共享模型/格式 | `Shared/`、`GameWorld/` 其他项目 | 文件格式、场景节点、动画、数学和 GPU 原语 |
+| 应用组合根 | `AssetEditor/` | 模块发现、编辑器宿主、窗口和 Pack 生命周期 |
+
+项目入口是 `Editors/Kitbashing/KitbasherEditor/DependencyInjectionContainer.cs`。它注册 scoped 的主视图/VM、场景创建、保存策略、菜单、节点编辑器和子工具，并在 `RegisterTools` 中声明 Kitbash 编辑器及扩展名优先级。不要绕过该入口在 View 或命令内部创建另一套服务容器。
+
+### 3.2 View3D 组件组成
+
+Kitbash 的 View3D 由两层组成：
+
+1. `View3DCoreComponentSet`：所有 View3D 宿主可复用的核心组件，例如键鼠、相机、场景管理、渲染、网格、动画和灯光。
+2. `KitbashSceneComponentSet`：只属于 Kitbash 的 `KitbashSelectionInputComponent`、`KitbashModelGizmoComponent` 和 `KitbashSelectionOverlayComponent`。
+
+`ComponentInserter` 先确保 `IWpfGame` 已创建，再按顺序插入核心组件和显式给出的编辑器组件。`KitbasherViewModel` 是 Kitbash 专属组件的实际插入入口。
+
+`KitbashSceneComponentSet` 有意手工构造三个专属组件，而不是让它们成为可全局解析的独立服务。这是隔离契约，不是待清理的重复代码。`Testing/AssetEditorTests/View3DComponentIsolationTests.cs` 对以下事实设有门禁：
+
+- 组合器只添加核心组件和调用方显式提供的组件；
+- 参考预览组件不会夹带 Kitbash 编辑组件；
+- 应用容器不全局注册 Kitbash 的三个专属组件或任意 `IGameComponent`。
+
+## 4. 主对象图与状态所有权
+
+| 对象 | 主要职责 | 不应承担的职责 |
+| --- | --- | --- |
+| `KitbasherViewModel` | 编辑器生命周期、加载/保存入口、主 VM 组合、dirty 汇总 | 逐帧拾取、GPU 覆盖层绘制、格式解析细节 |
+| `KitbasherRootScene` | Kitbash 根节点、主 `AnimationPlayer`、骨架查找/变更 | WPF 菜单和保存对话框 |
+| `KitbashSceneCreator` | 从 Pack 文件建立规范场景树和初始保存设置 | 处理用户手势或直接保存输出 |
+| `SelectionManager` | 当前选择模式与选择状态的共享状态机 | 解释 Kitbash 快捷键、绘制 Kitbash 覆盖层 |
+| `KitbashSelectionInputComponent` | Kitbash 鼠标/快捷键、拾取和选择命令 | 变换预览、持久化文件 |
+| `KitbashModelGizmoComponent` | Kitbash Gizmo/模态变换手势编排 | 通用变换数学的第二份实现 |
+| `TransformGizmoWrapper` | 把各类选择包装为可预览、提交、取消的变换目标 | 判断当前编辑器是谁 |
+| `KitbashSelectionOverlayComponent` | Kitbash 各选择模式的可视化 | 修改选择状态或保存数据 |
+| `CommandExecutor` | 撤销/重做、文档状态 ID、命令事件 | 直接决定 UI 是否显示按钮 |
+| `SceneExplorerViewModel` | 场景树与对象选择同步 | 面/边/顶点选择 |
+| `SceneNodeEditorFactory` | 为单个受支持节点创建右侧属性编辑器 | 兜底编辑任意未知节点 |
+| `SaveService` | 验证并按策略写出几何、材质和 LOD | 弹出 WPF 对话框或改动选择 |
+
+必须区分三种状态：
+
+- 场景/模型状态：`KitbasherRootScene` 及其节点、几何、材质、骨架和动画；
+- 交互状态：`SelectionManager`、活动 Gizmo、鼠标所有权、变换预览和覆盖层缓存；
+- 文档状态：`CommandExecutor.CurrentDocumentStateId` 与 `KitbasherViewModel` 保存时记录的状态 ID。
+
+不要用 UI 选中、GPU 预览或树展开状态代替真实模型变更，也不要让纯选择操作把文档错误地标记为已修改。
+
+## 5. 加载与规范场景树
+
+加载入口位于 `KitbasherViewModel`，场景构建由 `KitbashSceneCreator` 完成。核心流程：
+
+1. 根据 Pack 文件类型读取 `.rigid_model_v2`、`.variantmeshdefinition` 或 `.wsmodel`。
+2. `.wsmodel` 先解析其几何引用；`.variantmeshdefinition` 作为参考资产处理，并把默认输出指向 `.rigid_model_v2`。
+3. 建立固定根结构：骨架节点、`MainEditableNode` 和参考模型组。
+4. 将 LOD/网格装入主可编辑节点，初始化主动画播放器。
+5. 依据模型声明解析 `animations\skeletons\<name>.anim` 骨架资源。
+6. 从首个适用的 weighted material 复制附着点，并建立初始输出路径和 LOD 设置。
+7. 加载完成后更新当前文件、显示名、相机焦点和已保存文档状态。
+
+场景树不变量：
+
+- `MainEditableNode` 是可保存模型的权威根；没有可编辑内容时不能伪造成功保存。
+- 参考模型进入独立参考组，默认不可编辑、不可选择，不能混入主输出。
+- 骨架是网格蒙皮、骨骼选择、附着点和动画的共同参考；替换骨架必须通过既有事件和刷新链路传播。
+- 加载器建立的特殊根节点是结构契约，删除/重分组命令必须继续保护它们。
+
+修改加载支持时，同时检查场景树、保存设置初始化、参考/可编辑标记、骨架与动画连接以及对应 round-trip 测试。不能只让文件“能打开”。
+
+## 6. 选择系统
+
+### 6.1 模式与状态
+
+`SelectionManager` 是共享状态机，当前模式为：
+
+- `Object`：场景节点选择；
+- `Face`：网格三角面选择；
+- `Edge`：拓扑边选择；
+- `Vertex`：顶点选择，可带比例编辑权重；
+- `Bone`：骨骼选择。
+
+它发布状态和选择变更事件，并能复制/恢复选择状态。共享状态机不应知道 Kitbash 快捷键或覆盖层样式。
+
+选择/模式命令通常需要撤销，但不属于文档内容变更：它们可以 `IsMutation=true` 进入交互历史，同时必须保持 `AffectsDocument=false`。否则仅点击对象或切换模式就会触发“未保存”。
+
+### 6.2 Kitbash 输入解释
+
+`KitbashSelectionInputComponent` 拥有 Kitbash 语义：
+
+- 左键点选和框选；Shift 添加/切换，Ctrl 移除；
+- 根据当前模式选择对象、面、边、顶点或骨骼；
+- 编辑模式的拾取不得回落成对象拾取；
+- `A` 全选/取消，`Ctrl+I` 反选，`Ctrl+L` 沿拓扑扩展相连元素；
+- `F9` 进入骨骼模式；其他模式切换由 Gizmo 组件配合完成；
+- 拖框期间申请共享鼠标所有权，结束或取消时必须释放；
+- 组件释放时清理临时纹理、事件和鼠标状态。
+
+动画或蒙皮模型的面/边/顶点拾取必须以 `MeshPoseSnapshot` 的当前变形后世界坐标为准；只在静态路径使用 `RenderMatrix`。若拾取仍使用原始顶点，动画播放时视觉位置与命中位置会分离。
+
+### 6.3 场景树选择
+
+`SceneExplorerViewModel` 和 `MultiSelectTreeView` 只同步对象级选择，保留展开、可见性等树状态，并通过 `SceneNodeSelectedEvent` 驱动右侧编辑器。它不承载面/边/顶点选择。
+
+未知节点、多选或空选不应猜测属性编辑器：`SceneNodeEditorFactory` 只为明确支持的 `MainEditableNode`、`Rmv2MeshNode`、`SkeletonNode`、`GroupNode` 建立编辑器；切换目标时释放旧编辑器，重复选择同一节点时复用当前编辑器。
+
+## 7. 变换、撤销与 dirty
+
+### 7.1 变换链
+
+变换链为：
+
+`KitbashModelGizmoComponent` / 数值工具 → `TransformGizmoWrapper` → 预览备份 → 命令提交 → `CommandExecutor`。
+
+`KitbashModelGizmoComponent` 负责：
+
+- 将共享 `Gizmo` 配置为当前选择的 Kitbash 交互；
+- `G/R/S` 模态平移、旋转、缩放；
+- `Tab` 在对象与上次编辑子模式之间切换；数字 `1/2/3` 进入顶点/边/面；
+- Ctrl 吸附、左键确认、右键或 Escape 取消；
+- Toolbar Gizmo 的显示开关与模态变换分离；隐藏 Toolbar Gizmo 不应禁用 `G/R/S`；
+- 选择变化时取消旧手势、释放旧 wrapper、从新选择重建；
+- 开始时取得鼠标所有权，所有成功、取消和异常路径都释放所有权。
+
+### 7.2 预览事务
+
+`TransformGizmoWrapper` 位于共享 View3D，负责对象、顶点、面、边、骨骼的通用变换事务：
+
+1. `Begin` 固定本次目标、选择和比例权重，并捕获 CPU/GPU/动画基线；
+2. Preview 只更新显示状态，不创建多条历史；
+3. Commit 生成一个可撤销命令并释放备份；
+4. Cancel 恢复几何、骨架帧、包围盒和 GPU 显示；
+5. 失败时优先保留首个异常，同时尽量完成恢复和资源释放。
+
+手势中途改变选择、模式、比例权重、宿主生命周期或鼠标所有权，都不能留下半应用状态。不能把“每一帧 preview”当作独立命令，也不能在提交前丢弃基线。
+
+### 7.3 文档状态
+
+`CommandExecutor` 用 `CurrentDocumentStateId` 表示可保存文档内容的历史位置。`KitbasherViewModel` 保存成功后记录该 ID，之后以是否相等判断 dirty。
+
+- 属性、几何、材质、层级、骨骼等真实变更必须通过命令并影响文档状态。
+- 选择、选择模式、相机、焦点、视口着色和纯预览不能影响文档状态。
+- 失败的 Execute/Undo/Redo 不能破坏 undo/redo 栈或伪造新状态。
+- 直接修改模型对象而不经过既有命令体系，会破坏 dirty、撤销和保存一致性；除明确的加载/初始化/预览路径外禁止这样做。
+
+## 8. 渲染与选择覆盖层
+
+`KitbashSelectionOverlayComponent` 是 Kitbash 专属可视化层。当前视觉语义：
+
+| 模式 | 主要覆盖层 | 整体对象橙色轮廓 |
+| --- | --- | --- |
+| Object | RenderEngine 选择轮廓 | 有 |
+| Face | 选中/活动面、线框 | 有 |
+| Edge | 全线框、选中/活动边 | 有 |
+| Vertex | 顶点标记、必要时屏幕空间边/动画线框 | **没有** |
+| Bone | 骨架/骨骼选择显示 | 不由模型整体轮廓替代 |
+
+“顶点模式不显示整个对象橙色轮廓”是明确模式边界，不能为了复用 Face/Edge 分支而恢复。Face 和 Edge 当前仍有整体轮廓，不能把顶点修复扩大到它们。
+
+动画网格的覆盖层必须使用当前 `MeshPoseSnapshot`，保证线框、顶点和实际变形模型一致。静态密集顶点路径使用屏幕空间边实例并设容量上限，优先保留选中顶点；修改此路径要关注：
+
+- 拓扑/位置/矩阵缓存何时失效；
+- 选中与活动元素的颜色、透明度、深度偏移和遮挡关系；
+- GPU buffer、render item、事件订阅和临时实例是否释放；
+- 离屏像素测试与真实 WPF/GPU 视觉验收是否都覆盖。
+
+共享 `RenderEngineComponent`、选择 mask、Effect 参数和 render item 是高扩散面。若问题只出现在 Kitbash 某模式，优先在专属覆盖层修复；只有证明共享渲染契约本身错误，才修改共享层并验证其他 View3D 使用者。
+
+## 9. 界面、菜单与输入焦点
+
+主界面位于 `Core/KitbasherView.xaml`：左侧为菜单、Blender 风格工具栏、View3D、动画条和数值变换浮层；右侧为 Scene Explorer 与节点属性编辑器。布局尺寸、分隔条和样式复用 `KitbashUiStyles.xaml` 及共享 `Ae*` 资源。
+
+输入分两层：
+
+- WPF 菜单/快捷键：`MenuBarView` 挂接宿主窗口，在加载时订阅、卸载时解除；隐藏或非活动标签页不得响应；文本输入控件中的按键不得触发编辑命令。
+- View3D 键鼠：共享输入组件只在渲染焦点有效时读取状态；应用激活变化要清除陈旧按键跃迁；鼠标使用单一所有者协议。
+
+不要为同一快捷键在 View、VM 和 GameComponent 各写一份处理。先确定它属于 WPF 命令还是逐帧 View3D 手势，并保持焦点、文本输入和生命周期门禁。
+
+菜单和工具栏由 `MenuBarViewModel`、`ToolbarBuilder` 及命令类组合。可见性/可用性应来自当前选择模式和选择内容，不要在 XAML 中复制一套业务判断。数值变换仍必须走 `TransformGizmoWrapper` 的 begin/commit/cancel；比例编辑禁用时传递零权重范围，启用时半径不得低于现有最小值；视口着色只改变渲染设置，不得污染文档 dirty。
+
+## 10. 节点属性与材料编辑
+
+右侧节点编辑器是场景树对象属性的编辑入口。稳定约束：
+
+- 属性修改通过 `SceneNodePropertyEditor` 包装共享命令，确保 dirty、撤销和 UI 回读一致；
+- 初始化 ViewModel 时读取值不能产生变更命令；
+- 相同值写回不创建无意义历史；
+- 预览属性（例如阵营颜色）与持久属性要分开；
+- 材质子视图按真实材质类型路由，不建立“万能材质”兜底写入；
+- 骨架、附着点、网格名称、可见性和动画等变化要通知对应显示/保存链路。
+
+新增节点编辑器前先判断该节点是否真能独立编辑。参考组、根节点或未知节点不应因为存在公共属性就自动获得编辑器。
+
+## 11. 保存管线
+
+保存入口由 `SaveCommand`/Save As 命令发起，核心服务位于 `GameWorld/View3D/Services/SceneSaving/`。流程：
+
+1. 首次保存或 Save As 显示 `SaveDialog`；取消必须返回取消结果，不写文件、不清 dirty。
+2. 从 `MainEditableNode` 取得可编辑模型；缺失时保存失败。
+3. 将当前附着点和用户确认后的 LOD 草稿写入 `GeometrySaveSettings`。
+4. `SaveService` 依次执行验证、LOD 策略、几何策略和材质/`.wsmodel` 策略。
+5. 全部成功后发布 `ScopedFileSavedEvent`。
+6. `KitbasherViewModel` 仅在成功事件后更新文件身份和已保存文档状态。
+
+`SaveDialogViewModel` 对 LOD 设置使用草稿：浏览和输入不应立即改动真实场景；只有 Apply/确认才持久化。文件选择使用 `IStandardDialogs`，不要在模块里新增另一套原生对话框调用。
+
+保存相关修改至少要核对：
+
+- 游戏版本与几何格式策略选择；
+- LOD 生成、可见距离、空 LOD 和网格过滤；
+- 材质、贴图、附着点、骨架和 `.wsmodel` 引用；
+- Save/Save As/取消/失败时的文件身份与 dirty；
+- load-save round trip 是否保持格式语义，而不只是成功生成字节。
+
+## 12. 动画、骨架与附着点
+
+`KitbasherRootScene` 持有主 `AnimationPlayer`，其暂停时不做冗余刷新。骨架变化通过 `KitbasherSkeletonChangedEvent` 和 handler 传播到网格、附着点、动画及相关 UI。
+
+修改骨架或动画时必须同时考虑：
+
+- 当前动画 pose 与静态 bind pose；
+- 蒙皮网格拾取、覆盖层和 Gizmo 预览；
+- 骨骼选择/变换的世界空间与父子层级；
+- 附着点的骨骼索引、保存和重新加载；
+- 暂停状态下是否主动刷新显示；
+- 替换骨架后旧订阅、旧 resolver 和旧选择是否失效。
+
+骨骼变换和网格顶点变换共享部分数学/事务设施，但数据恢复路径不同。不要用网格备份替代骨架帧备份，也不要把骨骼命令降为纯视觉预览。
+
+## 13. 子工具
+
+子工具属于 Kitbash 编辑工作流，由 Kitbash DI 作用域创建；它们不是独立的全局模型编辑器。
+
+| 子工具 | 职责 | 关键边界 |
+| --- | --- | --- |
+| BMI Editor | 查看/筛选/修改 bone matrix influence | 必须保持骨骼索引和权重合法 |
+| Mesh Fitter | 骨骼映射、相对缩放和偏移 | 修改必须可撤销并刷新网格显示 |
+| Re-Rigging | 重映射骨骼索引 | 保留 undo，不能静默丢失未映射权重 |
+| Pin Tool | 将网格固定到顶点或执行 skin wrap | 使用现有加速/权重转移算法，不在 UI 线程写第二份算法 |
+| Photo Studio | 相机设置、离屏捕获、导入导出 | 复用 RenderEngine；捕获完成不等于主模型已保存 |
+| Vertex Debugger | 观察选中顶点与诊断数据 | 诊断显示不得修改模型 |
+| Save Dialog | 输出路径、格式、LOD 策略草稿 | 只有确认后改真实保存设置 |
+
+子窗口关闭、编辑器关闭或作用域释放时必须解除事件、释放 GameComponent/GPU 资源并停止持有主场景。不要把子工具注册成跨编辑器单例。
+
+## 14. 修改边界与路由
+
+### 14.1 默认允许在 Kitbash 模块内修改
+
+- Kitbash 专属界面、菜单、快捷键解释和场景树行为；
+- Kitbash 专属选择模式编排、覆盖层和 Gizmo 交互；
+- Kitbash 的加载组合、节点属性编辑和子工具；
+- Kitbash DI 注册及模块测试。
+
+仍需遵守最小修改、命令历史、生命周期和 UI 规范。
+
+### 14.2 修改共享层前必须证明
+
+下列位置可以修改，但必须先证明问题是通用契约而非 Kitbash 特例，并扩大验证：
+
+- `GameWorld/View3D/Components/Selection/SelectionManager.cs`；
+- `GameWorld/View3D/Components/Gizmo/TransformGizmoWrapper.cs`；
+- `GameWorld/View3D/Components/Rendering/` 与 RenderEngine；
+- `GameWorld/View3D/Components/Input/`；
+- `GameWorld/View3D/Services/CommandExecutor.cs`；
+- `GameWorld/View3D/Services/SceneSaving/`；
+- 公共场景节点、动画、数学和 GPU 资源类型。
+
+证明至少回答：其他调用者是谁；行为是否对所有调用者成立；能否在 Kitbash 组合层完成；现有共享测试覆盖什么；需要补哪些隔离/回归测试。
+
+### 14.3 禁止的实现方式
+
+- 在共享组件里判断编辑器类型或新增 Kitbash 模式开关；
+- 全局注册 Kitbash 专属 GameComponent；
+- 让参考/预览编辑器获得对象、网格或骨骼编辑能力；
+- 直接修改模型而绕过命令、dirty 和撤销；
+- 把 GPU preview 当作权威数据或把选择状态当作文件内容；
+- 为修复某一种选择模式而无证据改变其他模式；
+- 在未验证其他 View3D 使用者时改变共享选择、输入、Gizmo 或渲染默认值；
+- 只凭自动渲染测试宣称视觉已经验收。
+
+### 14.4 常见任务路由
+
+| 任务 | 首查入口 | 同时检查 |
+| --- | --- | --- |
+| 选不中/选错元素 | `KitbashSelectionInputComponent` | `SelectionManager`、`MeshPoseSnapshot`、输入焦点 |
+| 变换无法确认/取消 | `KitbashModelGizmoComponent` | `TransformGizmoWrapper`、鼠标所有权、命令历史 |
+| 轮廓/线框/顶点显示错误 | `KitbashSelectionOverlayComponent` | RenderEngine mask、动画 pose、离屏像素测试 |
+| 点击后误报未保存 | 命令的 `AffectsDocument` | `CommandExecutor`、`KitbasherViewModel` 保存状态 ID |
+| 场景树与视口选择不同步 | `SceneExplorerViewModel` | `SelectionManager`、事件发布和多选语义 |
+| 属性无法撤销或不变 dirty | `SceneNodePropertyEditor` | 对应节点 VM、命令事件 |
+| 打开文件内容不完整 | `KitbashSceneCreator` | 文件解析、骨架/动画、参考标记、初始保存设置 |
+| 保存后重开丢数据 | `SaveService` 和策略 | Load/Save round trip、附件/材质/LOD/路径 |
+| 子工具修改不生效 | 对应 `ChildEditors/` | 命令、场景刷新、作用域和关闭清理 |
+| 仅 Kitbash 出现共享 View3D 问题 | 先查 Kitbash 组合层 | 证明后才进入共享层 |
+
+## 15. 验证门禁
+
+验证必须按实际改动选择，不能用一个测试集冒充全部覆盖。
+
+| 改动范围 | 最低自动验证 | 仍需人工/集成验证 |
+| --- | --- | --- |
+| 组件隔离/DI | `View3DComponentIsolationTests`、受影响项目构建 | 打开非 Kitbash View3D，确认无编辑组件泄漏 |
+| 选择/快捷键 | Kitbash 选择与菜单回归测试 | 点选、框选、组合键、文本输入、切换标签 |
+| Gizmo/变换 | `TransformGestureTests`、`TransformUploadTests` | 对象/点/边/面/骨骼的确认、取消、连续手势 |
+| 覆盖层/渲染 | `RenderEngineSelectionMaskOffscreenTests` 及相关 Effect 测试 | 实际 GPU/WPF 视觉检查；逐模式检查 |
+| 节点属性/树 | `SceneNodeEditor*Tests` | 多选、空选、右键菜单、属性面板生命周期 |
+| 加载/保存 | `LoadAndSave/`、SaveDialog 与 round-trip 测试 | 用真实 Pack 文件重开并核对游戏内语义 |
+| 子工具 | 对应 MeshFitter/Pin/ReRigging/PhotoStudio 测试 | 子窗口关闭、主编辑器切换、实际输出 |
+| UI/XAML | 布局/本地化测试、Release 构建 | 实际中文界面、缩放、主题和焦点 |
+
+如果修改了共享 View3D，再运行所有受影响调用者的测试和架构门禁。UI、轮廓、材质或离屏渲染的自动测试只能说明已覆盖的契约；最终外观必须经过本地视觉验收。
+
+## 16. 完成前自检
+
+- 改动是否仍只让 Kitbash 拥有模型编辑能力？
+- 专属行为是否留在 `Editors/Kitbashing/KitbasherEditor/`？
+- 是否保持核心组件与显式编辑器组件的组成方式？
+- 选择、preview、文档 dirty、磁盘输出是否仍是不同状态？
+- 所有成功、取消、异常、关闭路径是否释放鼠标、事件和 GPU 资源？
+- 模型变更是否可撤销，纯选择/相机/视口变化是否不 dirty？
+- 动画 pose 下的拾取、覆盖层和变换是否使用同一显示几何？
+- 保存失败或取消是否保持文件身份与 dirty？
+- 如果改了共享层，是否列出了全部调用者并提供跨编辑器证据？
+- 如果改了 UI/渲染，是否完成实际视觉验证并说明未覆盖风险？

--- a/docs/superview.md
+++ b/docs/superview.md
@@ -1,0 +1,427 @@
+# 超级视图（SuperView）技术上下文
+
+> 面向修改、审查和验收超级视图的 AI。本文记录稳定架构、数据流、元数据预览/编辑原理、所有权边界和验证路由，不替代当前代码。涉及界面时还必须阅读 [`ui-design-system.md`](ui-design-system.md)。
+
+## 1. 阅读触发与事实优先级
+
+出现下列任一范围时，开始工作前完整阅读本文：
+
+- 超级视图、SuperView、Animation META、动画元数据预览；
+- persistent/animation metadata 双页签、Fragment/Slot、预览实例；
+- Impact、Target、Fire、Splash、Effect、Prop、Blood 等空间元数据；
+- 元数据 3D Gizmo、时间范围、骨骼附着、批量显示、聚焦；
+- 计划修改超级视图使用的 `SceneObject`、动画播放器、View3D、Gizmo 或元数据解析共享代码。
+
+事实发生冲突时按以下顺序处理：
+
+1. 当前代码、项目引用和测试；
+2. 本文记录的稳定契约与边界；
+3. 其他仓库文档；
+4. 历史提交、PR、对话和上游实现。
+
+本文只保存不能靠单个类快速重建的所有权、调用链和边界，不记录测试总数、提交 SHA 或机械式方法清单。稳定契约发生变化时同步更新本文。
+
+## 2. 编辑器身份与硬边界
+
+超级视图是动画及其元数据的组合预览、检查和元数据编辑宿主。它负责：
+
+- 选择动画 Fragment/Slot 并加载参考角色模型、骨架和动画；
+- 同时加载 persistent metadata 与当前 animation metadata；
+- 把元数据转换为可随动画更新的模型、标记、线段、形状和动画规则；
+- 提供元数据列表/属性编辑、时间跳转、分类显隐和选中聚焦；
+- 对已验证的空间元数据提供 3D 平移/旋转、撤销/重做和保存；
+- 在引用文件缺失且 Fragment 提供合法目标路径时创建元数据文件。
+
+超级视图不是模型编辑器。硬边界：
+
+- 参考模型和元数据生成的 Prop/标记默认不可被共享模型选择系统编辑。
+- 不得接入 Kitbash 的对象/面/边/顶点/骨骼选择输入、Kitbash 覆盖层或模型变换 wrapper。
+- 超级视图的 3D Gizmo 只写回受支持元数据字段，不修改网格、骨架资源或参考模型层级。
+- 元数据二进制定义、解析和序列化属于共享格式层；不能为超级视图方便而在 UI 层猜测字段布局。
+- 预览失败不应破坏原始元数据，也不应伪造不存在的资源；可降级为明确的通用空间标记或跳过单条规则。
+
+## 3. 模块、注册与宿主组成
+
+### 3.1 主要位置
+
+| 范围 | 位置 | 所有权 |
+| --- | --- | --- |
+| 超级视图 | `Editors/MetaDataEditor/AnimationMeta/SuperView/` | 宿主 VM、预览构建、空间编辑、专属界面 |
+| 元数据编辑器 | `Editors/MetaDataEditor/AnimationMeta/MetaEditor/` | 单份 metadata 文档的列表、字段、解析与保存 UI |
+| AnimationMeta 模块入口 | `Editors/MetaDataEditor/AnimationMeta/DependencyInjectionContainer.cs` | 编辑器和 scoped 服务注册 |
+| 共享编辑器宿主 | `Editors/Shared/Editors.Shared.Core/Common/` | 参考模型、动画选择、播放同步、View3D 宿主 |
+| 共享 View3D | `GameWorld/View3D/` | 场景、相机、渲染、Gizmo 原语和动画容器 |
+| 元数据格式 | `Shared/GameFiles/` 下相关 AnimationMeta 实现 | 定义、解析、未知 payload 保留和序列化 |
+| 模块测试 | `Editors/AnimationMeta/Test.AnimationMeta/` | 元数据编辑、预览、时间、空间 Gizmo 与保存 |
+
+### 3.2 工具注册
+
+`DependencyInjectionContainer.RegisterTools` 注册两类不同入口：
+
+- 超级视图：工具栏入口，没有直接文件扩展名所有权，用户先选择参考动画上下文；
+- Meta Editor：直接打开 `.anm.meta`、`.meta`、`.snd.meta` 等元数据文件。
+
+不要因为两者共用 `MetaDataEditorViewModel` 就把入口合并。直接 Meta Editor 是单文档编辑器；超级视图同时组合两份文档、动画、模型、预览和空间编辑。
+
+### 3.3 View3D 组成
+
+`SuperViewViewModel` 继承 `EditorHostBase`。基类建立共享 `IWpfGame`、核心 View3D 组件、参考模型 VM、动画播放器和场景对象集合；超级视图构造时再显式加入 scoped 的 `CombatMetaDataGizmoComponent`。
+
+超级视图不插入 `KitbashSceneComponentSet`。其专属 Gizmo 使用共享 `Gizmo` 原语，但编辑目标是 `ParsedMetadataAttribute`，不是 `SelectionManager` 中的模型选择。
+
+## 4. 对象与状态所有权
+
+| 对象 | 主要职责 | 状态所有权 |
+| --- | --- | --- |
+| `SuperViewViewModel` | 双文档组合、场景/动画事件、预览重建、保存与 UI 命令 | 当前 Fragment/Slot、活动页签、选中预览、分类显示设置 |
+| `PersistentMetaEditor` | persistent metadata 列表、字段、结构和保存 | 一份独立解析文档及 dirty |
+| `MetaEditor` | animation metadata 列表、字段、结构和保存 | 另一份独立解析文档及 dirty |
+| `SceneObjectViewModel` | 单个参考资产的 UI 状态 | 模型路径、动画选择、阵营/相机等共享预览状态 |
+| `SceneObjectEditor` | 加载模型、骨架、动画和 meta，并发布更新事件 | 当前运行时 `SceneObject` |
+| `SceneObject` | 场景根、主播放器、metadata instances | 每帧调用实例 `Update` |
+| `MetaDataBuilder` | 把两份已解析元数据建立为预览实例与动画规则 | 一次构建结果，不持有文档 dirty |
+| `CombatMetaDataEditSession` | 空间元数据预览事务、撤销/重做、每文档历史 | 以文档 owner 区分的编辑历史 |
+| `CombatMetaDataGizmoComponent` | 3D 手势与 Gizmo/鼠标生命周期 | 当前空间目标和活动 gesture |
+| `SpatialMetaDataCatalog` | 已验证空间标签到可写字段的适配 | 类型能力定义，不持有运行时选择 |
+
+必须区分：
+
+- 原始/解析文档：两个 `MetaDataEditorViewModel` 各自持有；
+- 预览实例：由 `MetaDataBuilder` 从当前文档快照重建，可随时清理；
+- 空间编辑事务：`CombatMetaDataEditSession` 在解析对象上 preview/commit/cancel；
+- 场景参考资源：模型、骨架、动画，只供显示和坐标参考；
+- 文件 dirty：两个子编辑器 dirty 与两个 owner 的空间编辑历史共同汇总。
+
+预览节点、分类显隐、当前播放时间和相机都不是文件内容。解析对象的字段值才是保存来源。
+
+## 5. 双文档模型与 UI 耦合
+
+超级视图在同一个编辑器作用域内手工创建两个独立 `MetaDataEditorViewModel`，而不是从 DI 解析同一个 scoped 实例：
+
+- `PersistentMetaEditor` 对应存活期/持久元数据；
+- `MetaEditor` 对应当前动画元数据。
+
+两者必须保持独立的：
+
+- 文件路径与 `FileOwner`；
+- 解析根和列表选择；
+- dirty、保存结果和结构变更事件；
+- `CombatMetaDataEditSession` owner 历史。
+
+`SuperView/EditorView.xaml` 提供 Persistent 与 Animation 页签，并在引用文件缺失时显示创建提示。
+
+存在一个跨目录但属于超级视图表面的关键耦合：`MetaEditor/View/MetaDataAttributeView.xaml` 通过 `AncestorType=superview:EditorView` 绑定超级视图的批量预览、选中标记、时间跳转、聚焦、3D 编辑、撤销和重做。直接 Meta Editor 没有该祖先，因此超级视图专属控件必须折叠或停用。
+
+修改这些控件时不能只搜索 `SuperView/`；必须同时检查 `MetaDataAttributeView.xaml`、其 code-behind、模板和 `MetaDataAttributeControlTests`。不要让超级视图专属按钮泄漏到直接 Meta Editor。
+
+## 6. 加载与运行时数据流
+
+### 6.1 参考动画加载
+
+共享 `BinAnimationViewModel` 负责 Fragment/Slot 选择：
+
+1. 选择 Fragment 和 Slot；
+2. 确定参考模型、骨架和动画；
+3. 解析当前 animation metadata 引用；
+4. 查找 persistent metadata，优先 `PERSISTENT_METADATA_ALIVE`，必要时使用既有 fallback；
+5. 调用 `SceneObjectEditor` 更新动画和两份 metadata；
+6. 发布 `SceneObjectUpdateEvent`。
+
+超级视图不应自己再写一套 Fragment/Slot 解析逻辑。若游戏数据库或引用语义变化，先修共享参考模型层并验证所有调用者。
+
+### 6.2 更新事件
+
+`SuperViewViewModel` 收到场景对象更新后：
+
+1. 重置/切换两个 owner 的空间编辑历史；
+2. 各自加载 persistent 与 animation metadata 编辑器；
+3. 清理旧的预览实例和动画规则；
+4. 清除已不属于当前源对象的用户预览覆盖设置；
+5. 调用 `MetaDataBuilder.Create(...)`；
+6. 把结果放入 `SceneObject.MetaDataItems`；
+7. 刷新播放器和选择状态，并保持所有参考模型节点不可选择。
+
+构建参数包含两份解析文档、当前选中属性、场景根、骨架、主播放器和 Fragment 上下文。任何缓存都必须以这些实际输入为准，不能只按 tag 名复用。
+
+### 6.3 每帧更新
+
+`SceneObject.Update` 以主播放器的当前秒数调用每个 `IMetaDataInstance.Update(currentTimeSeconds)`。动画 Prop 的附属播放器也必须与主时间同步；主播放器暂停时仍要在显式 seek 后刷新附属 pose。
+
+时间单位是秒。不要在 UI、元数据或动画播放器之间隐式混用微秒、帧序号和秒；只有动画 clip 的 `MicrosecondsPerFrame` 在边界处换算。
+
+## 7. 预览构建原理
+
+### 7.1 合并顺序
+
+`MetaDataBuilder.Create` 先应用 persistent metadata，再应用当前 animation metadata。若 animation metadata 包含格式定义中的 `DisablePersistant_v10`，则跳过 persistent 部分。保留代码中的格式拼写，不要为了文字正确而重命名二进制定义。
+
+两层来源的预览仍保留各自 `ParsedMetadataAttribute` 引用。后续选中、增量替换、批量显隐和保存都依赖对象身份，不应按字段值或 tag 文本猜来源。
+
+### 7.2 支持的输出
+
+构建器可产生三类运行时结果：
+
+1. 场景实例：普通 Prop、Animated Prop、Effect、战斗定位器和通用空间标记；
+2. 动画规则：Dock Equipment、Transform Bone、根变换复制等；
+3. 预览描述：来源、分类、世界变换、参考变换、焦点位置、时间范围、选中和显隐。
+
+战斗预览分类为 `Impact`、`Target`、`Fire`、`Splash`。每个实例都有独立显隐，不应通过隐藏整个模型实现分类筛选。
+
+### 7.3 资源失败隔离
+
+每个 tag 预览通过独立的容错边界创建：
+
+- 某个 Prop 模型或动画缺失时，记录警告，并在空间信息可用时降级为通用标记；
+- 某条 Dock 动画规则缺失时，只跳过该规则；
+- 某个 Splash 参数无效时，不能阻止其他合法定位器建立；
+- 未知或不支持的 tag 保留在解析文档中，不因无法预览而删除或改写；
+- 不能凭空生成一个“看起来合理”的资源或坐标掩盖数据缺失。
+
+资源失败策略的目标是保留可编辑文档与其余预览，而不是把整个构建标记为成功无误。UI/日志仍应让用户知道缺失项。
+
+### 7.4 增量刷新
+
+字段编辑后，超级视图优先尝试只重建受影响的一个预览：
+
+- 构建器能为该源创建替代实例时，保留其他实例和它们的 UI 状态；
+- 不支持增量创建、结构变更或影响动画规则时，回退到完整重建；
+- 选择变化只更新 `IsSelected` 和高亮，不应无条件重建全部预览；
+- 识别“同一预览”使用 `ParsedMetadataAttribute` 引用身份，不使用值相等。
+
+替换实例时先完成新实例建立，再有序清理旧实例；失败不能让源属性从列表消失。
+
+## 8. 预览实例生命周期
+
+所有预览实例实现 `IMetaDataInstance`，至少提供 `Update` 和 `CleanUp`。主要类型：
+
+| 类型 | 行为 | 清理责任 |
+| --- | --- | --- |
+| `DrawableMetaInstance` | 位置/方向标记，可跟随骨骼，可有时间范围 | 从父节点移除标记 |
+| `CombatMetaDataInstance` | 战斗分类标记，使用实时位置与参考变换 | 从父节点移除节点 |
+| `PropInstance` | 普通模型 Prop，按骨骼/根附着 | 移除节点并标记附属 player 删除 |
+| `AnimatedPropInstance` | 自带动画的 Prop，与主时间同步/循环 | 移除节点并标记附属 player 删除 |
+
+`ReferenceWorldTransform` 表示元数据局部值所依附的骨骼/父节点世界变换；`WorldTransform` 是局部位置/方向乘以该参考变换。3D 编辑和聚焦依赖这一分层，不能把二者合并成一个永久写回的世界矩阵。
+
+实例可同时受三种可见性条件控制：
+
+- `IsEnabled`：分类或用户开关；
+- 当前时间是否落在 authored range；
+- `ShowForEntireAnimation`：用户临时覆盖。
+
+`IsSelected` 只控制视觉强调，例如 preview outline，不等于共享场景对象选择。清理时必须移除节点、附属 animation player、选择高亮和事件引用，避免每次 rebuild 叠加实例。
+
+## 9. 时间语义
+
+`MetaDataTimeRange` 集中处理时间范围：
+
+- 从 v2/v10 的时间基类读取 start/end；
+- 使用小容差比较边界；
+- 普通范围在 start 到 end 内可见；
+- Instant 类型可用至少一帧的显示窗口，避免 `(0,0)` 完全不可见；
+- 只有明确列入 allowlist 的状态类 tag，`(0,0)` 才表示整段动画；
+- Prop 等既有格式语义可显式使用 `WholeAnimation` 零范围行为。
+
+不要建立“所有 `(0,0)` 都显示整段”的通用规则。这会让瞬时战斗事件错误地整段显示。新增 tag 时必须根据格式/游戏证据选择零范围语义并补测试。
+
+跳转到开始/结束、选中时间范围显示和实例更新必须使用同一秒数定义。播放条 seek 后既要更新主 pose，也要更新附属 Prop pose和时间可见性。
+
+## 10. 空间元数据能力目录
+
+`SpatialMetaDataCatalog` 是“哪些字段可由 3D Gizmo 安全编辑”的白名单适配层。当前覆盖 Effect、Prop、Blood、CameraShake、CrewLocation、SoundTrigger、SoundBuilding、Transform 等已验证类型，并为每类提供：
+
+- 位置 getter/setter；
+- 可选的方向 getter/setter；
+- 骨骼或根附着信息；
+- 是否使用通用空间标记；
+- 是否允许旋转。
+
+目录通过 `MetaDataTagAttribute` 识别可写的公开属性，但反射不是“任意字段都可编辑”的许可。只有显式适配并有格式证据的类型才能暴露 Gizmo。
+
+新增空间类型时必须证明：
+
+- 存储坐标是相对根、相对骨骼还是世界空间；
+- 位置/方向字段是否可写，四元数约定是否一致；
+- 是否需要可视标记、时间范围和骨骼高亮；
+- 直接字段编辑、Gizmo preview、undo/redo、保存/重载是否一致；
+- 未验证类型仍保持不可写，而不是猜测最相似的字段。
+
+## 11. 3D 元数据编辑
+
+### 11.1 与 Kitbash 变换的区别
+
+`CombatMetaDataEditSession` 不使用 Kitbash 的共享模型选择和 `TransformGizmoWrapper`。它为每个文档 owner 维护自己的命令历史，直接对 `ParsedMetadataAttribute` 的已适配空间字段执行事务。
+
+`CombatMetaDataGizmoComponent` 只提供 translate/rotate，默认以局部参考系显示；它不提供缩放，不选取网格，不改变模型节点。
+
+### 11.2 Gesture 事务
+
+空间编辑流程：
+
+1. 根据活动页签和选中属性确定 owner 与目标；
+2. 由预览取得 `ReferenceWorldTransform` 和当前世界 pose；
+3. `BeginGesture` 记录字段基线；
+4. 平移把世界 delta 转回元数据局部空间；
+5. 旋转用参考旋转的共轭关系把世界旋转转回局部方向；
+6. Preview 修改解析对象并发布预览刷新，不写入历史；
+7. Commit 建立一条可 redo 的命令；Cancel 恢复原值；
+8. 结束、禁用、选中变化或异常时释放鼠标所有权并清理目标。
+
+Splash 的 start/end 是两个独立控制点；不能把它们压成一个中心点。Effect 和其他骨骼跟随类型必须基于实时骨骼 frame 转换，不能把当前世界位置直接永久写回局部字段。
+
+### 11.3 历史与 dirty
+
+Edit Session 以 owner 的引用身份隔离历史。Persistent 与 Animation 页签的 Undo/Redo、saved state 和 dirty 互不串联。
+
+超级视图总 dirty 为：
+
+- 任一 `MetaDataEditorViewModel` 有未保存结构/字段变化；或
+- 任一 owner 的空间编辑历史偏离其 saved state。
+
+保存成功后才标记对应历史为 saved。切换 Fragment/Slot、重建预览或选择属性不能误清另一份文档的 dirty，也不能把 preview 手势当作已保存。
+
+## 12. 选择、显示和聚焦
+
+超级视图存在的是“元数据属性选择”，不是“模型选择”：
+
+- Meta 列表选中 `ParsedMetadataAttribute`；
+- 通过引用身份找到对应 `IMetaDataPreview`；
+- 设置其 `IsSelected`，更新高亮、时间信息和 3D Gizmo 目标；
+- 聚焦使用预览的 `FocusPosition`；
+- 需要时用 `HighlightedBoneIndex` 指示附着骨骼。
+
+参考模型节点和 Prop 节点保持 `IsSelectable=false`。选中预览可使用专用 preview outline，但不得写入共享 `SelectionManager` 或触发 Kitbash 整体选择语义。
+
+批量显示覆盖只应用于当前 animation metadata 来源的对应分类，不应修改 persistent metadata 的预览。用户覆盖按源对象身份跟踪；完整重建后应剔除已不存在的源，保留仍存在源的设置。
+
+## 13. 保存与文件所有权
+
+超级视图可以同时持有两份文件。保存流程必须分别处理：
+
+1. 已加载的 Persistent 文档；
+2. 已加载的 Animation 文档；
+3. 对应 owner 的空间编辑历史。
+
+若某份文件没有加载，不应因此让另一份保存失败。若引用文件缺失，只有 Fragment 提供明确目标路径时，创建按钮才可建立空的受支持 metadata 文件。
+
+`ScopedFileSavedEvent.FileOwner` 用于判断是哪一个子编辑器完成保存，并更新 `SceneObject` 中正确的 metadata 引用。未知 owner 是编程错误，应暴露，而不是猜成当前页签。
+
+只有两个需要保存的子操作都成功时，宿主才能把对应编辑历史标记为 saved。取消、解析失败、路径失败或部分保存不能清除仍未持久化的 dirty。
+
+保存/重载验证必须确认：
+
+- 位置与方向局部值没有被错误写成世界坐标；
+- 未知 metadata payload 原样保留；
+- tag 顺序、多选移动/删除和无效输入处理保持现有语义；
+- 双文件路径和 owner 没有交换；
+- 新建文件使用正确版本和引用路径。
+
+## 14. 动画规则
+
+预览构建器可把部分 metadata 转成运行时动画规则：
+
+- `CopyRootTransform`：把指定骨骼的动画世界变换及 authored offset 应用到附属对象根；
+- `DockEquipmentRule`：在活动时间内，把装备槽骨骼对齐到目标骨骼；
+- `TransformBoneRule`：在活动时间内对指定骨骼应用 authored 位置/方向增量。
+
+这些规则改变预览 pose，不直接改写原始动画文件。规则创建失败应只隔离单条规则；旧规则在 rebuild 时必须从播放器移除，不能累计执行。
+
+修改规则时同时检查：局部/世界空间接口、时间单位、骨骼索引、父子层级、循环/暂停刷新和错误后的停用行为。不能把预览规则的结果烘焙回模型或动画资源，除非另有明确功能授权。
+
+## 15. 生命周期与清理
+
+`SuperViewViewModel.Close` 和重新加载路径必须解除：
+
+- Fragment/Slot 与 `SceneObjectUpdateEvent` 订阅；
+- 主播放器和两个 Meta Editor 的属性/结构事件；
+- `CombatMetaDataEditSession` 事件；
+- EventHub 注册；
+- 当前 Gizmo gesture 与鼠标所有权；
+- 所有 metadata instances、附属 players、场景节点和动画规则。
+
+重新构建预览是高频生命周期，不等于关闭编辑器。每次 rebuild 都必须先有序清理旧结果，同时保留真正属于文档或用户覆盖的状态。不要依赖 GC 清理场景节点、GPU 资源或事件订阅。
+
+## 16. 修改边界与路由
+
+### 16.1 默认允许在 AnimationMeta/SuperView 内修改
+
+- 超级视图宿主、双文档协调和专属界面；
+- 元数据预览构建、实例、分类、时间和空间能力适配；
+- 元数据 3D Edit Session/Gizmo；
+- 超级视图专属测试和本地化。
+
+若改 `MetaDataAttributeView.xaml`，必须保持直接 Meta Editor 与超级视图的条件化边界。
+
+### 16.2 修改共享层前必须证明
+
+下列位置可以修改，但影响面更大：
+
+- `Editors/Shared/Editors.Shared.Core/Common/SceneObject*`；
+- `BinAnimationViewModel`、`AnimationPlayerViewModel`、`EditorHostBase`；
+- `GameWorld/View3D` 的 SceneManager、RenderEngine、Gizmo、动画容器和输入；
+- `Shared/GameFiles` 中 AnimationMeta 定义、解析和序列化；
+- 共享 Meta Editor 列表、字段控件和保存逻辑。
+
+修改前必须列出其他调用者，证明行为是共享事实，说明能否在超级视图适配层解决，并运行相应跨编辑器/格式测试。
+
+### 16.3 禁止的实现方式
+
+- 给超级视图接入 Kitbash 专属组件或模型编辑命令；
+- 让参考模型、Prop 或 marker 进入共享模型选择并可编辑；
+- 在共享 View3D 中增加 `IsSuperView`、编辑器类型判断或超级视图默认值；
+- 把 preview node/world matrix 当作持久数据源；
+- 根据 tag 名或值相等代替 `ParsedMetadataAttribute` 引用身份；
+- 把两份 Meta Editor 合并成同一个 scoped 文档实例或共用一条历史；
+- 将所有 `(0,0)` 时间范围解释为全动画；
+- 遇到缺失资源时删除 tag、修改源数据或虚构替代资源；
+- 为支持未知空间类型而反射写入未验证字段；
+- 保存部分失败后清除全部 dirty；
+- 只凭预览测试宣称 WPF/GPU 界面已视觉验收。
+
+### 16.4 常见任务路由
+
+| 任务 | 首查入口 | 同时检查 |
+| --- | --- | --- |
+| 切动画后预览没更新 | `SuperViewViewModel` 的场景更新链 | `BinAnimationViewModel`、`SceneObjectEditor`、事件订阅 |
+| persistent/animation 内容串线 | 两个 Meta Editor 的创建与 `FileOwner` | 活动页签、Edit Session owner、保存事件 |
+| 某 tag 没有可视化 | `MetaDataBuilder` | 资源路径、类型定义、fallback、单条异常日志 |
+| 选中 tag 后高亮/聚焦错误 | 预览引用身份和 `FocusPosition` | 活动页签、preview outline、骨骼参考变换 |
+| 时间显示不对 | `MetaDataTimeRange` | 秒/微秒换算、零范围策略、播放器 seek |
+| Gizmo 移动方向/保存坐标错误 | `CombatMetaDataEditSession` | `ReferenceWorldTransform`、局部/世界转换、骨骼 frame |
+| Undo/dirty 串到另一页签 | owner 历史映射 | 子编辑器 dirty、saved state、引用身份 |
+| 修改后全部预览闪烁/重建 | 增量 `TryCreateMetaDataPreview` | 结构/规则 fallback、旧实例清理 |
+| 缺失 Prop 导致整个视图失败 | 构建器资源隔离 | 通用 marker fallback、日志、其他实例保留 |
+| 超级视图按钮出现在直接 Meta Editor | `MetaDataAttributeView.xaml` 祖先绑定 | Visibility 条件、控件测试 |
+| 模型能被点选或编辑 | 场景节点 `IsSelectable` | 是否误插入共享/Kitbash 选择组件 |
+| 关闭/切换后重复预览 | instances/rules cleanup | 附属 player、事件、Gizmo 和鼠标所有权 |
+
+## 17. 验证门禁
+
+| 改动范围 | 最低自动验证 | 仍需人工/集成验证 |
+| --- | --- | --- |
+| 双文档、保存、dirty | `MetaDataEditorViewModelTests`、`MetaDataEditorMultiSelectTests` | 两页签修改、部分缺失、保存/重开 |
+| 空间 Gizmo | `CombatMetaDataEditSessionTests`、`SpatialMetaDataCatalogTests` | 根/骨骼附着、平移/旋转、取消/撤销/重做 |
+| 预览构建/资源失败 | `MetaDataBuilderMissingResourceTests` | 真实 Fragment、模型、动画和日志表现 |
+| 时间与同步 | `MetaDataPreviewTimeTests` | 播放/暂停/seek/循环、瞬时 tag 与整段 tag |
+| 字段 UI/批量控制 | `MetaDataAttributeControlTests` | 两页签、直接 Meta Editor、中文 UI 和焦点 |
+| 格式解析 | `MetaDataFileParserTests` 及格式项目测试 | 真实文件 round trip、未知 payload |
+| View3D 隔离 | `View3DComponentIsolationTests` | 确认模型不可选择、无 Kitbash 编辑工具泄漏 |
+| XAML/视觉 | 受影响项目构建和布局/本地化测试 | 实际 WPF 主题、缩放、marker、Gizmo 和遮挡 |
+
+若修改共享动画播放器、SceneObject、Gizmo、RenderEngine 或格式层，必须补跑所有受影响调用者的测试。自动测试不能替代本地 WPF/GPU 视觉检查。
+
+## 18. 完成前自检
+
+- 超级视图是否仍只编辑 metadata，不编辑模型/动画资源？
+- Persistent 与 Animation 是否仍是独立文档、独立 owner、独立历史？
+- 参考模型和 Prop 是否保持不可由模型选择系统编辑？
+- 预览是否由解析文档生成，而不是反向成为保存源？
+- 局部值、骨骼参考变换与世界显示矩阵是否仍正确分层？
+- `(0,0)` 是否按明确 tag 语义处理，而非全局猜测？
+- 缺失/无效资源是否只隔离单项并保留原始 tag？
+- 增量刷新是否保留无关实例，完整重建是否清理旧实例与规则？
+- 所有 gesture、切换、异常和 Close 路径是否释放鼠标、事件、节点和 player？
+- 保存失败或部分成功是否保留正确 dirty 与文件 owner？
+- 超级视图专属 UI 是否仍只在超级视图祖先下出现？
+- 如果改了共享层，是否提供了跨编辑器/格式证据？
+- 如果改了 UI/预览，是否完成实际视觉验证并说明未覆盖风险？


### PR DESCRIPTION
## Summary

- Add task-routed technical context for KitbashEditor and SuperView.
- Document ownership, module boundaries, data flows, lifecycle rules, persistence semantics, and validation gates.
- Update AGENTS.md and docs/README.md to require and route these domain documents.
- Remove outdated Kitbash-specific architecture rules from AGENTS.md now covered by the dedicated context.

## Testing

- Not run (documentation-only changes).