### PR TITLE
外部 glTF 1/8：为现有回导增加原子导入和冲突保护

### DIFF
--- a/AssetEditor/Language_Cn.json
+++ b/AssetEditor/Language_Cn.json
@@ -873,6 +873,8 @@
   "ImportWindow.WarningHeading": "警告",
   "ImportWindow.ErrorHeading": "失败原因",
   "ImportWindow.NoOutputs": "导入完成，但没有生成资源。",
+  "GltfImporter.TargetConflict": "目标 Pack 已存在资源：{0}",
+  "GltfImporter.DuplicateTarget": "导入内容包含重复目标：{0}",
 
   "ExportWindow.Title": "导出",
   "ExportWindow.SystemPath": "系统路径",

--- a/AssetEditor/Language_Cn.json
+++ b/AssetEditor/Language_Cn.json
@@ -867,6 +867,12 @@
   "ImportWindow.GltfHint": "支持 .gltf 与 .glb。蒙皮模型需包含 //skeleton//骨架名 节点；优先复用已加载的同名游戏骨架，缺失时自动创建。",
   "ImportWindow.ProgressTitle": "正在导入 glTF/GLB",
   "ImportWindow.ProgressStatus": "正在验证场景并转换网格、材质与动画…",
+  "ImportWindow.SuccessTitle": "导入完成",
+  "ImportWindow.FailureTitle": "导入失败",
+  "ImportWindow.OutputPathsHeading": "已写入资源",
+  "ImportWindow.WarningHeading": "警告",
+  "ImportWindow.ErrorHeading": "失败原因",
+  "ImportWindow.NoOutputs": "导入完成，但没有生成资源。",
 
   "ExportWindow.Title": "导出",
   "ExportWindow.SystemPath": "系统路径",

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/ImportResult.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/ImportResult.cs
@@ -1,0 +1,21 @@
+﻿namespace Editors.ImportExport.Importing;
+
+public sealed record ImportResult(
+    bool Succeeded,
+    IReadOnlyList<string> OutputPaths,
+    IReadOnlyList<string> Warnings,
+    IReadOnlyList<string> Errors,
+    Exception? Exception = null)
+{
+    public static ImportResult Success(
+        IReadOnlyList<string> outputPaths,
+        IReadOnlyList<string>? warnings = null) =>
+        new(true, outputPaths, warnings ?? [], []);
+
+    public static ImportResult Failure(Exception exception) =>
+        new(false, [], [], [exception.Message], exception);
+
+    public static ImportResult Failure(
+        IReadOnlyList<string> errors) =>
+        new(false, [], [], errors);
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporter.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporter.cs
@@ -206,17 +206,19 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
             if (validation.Errors.Count != 0)
                 return ImportResult.Failure(validation.Errors);
 
-            if (pendingFiles.Count != 0)
+            if (validation.Files.Count != 0)
             {
                 var conflicts = PackFileDispatcherWriter.AddFilesToPackIfNoConflicts(
                     _packFileService,
                     settings.DestinationPackFileContainer,
-                    pendingFiles,
+                    validation.Files,
                     validation.Paths);
                 if (conflicts.Count != 0)
                 {
                     return ImportResult.Failure(conflicts
-                        .Select(path => $"目标 Pack 已存在资源：{path}")
+                        .Select(path => LocalizationManager.Instance.GetFormat(
+                            "GltfImporter.TargetConflict",
+                            path))
                         .ToList());
                 }
             }
@@ -283,16 +285,33 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
 
         private static string GetImportedPackFileName(GltfImporterSettings settings) => Path.GetFileNameWithoutExtension(settings.InputGltfFile) + ".rigid_model_v2";
 
-        private static (IReadOnlyList<string> Paths, IReadOnlyList<string> Errors)
+        private static (
+            List<NewPackFileEntry> Files,
+            IReadOnlyList<string> Paths,
+            IReadOnlyList<string> Errors)
             ValidatePendingFiles(
                 IReadOnlyList<NewPackFileEntry> pendingFiles)
         {
-            var paths = pendingFiles
-                .Select(entry => FolderProjectPathPolicy.EnsureResourcePath(
-                    Path.Combine(
-                        entry.DirectoyPath ?? "",
-                        entry.PackFile.Name.Trim())))
-                .Select(path => path.ToLowerInvariant())
+            var normalizedFiles = pendingFiles
+                .Select(entry =>
+                {
+                    var path = FolderProjectPathPolicy.EnsureResourcePath(
+                        Path.Combine(
+                            (entry.DirectoyPath ?? "").Trim(),
+                            entry.PackFile.Name.Trim()))
+                        .ToLowerInvariant();
+                    var file = new PackFile(
+                        Path.GetFileName(path),
+                        entry.PackFile.DataSource);
+                    return new NewPackFileEntry(
+                        Path.GetDirectoryName(path) ?? "",
+                        file);
+                })
+                .ToList();
+            var paths = normalizedFiles
+                .Select(entry => Path.Combine(
+                    entry.DirectoyPath,
+                    entry.PackFile.Name))
                 .ToList();
             var duplicatePaths = paths
                 .GroupBy(path => path, StringComparer.OrdinalIgnoreCase)
@@ -301,9 +320,11 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
                 .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
                 .ToList();
             var errors = duplicatePaths
-                .Select(path => $"导入内容包含重复目标：{path}")
+                .Select(path => LocalizationManager.Instance.GetFormat(
+                    "GltfImporter.DuplicateTarget",
+                    path))
                 .ToList();
-            return (paths, errors);
+            return (normalizedFiles, paths, errors);
         }
 
         private static string FetchSkeletonIdStringFromScene(ModelRoot modelRoot)

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporter.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporter.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using Editors.ImportExport.Importing;
 using Editors.ImportExport.Importing.Importers.GltfToRmv.Helper;
 using Editors.ImportExport.Misc;
 using Editors.Shared.Core.Services;
@@ -9,6 +10,7 @@ using Serilog;
 using Shared.Core.ErrorHandling;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
+using Shared.Core.PackFiles.Utility;
 using Shared.Core.Services;
 using Shared.GameFormats.Animation;
 using Shared.GameFormats.RigidModel;
@@ -51,33 +53,37 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
             return rmv2File;
         }
 
-        private void SaveRmvFileToPack(GltfImporterSettings settings, string importedFileName, RmvFile rmv2File)
+        private static NewPackFileEntry CreateRmvEntry(
+            GltfImporterSettings settings,
+            string importedFileName,
+            RmvFile rmv2File)
         {
             var bytesRmv2 = ModelFactory.Create().Save(rmv2File);
 
             var packFileImported = new PackFile(importedFileName, new MemorySource(bytesRmv2));
-            var newFile = new NewPackFileEntry(settings.DestinationPackPath, packFileImported);
-
-            PackFileDispatcherWriter.AddFilesToPack(
-                _packFileService,
-                settings.DestinationPackFileContainer,
-                [newFile]);
+            return new NewPackFileEntry(settings.DestinationPackPath, packFileImported);
         }
 
-        private void ImportMaterials(GltfImporterSettings settings, ModelRoot modelRoot, RmvFile rmv2File)
-        {
+        private IReadOnlyList<NewPackFileEntry> ImportMaterials(
+            GltfImporterSettings settings,
+            ModelRoot modelRoot,
+            RmvFile rmv2File) =>
             _materialBuilder.BuildRmvFileMaterials(settings, modelRoot, rmv2File);
-        }
 
-        private void ImportAnimations(GltfImporterSettings settings, ModelRoot modelRoot, AnimationFile? skeletonAnimFile, string skeletonName)
+        private static IReadOnlyList<NewPackFileEntry> ImportAnimations(
+            GltfImporterSettings settings,
+            ModelRoot modelRoot,
+            AnimationFile? skeletonAnimFile,
+            string skeletonName)
         {
             if (modelRoot.LogicalAnimations.Count == 0)
-                return;
+                return [];
             if (skeletonAnimFile == null)
                 throw new InvalidDataException("glTF 包含动画，但未能确定对应的游戏骨架，已停止导入以避免生成损坏的 ANIM 文件。");
 
             var baseFileName = Path.GetFileNameWithoutExtension(settings.InputGltfFile);
             var usedFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var animationEntries = new List<NewPackFileEntry>();
             for (var animationIndex = 0; animationIndex < modelRoot.LogicalAnimations.Count; animationIndex++)
             {
                 var animation = modelRoot.LogicalAnimations[animationIndex];
@@ -98,12 +104,12 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
                 var importedFileName = GetUniqueFileName(candidateFileName, usedFileNames);
                 var animBytes = AnimationFile.ConvertToBytes(animFile);
                 var packFileImported = new PackFile(importedFileName, new MemorySource(animBytes));
-                var newFile = new NewPackFileEntry(settings.DestinationPackPath, packFileImported);
-                PackFileDispatcherWriter.AddFilesToPack(
-                    _packFileService,
-                    settings.DestinationPackFileContainer,
-                    [newFile]);
+                animationEntries.Add(new NewPackFileEntry(
+                    settings.DestinationPackPath,
+                    packFileImported));
             }
+
+            return animationEntries;
         }
 
         private static string GetUniqueFileName(string candidate, HashSet<string> usedFileNames)
@@ -132,11 +138,25 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
             return name.Replace(' ', '_');
         }
 
-        public bool Import(GltfImporterSettings settings)
+        public ImportResult Import(GltfImporterSettings settings)
+        {
+            try
+            {
+                return ImportCore(settings);
+            }
+            catch (Exception exception)
+            {
+                _logger.Error(exception, "Failed to import glTF file {InputFile}", settings.InputGltfFile);
+                return ImportResult.Failure(exception);
+            }
+        }
+
+        private ImportResult ImportCore(GltfImporterSettings settings)
         {
             var modelRoot = CreateModelRoot(settings);
 
             var skeletonData = GetSkeletonData(modelRoot);
+            var pendingFiles = new List<NewPackFileEntry>();
 
             if (settings.ImportAnimations && modelRoot.LogicalAnimations.Count > 0 && skeletonData.skeletonAnimFile == null)
                 throw new InvalidDataException("导入 glTF 动画需要有效的游戏骨架标识和已加载的 CA Pack 文件。");
@@ -144,7 +164,11 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
             if (skeletonData.wasCreated &&
                 skeletonData.skeletonAnimFile != null &&
                 (settings.ImportMeshes || settings.ImportAnimations))
-                SaveSkeletonToPack(skeletonData.skeletonName!, skeletonData.skeletonAnimFile, settings);
+            {
+                pendingFiles.Add(CreateSkeletonEntry(
+                    skeletonData.skeletonName!,
+                    skeletonData.skeletonAnimFile));
+            }
 
             RmvFile? rmv2File = null;
             if (settings.ImportMeshes || settings.ImportMaterials)
@@ -158,16 +182,46 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
                     throw new InvalidDataException("glTF 场景中没有可导入的网格。");
 
                 if (settings.ImportMaterials)
-                    ImportMaterials(settings, modelRoot, rmv2File);
+                    pendingFiles.AddRange(ImportMaterials(settings, modelRoot, rmv2File));
             }
 
             if (settings.ImportAnimations)
-                ImportAnimations(settings, modelRoot, skeletonData.skeletonAnimFile, skeletonData.skeletonName ?? "");
+            {
+                pendingFiles.AddRange(ImportAnimations(
+                    settings,
+                    modelRoot,
+                    skeletonData.skeletonAnimFile,
+                    skeletonData.skeletonName ?? ""));
+            }
 
             if (settings.ImportMeshes && rmv2File != null)
-                SaveRmvFileToPack(settings, GetImportedPackFileName(settings), rmv2File);
+            {
+                pendingFiles.Add(CreateRmvEntry(
+                    settings,
+                    GetImportedPackFileName(settings),
+                    rmv2File));
+            }
 
-            return true;
+            var validation = ValidatePendingFiles(pendingFiles);
+            if (validation.Errors.Count != 0)
+                return ImportResult.Failure(validation.Errors);
+
+            if (pendingFiles.Count != 0)
+            {
+                var conflicts = PackFileDispatcherWriter.AddFilesToPackIfNoConflicts(
+                    _packFileService,
+                    settings.DestinationPackFileContainer,
+                    pendingFiles,
+                    validation.Paths);
+                if (conflicts.Count != 0)
+                {
+                    return ImportResult.Failure(conflicts
+                        .Select(path => $"目标 Pack 已存在资源：{path}")
+                        .ToList());
+                }
+            }
+
+            return ImportResult.Success(validation.Paths);
         }
 
         private static ModelRoot CreateModelRoot(GltfImporterSettings settings)
@@ -216,22 +270,41 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv
                 $"找不到游戏骨架“{skeletonName}”，且 glTF 不包含可用于创建骨架的蒙皮数据。");
         }
 
-        private void SaveSkeletonToPack(
+        private static NewPackFileEntry CreateSkeletonEntry(
             string skeletonName,
-            AnimationFile skeleton,
-            GltfImporterSettings settings)
+            AnimationFile skeleton)
         {
             var fileName = Path.GetFileNameWithoutExtension(skeletonName) + ".anim";
             var packFile = new PackFile(
                 fileName,
                 new MemorySource(AnimationFile.ConvertToBytes(skeleton)));
-            PackFileDispatcherWriter.AddFilesToPack(
-                _packFileService,
-                settings.DestinationPackFileContainer,
-                [new NewPackFileEntry(@"animations\skeletons", packFile)]);
+            return new NewPackFileEntry(@"animations\skeletons", packFile);
         }
 
         private static string GetImportedPackFileName(GltfImporterSettings settings) => Path.GetFileNameWithoutExtension(settings.InputGltfFile) + ".rigid_model_v2";
+
+        private static (IReadOnlyList<string> Paths, IReadOnlyList<string> Errors)
+            ValidatePendingFiles(
+                IReadOnlyList<NewPackFileEntry> pendingFiles)
+        {
+            var paths = pendingFiles
+                .Select(entry => FolderProjectPathPolicy.EnsureResourcePath(
+                    Path.Combine(
+                        entry.DirectoyPath ?? "",
+                        entry.PackFile.Name.Trim())))
+                .Select(path => path.ToLowerInvariant())
+                .ToList();
+            var duplicatePaths = paths
+                .GroupBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .Where(group => group.Count() > 1)
+                .Select(group => group.Key)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            var errors = duplicatePaths
+                .Select(path => $"导入内容包含重复目标：{path}")
+                .ToList();
+            return (paths, errors);
+        }
 
         private static string FetchSkeletonIdStringFromScene(ModelRoot modelRoot)
         {

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/PackFileDispatcherWriter.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/PackFileDispatcherWriter.cs
@@ -1,4 +1,4 @@
-using System.Windows;
+﻿using System.Windows;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
 
@@ -6,20 +6,36 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper;
 
 internal static class PackFileDispatcherWriter
 {
-    public static void AddFilesToPack(
+    public static IReadOnlyList<string> AddFilesToPackIfNoConflicts(
         IPackFileService packFileService,
         PackFileContainer container,
-        List<NewPackFileEntry> files)
+        List<NewPackFileEntry> files,
+        IReadOnlyList<string> targetPaths)
     {
-        var dispatcher = Application.Current?.Dispatcher;
-        if (dispatcher == null || dispatcher.CheckAccess())
+        IReadOnlyList<string> AddFiles()
         {
-            packFileService.AddFilesToPack(container, files);
-            return;
+            var existingPaths = container.FileList.Keys
+                .Select(path => path.Replace('/', '\\').Trim())
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var conflicts = targetPaths
+                .Where(existingPaths.Contains)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (conflicts.Count != 0)
+                return conflicts;
+
+            packFileService.AddFilesToPack(
+                container,
+                files,
+                overwriteExisting: false);
+            return [];
         }
 
-        dispatcher.Invoke(() => packFileService.AddFilesToPack(
-            container,
-            files));
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher == null || dispatcher.CheckAccess())
+            return AddFiles();
+
+        return dispatcher.Invoke(AddFiles);
     }
 }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/PackFileDispatcherWriter.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/PackFileDispatcherWriter.cs
@@ -25,11 +25,18 @@ internal static class PackFileDispatcherWriter
             if (conflicts.Count != 0)
                 return conflicts;
 
-            packFileService.AddFilesToPack(
-                container,
-                files,
-                overwriteExisting: false);
-            return [];
+            try
+            {
+                packFileService.AddFilesToPack(
+                    container,
+                    files,
+                    overwriteExisting: false);
+                return [];
+            }
+            catch (FolderProjectFileConflictException exception)
+            {
+                return exception.Paths;
+            }
         }
 
         var dispatcher = Application.Current?.Dispatcher;

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/RmvMaterialBuilder.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/RmvMaterialBuilder.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Editors.ImportExport.Importing.Importers.PngToDds;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
-using Shared.Core.Services;
 using Shared.Core.Settings;
 using Shared.GameFormats.RigidModel;
 using Shared.GameFormats.RigidModel.Types;
@@ -48,36 +47,35 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper
     }
     public class RmvMaterialBuilder
     {
-        private readonly IPackFileService _packFileService;
-        private readonly IStandardDialogs _exceptionService;        
-
-        public RmvMaterialBuilder(IPackFileService packFileSerivce, IStandardDialogs exceptionService)
-        {
-            _packFileService = packFileSerivce;
-            _exceptionService = exceptionService;
-        }
-
-        public void BuildRmvFileMaterials(GltfImporterSettings settings, SharpGLTF.Schema2.ModelRoot modelRoot, RmvFile rmvFile)
+        public IReadOnlyList<NewPackFileEntry> BuildRmvFileMaterials(
+            GltfImporterSettings settings,
+            SharpGLTF.Schema2.ModelRoot modelRoot,
+            RmvFile rmvFile)
         {
             ValidateInput_BuildRmvFileMaterials(modelRoot, rmvFile);
 
+            var textureEntries = new Dictionary<string, NewPackFileEntry>(
+                StringComparer.OrdinalIgnoreCase);
             var meshSources = RmvMeshBuilder.GetMeshSources(modelRoot);
             for (int i = 0; i < meshSources.Count; i++)
             {
                 BuildRmvModelMaterial(
                     settings,
                     meshSources[i],
-                    rmvFile.ModelList[0][i]
+                    rmvFile.ModelList[0][i],
+                    textureEntries
                 );
             }
 
             rmvFile.RecalculateOffsets();
+            return textureEntries.Values.ToList();
         }
 
         private void BuildRmvModelMaterial(
             GltfImporterSettings settings,
             RmvMeshBuilder.MeshSource source,
-            RmvModel rmvModel)
+            RmvModel rmvModel,
+            Dictionary<string, NewPackFileEntry> textureEntries)
         {
             var gltfMaterial = source.Primitive.Material;
             if (gltfMaterial == null || !gltfMaterial.Channels.Any())
@@ -112,14 +110,10 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper
 
                 rmvModel.Material.SetTexture(textureType, texturePackFolder);
 
-                // make sure we don't add the same file to .pack more the once, as several meshes, may use the same texture, 
-                if (!settings.DestinationPackFileContainer.FileList.ContainsKey(texturePackFolder))
+                if (!textureEntries.ContainsKey(texturePackFolder))
                 {
                     var newFile = new NewPackFileEntry(Path.GetDirectoryName(texturePackFolder) ?? "", ddsPackFile);
-                    PackFileDispatcherWriter.AddFilesToPack(
-                        _packFileService,
-                        settings.DestinationPackFileContainer,
-                        [newFile]);
+                    textureEntries.Add(texturePackFolder, newFile);
                 }
 
             }
@@ -137,8 +131,12 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper
 
             var textureFileName = $"{textureNameBase}{(postFixString.Any() ? $"_{postFixString}.dds" : ".dds")}";
 
-            var texturePackFolder = settings.DestinationPackPath + @"\tex";
-            var textureFullPackPath = @$"{texturePackFolder}\{textureFileName}";
+            var texturePackFolder = Path.Combine(
+                settings.DestinationPackPath,
+                "tex");
+            var textureFullPackPath = Path.Combine(
+                texturePackFolder,
+                textureFileName);
 
             return textureFullPackPath;
         }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/GltfToRmv/RmvToGltfImporterViewModel.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/GltfToRmv/RmvToGltfImporterViewModel.cs
@@ -2,6 +2,7 @@
 using Editors.ImportExport.Exporting.Exporters.RmvToGltf;
 using Editors.ImportExport.Exporting.Presentation.RmvToGltf;
 using Editors.ImportExport.Importing.Importers;
+using Editors.ImportExport.Importing;
 using Editors.ImportExport.Importing.Importers.GltfToRmv;
 using Editors.ImportExport.Importing.Presentation;
 using Shared.Core.PackFiles.Models;
@@ -40,7 +41,7 @@ namespace Editors.ImportImport.Importing.Presentation.RmvToGltf
 
         public ImportSupportEnum CanImportFile(PackFile file) => _Importer.CanImportFile(file);
 
-        public bool Execute(PackFile importSource, string outputPath, PackFileContainer packFileContainer, GameTypeEnum gameType)
+        public ImportResult Execute(PackFile importSource, string outputPath, PackFileContainer packFileContainer, GameTypeEnum gameType)
         {
             if (!float.IsFinite(AnimationKeysPerSecond) || AnimationKeysPerSecond <= 0)
                 throw new ArgumentOutOfRangeException(nameof(AnimationKeysPerSecond), "动画采样率必须大于 0。");

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/IImporterViewModel.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/IImporterViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Editors.ImportExport.Importing;
 using Editors.ImportExport.Misc;
 using Shared.Core.PackFiles.Models;
 using Shared.Core.Settings;
@@ -13,7 +14,7 @@ namespace Editors.ImportExport.Importing.Presentation
         public string DisplayName { get; }
         string OutputExtension { get; }
         string[] InputExtensions { get; } // ADDed THIS!
-        bool Execute(PackFile exportSource, string outputPath, PackFileContainer packFileContainer, GameTypeEnum gameType);
+        ImportResult Execute(PackFile exportSource, string outputPath, PackFileContainer packFileContainer, GameTypeEnum gameType);
         public ImportSupportEnum CanImportFile(PackFile file);
 
     }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml.cs
@@ -1,6 +1,7 @@
-using System.Windows;
+﻿using System.Windows;
 using Editors.ImportExport.Common;
 using Editors.ImportExport.Exporting.Presentation;
+using Editors.ImportExport.Importing;
 using Shared.Core.PackFiles.Models;
 using Shared.Core.Services;
 using WindowHandling;
@@ -42,10 +43,10 @@ public partial class ImportWindow : AssetEditorWindow
 
         ImportButton.IsEnabled = false;
         _viewModel.IsOperationActive = true;
-        var succeeded = false;
+        ImportResult? result = null;
         try
         {
-            succeeded = await _viewModel.ImportAsync();
+            result = await _viewModel.ImportAsync();
         }
         catch (Exception ex)
         {
@@ -57,7 +58,63 @@ public partial class ImportWindow : AssetEditorWindow
             ImportButton.IsEnabled = true;
         }
 
-        if (succeeded)
+        if (result == null)
+            return;
+
+        var resultMessage = BuildResultMessage(result);
+        if (result.Succeeded)
+        {
+            _standardDialogs.ShowDialogBox(
+                resultMessage,
+                LocalizationManager.Instance.Get("ImportWindow.SuccessTitle"));
             Close();
+            return;
+        }
+
+        if (result.Exception != null)
+        {
+            _standardDialogs.ShowExceptionWindow(
+                result.Exception,
+                resultMessage);
+            return;
+        }
+
+        _standardDialogs.ShowDialogBox(
+            resultMessage,
+            LocalizationManager.Instance.Get("ImportWindow.FailureTitle"));
     }
+
+    internal static string BuildResultMessage(ImportResult result)
+    {
+        var sections = new List<string>();
+        if (result.Succeeded)
+        {
+            sections.Add(result.OutputPaths.Count == 0
+                ? LocalizationManager.Instance.Get("ImportWindow.NoOutputs")
+                : BuildSection(
+                    LocalizationManager.Instance.Get("ImportWindow.OutputPathsHeading"),
+                    result.OutputPaths));
+        }
+        else
+        {
+            sections.Add(BuildSection(
+                LocalizationManager.Instance.Get("ImportWindow.ErrorHeading"),
+                result.Errors));
+        }
+
+        if (result.Warnings.Count != 0)
+        {
+            sections.Add(BuildSection(
+                LocalizationManager.Instance.Get("ImportWindow.WarningHeading"),
+                result.Warnings));
+        }
+
+        return string.Join(Environment.NewLine + Environment.NewLine, sections);
+    }
+
+    private static string BuildSection(
+        string heading,
+        IReadOnlyList<string> items) =>
+        heading + Environment.NewLine +
+        string.Join(Environment.NewLine, items.Select(item => $"• {item}"));
 }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml.cs
@@ -66,7 +66,8 @@ public partial class ImportWindow : AssetEditorWindow
         {
             _standardDialogs.ShowDialogBox(
                 resultMessage,
-                LocalizationManager.Instance.Get("ImportWindow.SuccessTitle"));
+                LocalizationManager.Instance.Get("ImportWindow.SuccessTitle"),
+                UiMessageBoxIcon.Information);
             Close();
             return;
         }
@@ -81,7 +82,8 @@ public partial class ImportWindow : AssetEditorWindow
 
         _standardDialogs.ShowDialogBox(
             resultMessage,
-            LocalizationManager.Instance.Get("ImportWindow.FailureTitle"));
+            LocalizationManager.Instance.Get("ImportWindow.FailureTitle"),
+            UiMessageBoxIcon.Error);
     }
 
     internal static string BuildResultMessage(ImportResult result)

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImporterCoreViewModel.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImporterCoreViewModel.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Editors.ImportExport.Importing;
 using Editors.ImportExport.Misc;
 using Shared.Core.PackFiles.Models;
 using Shared.Core.Settings;
@@ -75,7 +76,7 @@ namespace Editors.ImportExport.Importing.Presentation
                 SelectedImporter = PossibleImporters.First();
         }
 
-        public Task<bool> ImportAsync()
+        public Task<ImportResult> ImportAsync()
         {
             if (SelectedImporter == null || _inputFile == null || _destPackFileContainer == null)
                 throw new InvalidOperationException("没有可用于当前文件的导入器。");

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfIToRmvImporterTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfIToRmvImporterTests.cs
@@ -61,7 +61,7 @@ namespace Test.ImportExport.Importing.Importers.GltfImporterTest
             var sceneSaver = new TestGltfSceneSaver();
             var standardDialog = new Mock<IStandardDialogs>();
             var sceneLoader = new GltfSceneLoader(standardDialog.Object);
-            var materialBuilder = new RmvMaterialBuilder(pfs, standardDialog.Object);
+            var materialBuilder = new RmvMaterialBuilder();
             var importer = new GltfImporter(pfs, skeletontonLookupHelper, materialBuilder);
             var packFileContainer = new PackFileContainer("new");
             var settings = new GltfImporterSettings(TestData.InputGtlfFile, "skeletons", packFileContainer, Shared.Core.Settings.GameTypeEnum.Warhammer3, true, true, true, true, true, 20.0f, true);
@@ -90,11 +90,10 @@ namespace Test.ImportExport.Importing.Importers.GltfImporterTest
         }
 
         [Test]
-        public void InvalidGltf_ThrowsReadableError()
+        public void InvalidGltf_ReturnsReadableFailure()
         {
             var packFileService = new Mock<IPackFileService>();
-            var standardDialogs = new Mock<IStandardDialogs>();
-            var materialBuilder = new RmvMaterialBuilder(packFileService.Object, standardDialogs.Object);
+            var materialBuilder = new RmvMaterialBuilder();
             var importer = new GltfImporter(
                 packFileService.Object,
                 Mock.Of<ISkeletonAnimationLookUpHelper>(),
@@ -112,8 +111,14 @@ namespace Test.ImportExport.Importing.Importers.GltfImporterTest
                 20.0f,
                 false);
 
-            var exception = Assert.Throws<InvalidDataException>(() => importer.Import(settings));
-            Assert.That(exception!.Message, Does.Contain("无法读取 glTF/GLB 文件"));
+            var result = importer.Import(settings);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Succeeded, Is.False);
+                Assert.That(result.Errors, Has.Some.Contains("无法读取 glTF/GLB 文件"));
+                Assert.That(result.Exception, Is.TypeOf<InvalidDataException>());
+            });
         }
     }
 
@@ -132,7 +137,7 @@ namespace Test.ImportExport.Importing.Importers.GltfImporterTest
             var skeletontonLookupHelper = new SkeletonAnimationLookUpHelper(pfs, eventHub.Object);
             var skeletontonBuilder = new GltfSkeletonBuilder(pfs);
             var animationBuilder = new GltfAnimationBuilder(pfs);
-            var materialBuilder = new RmvMaterialBuilder(pfs, standardDialog.Object);
+            var materialBuilder = new RmvMaterialBuilder();
             var sceneLoader = new GltfSceneLoader(standardDialog.Object);
             var skeletonFile = skeletontonLookupHelper.GetSkeletonFileFromName(TestData.Rmv2Expected.skeletonName);
             var packFileContainer = new PackFileContainer("new");
@@ -166,7 +171,7 @@ namespace Test.ImportExport.Importing.Importers.GltfImporterTest
             var skeletontonLookupHelper = new SkeletonAnimationLookUpHelper(pfs, eventHub.Object);
             var skeletontonBuilder = new GltfSkeletonBuilder(pfs);
             var animationBuilder = new GltfAnimationBuilder(pfs);
-            var materialBuilder = new RmvMaterialBuilder(pfs, standardDialog.Object);
+            var materialBuilder = new RmvMaterialBuilder();
             var sceneLoader = new GltfSceneLoader(standardDialog.Object);
             var skeletonFile = skeletontonLookupHelper.GetSkeletonFileFromName(TestData.Rmv2Expected.skeletonName);
             var packFileContainer = new PackFileContainer("new");

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfImporterAtomicImportTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfImporterAtomicImportTests.cs
@@ -1,0 +1,429 @@
+﻿using System.Drawing;
+using System.Drawing.Imaging;
+using System.Numerics;
+using Editors.ImportExport.Importing;
+using Editors.ImportExport.Importing.Importers.GltfToRmv;
+using Editors.ImportExport.Importing.Importers.GltfToRmv.Helper;
+using GameWorld.Core.Services;
+using Moq;
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Settings;
+using Shared.TestUtility;
+using SharpGLTF.Geometry;
+using SharpGLTF.Geometry.VertexTypes;
+using SharpGLTF.Materials;
+using SharpGLTF.Schema2;
+
+namespace Test.ImportExport.Importing.Importers.GltfImporterTest;
+
+public class GltfImporterAtomicImportTests
+{
+    [Test]
+    public void Import_ModelTargetExists_ReturnsConflictAndLeavesPackUnchanged()
+    {
+        var glbPath = CreateStaticGlb();
+        try
+        {
+            var packFileService = PackFileSerivceTestHelper.Create(
+                TestData.InputPack);
+            var destination = new PackFileContainer("test");
+            var targetPath = $"models\\{Path.GetFileNameWithoutExtension(glbPath)}.rigid_model_v2"
+                .ToLowerInvariant();
+            var existingFile = new PackFile(
+                Path.GetFileName(targetPath),
+                new MemorySource([1, 2, 3]));
+            destination.FileList[targetPath] = existingFile;
+            var importer = new GltfImporter(
+                packFileService,
+                Mock.Of<ISkeletonAnimationLookUpHelper>(),
+                new RmvMaterialBuilder());
+
+            var result = importer.Import(new GltfImporterSettings(
+                glbPath,
+                "models",
+                destination,
+                GameTypeEnum.Warhammer3,
+                true,
+                false,
+                false,
+                false,
+                false,
+                20,
+                true));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Succeeded, Is.False);
+                Assert.That(result.Errors, Has.Some.Contains(targetPath));
+                Assert.That(destination.FileList, Has.Count.EqualTo(1));
+                Assert.That(destination.FileList[targetPath], Is.SameAs(existingFile));
+                Assert.That(
+                    destination.FileList[targetPath].DataSource.ReadData(),
+                    Is.EqualTo(new byte[] { 1, 2, 3 }));
+            });
+        }
+        finally
+        {
+            File.Delete(glbPath);
+        }
+    }
+
+    [Test]
+    public void Import_MeshVertexLimitFailsAfterSkeletonBuild_ReturnsFailureAndLeavesPackUnchanged()
+    {
+        var glbPath = CreateOversizedSkinnedGlb();
+        try
+        {
+            var packFileService = PackFileSerivceTestHelper.Create(
+                TestData.InputPack);
+            var destination = new PackFileContainer("test");
+            const string existingPath = @"models\existing.bin";
+            var existingFile = new PackFile(
+                "existing.bin",
+                new MemorySource([7, 8, 9]));
+            destination.FileList[existingPath] = existingFile;
+            var importer = new GltfImporter(
+                packFileService,
+                Mock.Of<ISkeletonAnimationLookUpHelper>(),
+                new RmvMaterialBuilder());
+            var settings = new GltfImporterSettings(
+                glbPath,
+                "models",
+                destination,
+                GameTypeEnum.Warhammer3,
+                true,
+                false,
+                false,
+                false,
+                false,
+                20,
+                true);
+
+            ImportResult? result = null;
+            Exception? thrownException = null;
+            try
+            {
+                result = importer.Import(settings);
+            }
+            catch (Exception exception)
+            {
+                thrownException = exception;
+            }
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(thrownException, Is.Null);
+                Assert.That(result?.Succeeded, Is.False);
+                Assert.That(result?.Errors, Is.Not.Empty);
+                Assert.That(destination.FileList, Has.Count.EqualTo(1));
+                Assert.That(destination.FileList[existingPath], Is.SameAs(existingFile));
+                Assert.That(
+                    existingFile.DataSource.ReadData(),
+                    Is.EqualTo(new byte[] { 7, 8, 9 }));
+            });
+        }
+        finally
+        {
+            File.Delete(glbPath);
+        }
+    }
+
+    [Test]
+    public void Import_ModelSkeletonAnimationAndTexture_SucceedsWithOnePackWriteAndReportsEveryOutput()
+    {
+        var imagePath = CreatePng();
+        var glbPath = CreateAnimatedSkinnedGlb(imagePath);
+        try
+        {
+            var innerPackFileService = PackFileSerivceTestHelper.Create(
+                TestData.InputPack);
+            var destination = new PackFileContainer("test");
+            var packFileService = new Mock<IPackFileService>();
+            packFileService
+                .Setup(service => service.AddFilesToPack(
+                    destination,
+                    It.IsAny<List<NewPackFileEntry>>(),
+                    It.IsAny<bool>()))
+                .Callback<PackFileContainer, List<NewPackFileEntry>, bool>(
+                    (container, entries, overwriteExisting) =>
+                        innerPackFileService.AddFilesToPack(
+                            container,
+                            entries,
+                            overwriteExisting));
+            var importer = new GltfImporter(
+                packFileService.Object,
+                Mock.Of<ISkeletonAnimationLookUpHelper>(),
+                new RmvMaterialBuilder());
+
+            var result = importer.Import(new GltfImporterSettings(
+                glbPath,
+                "models",
+                destination,
+                GameTypeEnum.Warhammer3,
+                true,
+                true,
+                false,
+                false,
+                true,
+                20,
+                true));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Succeeded, Is.True);
+                Assert.That(result.Errors, Is.Empty);
+                Assert.That(result.Warnings, Is.Empty);
+                Assert.That(result.OutputPaths, Is.EquivalentTo(destination.FileList.Keys));
+                Assert.That(destination.FileList.Keys, Has.Some.EndsWith(".rigid_model_v2"));
+                Assert.That(destination.FileList.Keys, Has.Some.EndsWith(".dds"));
+                Assert.That(destination.FileList.Keys.Count(path => path.EndsWith(".anim")), Is.EqualTo(2));
+            });
+            packFileService.Verify(
+                service => service.AddFilesToPack(
+                    destination,
+                    It.IsAny<List<NewPackFileEntry>>(),
+                    It.IsAny<bool>()),
+                Times.Once);
+        }
+        finally
+        {
+            File.Delete(glbPath);
+            File.Delete(imagePath);
+        }
+    }
+
+    [Test]
+    public void Import_AllOutputTargetsExist_ReportsEveryConflictAndLeavesPackUnchanged()
+    {
+        var imagePath = CreatePng();
+        var glbPath = CreateAnimatedSkinnedGlb(imagePath);
+        try
+        {
+            var packFileService = PackFileSerivceTestHelper.Create(
+                TestData.InputPack);
+            var destination = new PackFileContainer("test");
+            var baseName = Path.GetFileNameWithoutExtension(glbPath)
+                .ToLowerInvariant();
+            var conflictPaths = new[]
+            {
+                @"animations\skeletons\test_skeleton.anim",
+                $@"models\{baseName}.anim",
+                @"models\tex\mesh_node_base_colour.dds",
+                $@"models\{baseName}.rigid_model_v2",
+            };
+            var existingFiles = conflictPaths
+                .Select((path, index) => new
+                {
+                    Path = index == 1 ? path.ToUpperInvariant() : path,
+                    Content = (byte)(index + 1),
+                    File = new PackFile(
+                        Path.GetFileName(path),
+                        new MemorySource([(byte)(index + 1)])),
+                })
+                .ToList();
+            foreach (var existing in existingFiles)
+                destination.FileList[existing.Path] = existing.File;
+
+            var importer = new GltfImporter(
+                packFileService,
+                Mock.Of<ISkeletonAnimationLookUpHelper>(),
+                new RmvMaterialBuilder());
+            var result = importer.Import(new GltfImporterSettings(
+                glbPath,
+                "models",
+                destination,
+                GameTypeEnum.Warhammer3,
+                true,
+                true,
+                false,
+                false,
+                true,
+                20,
+                true));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Succeeded, Is.False);
+                Assert.That(result.Errors, Has.Count.EqualTo(conflictPaths.Length));
+                foreach (var conflictPath in conflictPaths)
+                    Assert.That(result.Errors, Has.Some.Contains(conflictPath));
+                Assert.That(destination.FileList, Has.Count.EqualTo(existingFiles.Count));
+                foreach (var existing in existingFiles)
+                {
+                    Assert.That(destination.FileList[existing.Path], Is.SameAs(existing.File));
+                    Assert.That(
+                        existing.File.DataSource.ReadData(),
+                        Is.EqualTo(new[] { existing.Content }));
+                }
+            });
+        }
+        finally
+        {
+            File.Delete(glbPath);
+            File.Delete(imagePath);
+        }
+    }
+
+    [Test]
+    public void Import_MaterialAtPackRoot_NormalizesTextureTargetPath()
+    {
+        var imagePath = CreatePng();
+        var glbPath = CreateAnimatedSkinnedGlb(imagePath);
+        try
+        {
+            var packFileService = PackFileSerivceTestHelper.Create(
+                TestData.InputPack);
+            var destination = new PackFileContainer("test");
+            var importer = new GltfImporter(
+                packFileService,
+                Mock.Of<ISkeletonAnimationLookUpHelper>(),
+                new RmvMaterialBuilder());
+
+            var result = importer.Import(new GltfImporterSettings(
+                glbPath,
+                "",
+                destination,
+                GameTypeEnum.Warhammer3,
+                false,
+                true,
+                false,
+                false,
+                false,
+                20,
+                true));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Succeeded, Is.True);
+                Assert.That(result.OutputPaths, Is.EqualTo(new[]
+                {
+                    @"tex\mesh_node_base_colour.dds",
+                }));
+                Assert.That(destination.FileList.Keys, Is.EquivalentTo(result.OutputPaths));
+            });
+        }
+        finally
+        {
+            File.Delete(glbPath);
+            File.Delete(imagePath);
+        }
+    }
+
+    private static string CreateStaticGlb()
+    {
+        var material = new MaterialBuilder("material")
+            .WithMetallicRoughness();
+        var geometry = new MeshBuilder<
+            VertexPositionNormalTangent,
+            VertexTexture1,
+            VertexJoints4>("mesh");
+        var primitive = geometry.UsePrimitive(material);
+        primitive.AddTriangle(
+            CreateVertex(0, 0),
+            CreateVertex(1, 0),
+            CreateVertex(0, 1));
+
+        var modelRoot = ModelRoot.CreateModel();
+        var mesh = modelRoot.CreateMesh(geometry);
+        modelRoot.UseScene("default").CreateNode("mesh_node").WithMesh(mesh);
+
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.glb");
+        modelRoot.SaveGLB(path);
+        return path;
+    }
+
+    private static string CreateOversizedSkinnedGlb()
+    {
+        var material = new MaterialBuilder("material")
+            .WithMetallicRoughness();
+        var geometry = new MeshBuilder<
+            VertexPositionNormalTangent,
+            VertexTexture1,
+            VertexJoints4>("mesh");
+        var primitive = geometry.UsePrimitive(material);
+        for (var triangleIndex = 0; triangleIndex < 21_846; triangleIndex++)
+        {
+            var x = triangleIndex * 2;
+            primitive.AddTriangle(
+                CreateVertex(x, 0),
+                CreateVertex(x + 1, 0),
+                CreateVertex(x, 1));
+        }
+
+        var modelRoot = ModelRoot.CreateModel();
+        var mesh = modelRoot.CreateMesh(geometry);
+        var scene = modelRoot.UseScene("default");
+        scene.CreateNode("//skeleton//test_skeleton");
+        var root = scene.CreateNode("root");
+        scene.CreateNode("mesh_node").WithSkinnedMesh(
+            mesh,
+            (root, Matrix4x4.Identity));
+
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.glb");
+        modelRoot.SaveGLB(path);
+        return path;
+    }
+
+    private static string CreateAnimatedSkinnedGlb(string imagePath)
+    {
+        var material = new MaterialBuilder("material")
+            .WithMetallicRoughness()
+            .WithChannelImage(KnownChannel.BaseColor, imagePath);
+        var geometry = new MeshBuilder<
+            VertexPositionNormalTangent,
+            VertexTexture1,
+            VertexJoints4>("mesh");
+        var primitive = geometry.UsePrimitive(material);
+        primitive.AddTriangle(
+            CreateVertex(0, 0),
+            CreateVertex(1, 0),
+            CreateVertex(0, 1));
+
+        var modelRoot = ModelRoot.CreateModel();
+        var mesh = modelRoot.CreateMesh(geometry);
+        var scene = modelRoot.UseScene("default");
+        scene.CreateNode("//skeleton//test_skeleton");
+        var root = scene.CreateNode("root");
+        scene.CreateNode("mesh_node").WithSkinnedMesh(
+            mesh,
+            (root, Matrix4x4.Identity));
+        modelRoot.CreateAnimation("idle").CreateTranslationChannel(
+            root,
+            new Dictionary<float, Vector3>
+            {
+                [0] = Vector3.Zero,
+                [0.05f] = Vector3.UnitY,
+            });
+
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.glb");
+        modelRoot.SaveGLB(path);
+        return path;
+    }
+
+    private static string CreatePng()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.png");
+        using var bitmap = new Bitmap(2, 2);
+        bitmap.SetPixel(0, 0, Color.White);
+        bitmap.Save(path, ImageFormat.Png);
+        return path;
+    }
+
+    private static VertexBuilder<
+        VertexPositionNormalTangent,
+        VertexTexture1,
+        VertexJoints4> CreateVertex(float x, float y)
+    {
+        var vertex = new VertexBuilder<
+            VertexPositionNormalTangent,
+            VertexTexture1,
+            VertexJoints4>();
+        vertex.Geometry.Position = new Vector3(x, y, 0);
+        vertex.Geometry.Normal = Vector3.UnitZ;
+        vertex.Geometry.Tangent = new Vector4(1, 0, 0, 1);
+        vertex.Material.TexCoord = new Vector2(x, y);
+        vertex.Skinning.SetBindings((0, 1), (0, 0), (0, 0), (0, 0));
+        return vertex;
+    }
+}

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfImporterAtomicImportTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfImporterAtomicImportTests.cs
@@ -8,6 +8,7 @@ using GameWorld.Core.Services;
 using Moq;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
+using Shared.Core.Services;
 using Shared.Core.Settings;
 using Shared.TestUtility;
 using SharpGLTF.Geometry;
@@ -19,6 +20,9 @@ namespace Test.ImportExport.Importing.Importers.GltfImporterTest;
 
 public class GltfImporterAtomicImportTests
 {
+    [SetUp]
+    public void SetUp() => new LocalizationManager().LoadLanguage();
+
     [Test]
     public void Import_ModelTargetExists_ReturnsConflictAndLeavesPackUnchanged()
     {
@@ -41,7 +45,7 @@ public class GltfImporterAtomicImportTests
 
             var result = importer.Import(new GltfImporterSettings(
                 glbPath,
-                "models",
+                " models ",
                 destination,
                 GameTypeEnum.Warhammer3,
                 true,
@@ -70,9 +74,9 @@ public class GltfImporterAtomicImportTests
     }
 
     [Test]
-    public void Import_MeshVertexLimitFailsAfterSkeletonBuild_ReturnsFailureAndLeavesPackUnchanged()
+    public void Import_InvalidAnimationRateAfterSkeletonAndMeshBuild_ReturnsFailureAndLeavesPackUnchanged()
     {
-        var glbPath = CreateOversizedSkinnedGlb();
+        var glbPath = CreateAnimatedSkinnedGlb();
         try
         {
             var packFileService = PackFileSerivceTestHelper.Create(
@@ -96,9 +100,10 @@ public class GltfImporterAtomicImportTests
                 false,
                 false,
                 false,
-                false,
-                20,
-                true);
+                true,
+                0,
+                true,
+                false);
 
             ImportResult? result = null;
             Exception? thrownException = null;
@@ -126,6 +131,82 @@ public class GltfImporterAtomicImportTests
         finally
         {
             File.Delete(glbPath);
+        }
+    }
+
+    [Test]
+    public void Import_FolderProjectDiskConflictsMissingFromFileList_ReportsEveryConflictAndLeavesDiskUnchanged()
+    {
+        var glbPath = CreateAnimatedSkinnedGlb();
+        var projectRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"AssetEditorGltfImport-{Guid.NewGuid():N}");
+        var baseName = Path.GetFileNameWithoutExtension(glbPath)
+            .ToLowerInvariant();
+        var conflictPaths = new[]
+        {
+            $@"models\{baseName}.anim",
+            $@"models\{baseName}.rigid_model_v2",
+        };
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "models"));
+            for (var index = 0; index < conflictPaths.Length; index++)
+            {
+                File.WriteAllBytes(
+                    Path.Combine(projectRoot, conflictPaths[index]),
+                    [(byte)(index + 1)]);
+            }
+
+            using var destination = FolderProjectContainer.Create(
+                projectRoot,
+                new FolderProjectSettings { Name = "test" });
+            foreach (var conflictPath in conflictPaths)
+                destination.FileList.Remove(conflictPath);
+            var packFileService = PackFileSerivceTestHelper.Create(
+                TestData.InputPack);
+            var importer = new GltfImporter(
+                packFileService,
+                Mock.Of<ISkeletonAnimationLookUpHelper>(),
+                new RmvMaterialBuilder());
+
+            var result = importer.Import(new GltfImporterSettings(
+                glbPath,
+                "models",
+                destination,
+                GameTypeEnum.Warhammer3,
+                true,
+                false,
+                false,
+                false,
+                true,
+                20,
+                true));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Succeeded, Is.False);
+                Assert.That(result.Errors, Has.Count.EqualTo(conflictPaths.Length));
+                foreach (var conflictPath in conflictPaths)
+                    Assert.That(result.Errors, Has.Some.Contains(conflictPath));
+                for (var index = 0; index < conflictPaths.Length; index++)
+                {
+                    Assert.That(
+                        File.ReadAllBytes(Path.Combine(projectRoot, conflictPaths[index])),
+                        Is.EqualTo(new[] { (byte)(index + 1) }));
+                }
+                Assert.That(
+                    File.Exists(Path.Combine(
+                        projectRoot,
+                        @"animations\skeletons\test_skeleton.anim")),
+                    Is.False);
+            });
+        }
+        finally
+        {
+            File.Delete(glbPath);
+            if (Directory.Exists(projectRoot))
+                Directory.Delete(projectRoot, recursive: true);
         }
     }
 
@@ -333,43 +414,12 @@ public class GltfImporterAtomicImportTests
         return path;
     }
 
-    private static string CreateOversizedSkinnedGlb()
+    private static string CreateAnimatedSkinnedGlb(string? imagePath = null)
     {
         var material = new MaterialBuilder("material")
             .WithMetallicRoughness();
-        var geometry = new MeshBuilder<
-            VertexPositionNormalTangent,
-            VertexTexture1,
-            VertexJoints4>("mesh");
-        var primitive = geometry.UsePrimitive(material);
-        for (var triangleIndex = 0; triangleIndex < 21_846; triangleIndex++)
-        {
-            var x = triangleIndex * 2;
-            primitive.AddTriangle(
-                CreateVertex(x, 0),
-                CreateVertex(x + 1, 0),
-                CreateVertex(x, 1));
-        }
-
-        var modelRoot = ModelRoot.CreateModel();
-        var mesh = modelRoot.CreateMesh(geometry);
-        var scene = modelRoot.UseScene("default");
-        scene.CreateNode("//skeleton//test_skeleton");
-        var root = scene.CreateNode("root");
-        scene.CreateNode("mesh_node").WithSkinnedMesh(
-            mesh,
-            (root, Matrix4x4.Identity));
-
-        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.glb");
-        modelRoot.SaveGLB(path);
-        return path;
-    }
-
-    private static string CreateAnimatedSkinnedGlb(string imagePath)
-    {
-        var material = new MaterialBuilder("material")
-            .WithMetallicRoughness()
-            .WithChannelImage(KnownChannel.BaseColor, imagePath);
+        if (imagePath != null)
+            material.WithChannelImage(KnownChannel.BaseColor, imagePath);
         var geometry = new MeshBuilder<
             VertexPositionNormalTangent,
             VertexTexture1,

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/RmvMeshBuilderSceneTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/RmvMeshBuilderSceneTests.cs
@@ -1,11 +1,10 @@
-using System.Numerics;
+﻿using System.Numerics;
 using Editors.ImportExport.Importing.Importers.GltfToRmv;
 using Editors.ImportExport.Importing.Importers.GltfToRmv.Helper;
 using GameWorld.Core.Services;
 using Moq;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
-using Shared.Core.Services;
 using Shared.TestUtility;
 using Shared.GameFormats.Animation;
 using Shared.GameFormats.RigidModel.Transforms;
@@ -65,8 +64,7 @@ public class RmvMeshBuilderSceneTests
         {
             modelRoot.SaveGLB(glbPath);
             var packFileService = PackFileSerivceTestHelper.Create(TestData.InputPack);
-            var standardDialogs = Mock.Of<IStandardDialogs>();
-            var materialBuilder = new RmvMaterialBuilder(packFileService, standardDialogs);
+            var materialBuilder = new RmvMaterialBuilder();
             var importer = new GltfImporter(
                 packFileService,
                 Mock.Of<ISkeletonAnimationLookUpHelper>(),
@@ -85,7 +83,7 @@ public class RmvMeshBuilderSceneTests
                 20,
                 true);
 
-            var succeeded = importer.Import(settings);
+            var succeeded = importer.Import(settings).Succeeded;
 
             Assert.That(succeeded, Is.True);
             Assert.That(
@@ -152,9 +150,7 @@ public class RmvMeshBuilderSceneTests
             skeletonLookup
                 .Setup(service => service.GetSkeletonFileFromName("test_skeleton"))
                 .Returns(skeleton);
-            var materialBuilder = new RmvMaterialBuilder(
-                packFileService,
-                Mock.Of<IStandardDialogs>());
+            var materialBuilder = new RmvMaterialBuilder();
             var importer = new GltfImporter(
                 packFileService,
                 skeletonLookup.Object,
@@ -197,9 +193,7 @@ public class RmvMeshBuilderSceneTests
         {
             modelRoot.SaveGLB(glbPath);
             var packFileService = PackFileSerivceTestHelper.Create(TestData.InputPack);
-            var materialBuilder = new RmvMaterialBuilder(
-                packFileService,
-                Mock.Of<IStandardDialogs>());
+            var materialBuilder = new RmvMaterialBuilder();
             var importer = new GltfImporter(
                 packFileService,
                 Mock.Of<ISkeletonAnimationLookUpHelper>(),
@@ -247,9 +241,7 @@ public class RmvMeshBuilderSceneTests
             skeletonLookup
                 .Setup(service => service.GetSkeletonFileFromName("test_skeleton"))
                 .Returns(CreateSkeletonFile("test_skeleton"));
-            var materialBuilder = new RmvMaterialBuilder(
-                packFileService,
-                Mock.Of<IStandardDialogs>());
+            var materialBuilder = new RmvMaterialBuilder();
             var importer = new GltfImporter(
                 packFileService,
                 skeletonLookup.Object,

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Presentation/GltfToRmvImporterViewModelTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Presentation/GltfToRmvImporterViewModelTests.cs
@@ -1,4 +1,10 @@
+﻿using Editors.ImportExport.Importing;
+using Editors.ImportExport.Importing.Presentation;
+using Editors.ImportExport.Misc;
 using Editors.ImportImport.Importing.Presentation.RmvToGltf;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Services;
+using Shared.Core.Settings;
 
 namespace Test.ImportExport.Importing.Presentation;
 
@@ -20,5 +26,73 @@ public class GltfToRmvImporterViewModelTests
 
         viewModel.ImportAnimations = false;
         Assert.That(viewModel.CanEditAnimationKeysPerSecond, Is.False);
+    }
+
+    [Test]
+    public async Task ImportAsync_ReturnsStructuredImporterResult()
+    {
+        var expected = ImportResult.Failure(["目标 Pack 已存在资源：models\\test.rigid_model_v2"]);
+        var importer = new TestImporter(expected);
+        var viewModel = new ImporterCoreViewModel(
+            [importer],
+            new ApplicationSettingsService(GameTypeEnum.Warhammer3));
+        var inputPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.glb");
+        try
+        {
+            File.WriteAllBytes(inputPath, []);
+            viewModel.Initialize(
+                new PackFileContainer("test"),
+                "models",
+                inputPath);
+
+            var actual = await viewModel.ImportAsync();
+
+            Assert.That(actual, Is.SameAs(expected));
+        }
+        finally
+        {
+            File.Delete(inputPath);
+        }
+    }
+
+    [Test]
+    public void BuildResultMessage_ListsStructuredOutputsWarningsAndErrors()
+    {
+        var localization = new LocalizationManager();
+        localization.LoadLanguage();
+        var successMessage = ImportWindow.BuildResultMessage(new ImportResult(
+            true,
+            [@"models\test.rigid_model_v2"],
+            ["测试警告"],
+            []));
+        var failureMessage = ImportWindow.BuildResultMessage(
+            ImportResult.Failure([
+                "目标 Pack 已存在资源：models\\test.rigid_model_v2",
+                "目标 Pack 已存在资源：models\\test.anim",
+            ]));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(successMessage, Does.Contain(@"models\test.rigid_model_v2"));
+            Assert.That(successMessage, Does.Contain("测试警告"));
+            Assert.That(failureMessage, Does.Contain(@"models\test.rigid_model_v2"));
+            Assert.That(failureMessage, Does.Contain(@"models\test.anim"));
+        });
+    }
+
+    private sealed class TestImporter(ImportResult result) : IImporterViewModel
+    {
+        public string DisplayName => "test";
+        public string OutputExtension => ".rigid_model_v2";
+        public string[] InputExtensions => [".glb"];
+
+        public ImportResult Execute(
+            PackFile exportSource,
+            string outputPath,
+            PackFileContainer packFileContainer,
+            GameTypeEnum gameType) => result;
+
+        public ImportSupportEnum CanImportFile(PackFile file) =>
+            ImportSupportEnum.HighPriority;
     }
 }

--- a/Shared/SharedCore/PackFiles/Models/FolderProjectContainer.cs
+++ b/Shared/SharedCore/PackFiles/Models/FolderProjectContainer.cs
@@ -489,7 +489,7 @@ public sealed class FolderProjectContainer :
                         item.Entry.PackFile.DataSource.ReadData()))
                     .ToList();
 
-                return ApplyFileWritesCore(writes);
+                return ApplyFileWritesCore(writes, overwriteExisting);
             });
     }
 
@@ -497,13 +497,18 @@ public sealed class FolderProjectContainer :
         IReadOnlyCollection<Shared.Core.PackFiles.PackFileWrite> writes)
     {
         return ExecuteSerializedMutation(
-            () => ApplyFileWritesCore(writes));
+            () => ApplyFileWritesCore(writes, overwriteExisting: true));
     }
 
     private List<PackFile> ApplyFileWritesCore(
-        IReadOnlyCollection<Shared.Core.PackFiles.PackFileWrite> writes)
+        IReadOnlyCollection<Shared.Core.PackFiles.PackFileWrite> writes,
+        bool overwriteExisting)
     {
         var prepared = new List<PreparedFileWrite>();
+        var validatedWrites = new List<(
+            string RelativePath,
+            string FullPath,
+            byte[] Content)>();
         var uniquePaths = new HashSet<string>(
             StringComparer.OrdinalIgnoreCase);
         var createdDirectories = new HashSet<string>(
@@ -523,16 +528,39 @@ public sealed class FolderProjectContainer :
                 var fullPath = FolderProjectPathPolicy.ResolveFilePath(
                     ProjectRoot,
                     relativePath);
-                var directoryPath = Path.GetDirectoryName(fullPath)!;
-                if (createdDirectories.Add(directoryPath))
-                    Directory.CreateDirectory(directoryPath);
-                var tempPath = $"{fullPath}.{Guid.NewGuid():N}.tmp";
-                prepared.Add(new PreparedFileWrite(
+                validatedWrites.Add((
                     relativePath,
                     fullPath,
+                    write.Content));
+            }
+
+            if (!overwriteExisting)
+            {
+                var conflicts = validatedWrites
+                    .Where(write => File.Exists(write.FullPath))
+                    .Select(write => write.RelativePath)
+                    .ToList();
+                if (conflicts.Count != 0)
+                {
+                    throw new FolderProjectFileConflictException(
+                        conflicts);
+                }
+            }
+
+            foreach (var write in validatedWrites)
+            {
+                var directoryPath = Path.GetDirectoryName(
+                    write.FullPath)!;
+                if (createdDirectories.Add(directoryPath))
+                    Directory.CreateDirectory(directoryPath);
+                var tempPath =
+                    $"{write.FullPath}.{Guid.NewGuid():N}.tmp";
+                prepared.Add(new PreparedFileWrite(
+                    write.RelativePath,
+                    write.FullPath,
                     tempPath,
                     write.Content,
-                    File.Exists(fullPath)));
+                    overwriteExisting && File.Exists(write.FullPath)));
             }
 
             try

--- a/Shared/SharedCore/PackFiles/Models/FolderProjectContainer.cs
+++ b/Shared/SharedCore/PackFiles/Models/FolderProjectContainer.cs
@@ -10,6 +10,13 @@ public readonly record struct FolderProjectReconciliation(
     int Removed,
     int Updated);
 
+public sealed class FolderProjectFileConflictException(
+    IReadOnlyList<string> paths) :
+    IOException($"The destinations already exist: {string.Join(", ", paths)}")
+{
+    public IReadOnlyList<string> Paths { get; } = paths.ToArray();
+}
+
 public sealed class FolderProjectReconciledEventArgs(
     FolderProjectReconciliation changes,
     IReadOnlyList<PackFile> addedFiles,
@@ -443,7 +450,10 @@ public sealed class FolderProjectContainer :
         return ExecuteSerializedMutation(
             () =>
             {
-                var writes = new List<Shared.Core.PackFiles.PackFileWrite>();
+                var validatedFiles = new List<(
+                    Shared.Core.PackFiles.NewPackFileEntry Entry,
+                    string RelativePath,
+                    string FullPath)>();
                 foreach (var entry in newFiles)
                 {
                     if (string.IsNullOrWhiteSpace(entry.PackFile.Name))
@@ -461,15 +471,23 @@ public sealed class FolderProjectContainer :
                         FolderProjectPathPolicy.ResolveFilePath(
                             ProjectRoot,
                             relativePath);
-                    if (File.Exists(fullPath) && !overwriteExisting)
-                    {
-                        throw new IOException(
-                            $"The destination already exists: {fullPath}");
-                    }
-                    writes.Add(new Shared.Core.PackFiles.PackFileWrite(
-                        relativePath,
-                        entry.PackFile.DataSource.ReadData()));
+                    validatedFiles.Add((entry, relativePath, fullPath));
                 }
+
+                var conflicts = overwriteExisting
+                    ? []
+                    : validatedFiles
+                        .Where(item => File.Exists(item.FullPath))
+                        .Select(item => item.RelativePath)
+                        .ToList();
+                if (conflicts.Count != 0)
+                    throw new FolderProjectFileConflictException(conflicts);
+
+                var writes = validatedFiles
+                    .Select(item => new Shared.Core.PackFiles.PackFileWrite(
+                        item.RelativePath,
+                        item.Entry.PackFile.DataSource.ReadData()))
+                    .ToList();
 
                 return ApplyFileWritesCore(writes);
             });

--- a/Shared/SharedCore/PackFiles/Models/FolderProjectContainer.cs
+++ b/Shared/SharedCore/PackFiles/Models/FolderProjectContainer.cs
@@ -653,6 +653,19 @@ public sealed class FolderProjectContainer :
                         committed[index].BackupPath);
                 }
 
+                if (!overwriteExisting)
+                {
+                    var conflicts = prepared
+                        .Where(write => File.Exists(write.FullPath))
+                        .Select(write => write.RelativePath)
+                        .ToList();
+                    if (conflicts.Count != 0)
+                    {
+                        throw new FolderProjectFileConflictException(
+                            conflicts);
+                    }
+                }
+
                 if (failure is AggregateException parallelFailure)
                     RethrowSingleParallelFailure(parallelFailure);
                 throw;

--- a/Shared/SharedCore/Services/IStandardDialogs.cs
+++ b/Shared/SharedCore/Services/IStandardDialogs.cs
@@ -21,6 +21,10 @@ namespace Shared.Core.Services
             string initialTitle = "",
             string initialDescription = "");
         void ShowDialogBox(string message, string title = "Error");
+        void ShowDialogBox(
+            string message,
+            string title,
+            UiMessageBoxIcon image);
         ShowMessageBoxResult ShowYesNoBox(string message, string title);
     }
 

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/StandardDialogs.cs
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/StandardDialogs.cs
@@ -109,10 +109,26 @@ namespace Shared.Ui.BaseDialogs.StandardDialog
 
         public void ShowDialogBox(string message, string title)
         {
+            ShowDialogBox(message, title, UiMessageBoxIcon.None);
+        }
+
+        public void ShowDialogBox(
+            string message,
+            string title,
+            UiMessageBoxIcon image)
+        {
             var dialog = new MessageDialogWindow(
                 title,
                 message,
-                MessageDialogButtonSet.Ok);
+                MessageDialogButtonSet.Ok,
+                image switch
+                {
+                    UiMessageBoxIcon.Error => MessageBoxImage.Error,
+                    UiMessageBoxIcon.Warning => MessageBoxImage.Warning,
+                    UiMessageBoxIcon.Question => MessageBoxImage.Question,
+                    UiMessageBoxIcon.Information => MessageBoxImage.Information,
+                    _ => MessageBoxImage.None,
+                });
             ShowOwnedDialog(dialog);
         }
 

--- a/Testing/AssetEditorTests/GltfImporterThreadingTests.cs
+++ b/Testing/AssetEditorTests/GltfImporterThreadingTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Numerics;
 using System.Windows.Data;
 using Editors.ImportExport.Importing.Importers.GltfToRmv;
@@ -8,7 +8,6 @@ using Moq;
 using NUnit.Framework;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
-using Shared.Core.Services;
 using Shared.Core.Settings;
 using Shared.GameFormats.Animation;
 using Shared.GameFormats.RigidModel.Transforms;
@@ -48,9 +47,7 @@ public class GltfImporterThreadingTests
                         It.IsAny<List<NewPackFileEntry>>(),
                         It.IsAny<bool>()))
                     .Callback(() => uiCollection.Add(1));
-                var materialBuilder = new RmvMaterialBuilder(
-                    packFileService.Object,
-                    Mock.Of<IStandardDialogs>());
+                var materialBuilder = new RmvMaterialBuilder();
                 var skeletonLookup = new Mock<ISkeletonAnimationLookUpHelper>();
                 if (writePath == PackWritePath.Animation)
                 {

--- a/Testing/AssetEditorTests/UiRemainingEditorFamilyGallery.cs
+++ b/Testing/AssetEditorTests/UiRemainingEditorFamilyGallery.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -17,6 +17,7 @@ using Editors.ImportExport.Exporting.Presentation;
 using Editors.ImportExport.Exporting.Presentation.DdsToMaterialPng;
 using Editors.ImportExport.Exporting.Presentation.DdsToNormalPng;
 using Editors.ImportExport.Exporting.Presentation.RmvToGltf;
+using Editors.ImportExport.Importing;
 using Editors.ImportExport.Importing.Presentation;
 using Editors.ImportExport.Misc;
 using Editors.Twui.Editor.ComponentEditor;
@@ -832,13 +833,13 @@ public class UiRemainingEditorFamilyGallery
         public bool CanEditAnimationKeysPerSecond =>
             ImportAnimations && !AutoDetectAnimationKeysPerSecond;
         public float AnimationKeysPerSecond { get; set; } = 30;
-        public bool Execute(
+        public ImportResult Execute(
             PackFile exportSource,
             string outputPath,
             PackFileContainer packFileContainer,
             GameTypeEnum gameType)
         {
-            return true;
+            return ImportResult.Success([]);
         }
         public ImportSupportEnum CanImportFile(PackFile file) =>
             ImportSupportEnum.HighPriority;

--- a/Testing/Shared.Core.Test/PackFiles/FolderProjectContainerTests.cs
+++ b/Testing/Shared.Core.Test/PackFiles/FolderProjectContainerTests.cs
@@ -1,4 +1,7 @@
+using Moq;
 using Shared.ByteParsing;
+using Shared.Core.Events;
+using Shared.Core.Events.Global;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
 using Shared.Core.PackFiles.Utility;
@@ -730,6 +733,70 @@ public class FolderProjectContainerTests
                 File.Exists(
                     Path.Combine(project.Path, "db", "new.bin")),
                 Is.False);
+        });
+    }
+
+    [Test]
+    public void AddFiles_TargetAppearsDuringFinalCommitWithoutOverwrite_ReportsConflictAndRollsBackBatch()
+    {
+        using var project = new TemporaryDirectory();
+        using var container = FolderProjectContainer.Create(
+            project.Path,
+            new FolderProjectSettings { Name = "工程" });
+        using var firstCommitted = new ManualResetEventSlim(false);
+        var eventHub = new Mock<IGlobalEventHub>();
+        var service = new PackFileService(eventHub.Object);
+        container.CommitPreparedFile = (tempPath, fullPath) =>
+        {
+            if (Path.GetFileName(fullPath).Equals(
+                    "new.bin",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                File.Move(tempPath, fullPath);
+                firstCommitted.Set();
+                return;
+            }
+
+            if (!firstCommitted.Wait(TimeSpan.FromSeconds(5)))
+            {
+                throw new TimeoutException(
+                    "The first file was not committed.");
+            }
+            File.WriteAllBytes(fullPath, [9, 8, 7]);
+            File.Move(tempPath, fullPath);
+        };
+
+        var exception = Assert.Throws<FolderProjectFileConflictException>(
+            () => service.AddFilesToPack(
+                container,
+                [
+                    new NewPackFileEntry(
+                        "db",
+                        PackFile.CreateFromBytes("new.bin", [1, 2, 3])),
+                    new NewPackFileEntry(
+                        "db",
+                        PackFile.CreateFromBytes("late.bin", [4, 5, 6])),
+                ],
+                overwriteExisting: false));
+        var changeEvents = eventHub.Invocations
+            .Select(invocation => invocation.Arguments.SingleOrDefault())
+            .OfType<FolderProjectChangedEvent>();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                exception!.Paths,
+                Is.EquivalentTo(new[] { @"db\late.bin" }));
+            Assert.That(
+                File.ReadAllBytes(
+                    Path.Combine(project.Path, "db", "late.bin")),
+                Is.EqualTo(new byte[] { 9, 8, 7 }));
+            Assert.That(
+                File.Exists(
+                    Path.Combine(project.Path, "db", "new.bin")),
+                Is.False);
+            Assert.That(container.FileList, Is.Empty);
+            Assert.That(changeEvents, Is.Empty);
         });
     }
 

--- a/Testing/Shared.Core.Test/PackFiles/FolderProjectContainerTests.cs
+++ b/Testing/Shared.Core.Test/PackFiles/FolderProjectContainerTests.cs
@@ -1,5 +1,7 @@
+using Shared.ByteParsing;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
+using Shared.Core.PackFiles.Utility;
 
 namespace Test.Shared.Core.PackFiles;
 
@@ -679,6 +681,59 @@ public class FolderProjectContainerTests
     }
 
     [Test]
+    public void AddFiles_TargetAppearsDuringSourceReadWithoutOverwrite_PreservesExternalFileAndRollsBackBatch()
+    {
+        using var project = new TemporaryDirectory();
+        using var container = FolderProjectContainer.Create(
+            project.Path,
+            new FolderProjectSettings { Name = "工程" });
+        using var source = new BlockingDataSource([4, 5, 6]);
+        var delayedFile = PackFile.CreateFromBytes(
+            "late.bin",
+            [4, 5, 6]);
+        delayedFile.DataSource = source;
+
+        var addTask = Task.Run(
+            () => container.AddFiles(
+            [
+                new NewPackFileEntry(
+                    "db",
+                    PackFile.CreateFromBytes("new.bin", [1, 2, 3])),
+                new NewPackFileEntry("db", delayedFile),
+            ],
+            overwriteExisting: false));
+        try
+        {
+            Assert.That(
+                source.ReadStarted.Wait(TimeSpan.FromSeconds(5)),
+                Is.True,
+                "The add operation did not start reading its source.");
+            project.Write(@"db\late.bin", [9, 8, 7]);
+        }
+        finally
+        {
+            source.ReleaseRead.Set();
+        }
+
+        var exception = Assert.Throws<FolderProjectFileConflictException>(
+            () => addTask.GetAwaiter().GetResult());
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                exception!.Paths,
+                Is.EquivalentTo(new[] { @"db\late.bin" }));
+            Assert.That(
+                File.ReadAllBytes(
+                    Path.Combine(project.Path, "db", "late.bin")),
+                Is.EqualTo(new byte[] { 9, 8, 7 }));
+            Assert.That(
+                File.Exists(
+                    Path.Combine(project.Path, "db", "new.bin")),
+                Is.False);
+        });
+    }
+
+    [Test]
     public void MoveAndRename_IgnoredPathsFollowResource()
     {
         using var project = new TemporaryDirectory();
@@ -872,6 +927,42 @@ public class FolderProjectContainerTests
         public void Dispose()
         {
             Directory.Delete(Path, true);
+        }
+    }
+
+    private sealed class BlockingDataSource(byte[] data) :
+        IDataSource,
+        IDisposable
+    {
+        public ManualResetEventSlim ReadStarted { get; } = new(false);
+        public ManualResetEventSlim ReleaseRead { get; } = new(false);
+
+        public long Size => data.Length;
+        public CompressionFormat CompressionFormat =>
+            CompressionFormat.None;
+
+        public byte[] ReadData()
+        {
+            ReadStarted.Set();
+            if (!ReleaseRead.Wait(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException("The test did not release the read.");
+            return data.ToArray();
+        }
+
+        public byte[] PeekData(int size)
+        {
+            return data.Take(size).ToArray();
+        }
+
+        public ByteChunk ReadDataAsChunk()
+        {
+            return new ByteChunk(ReadData());
+        }
+
+        public void Dispose()
+        {
+            ReadStarted.Dispose();
+            ReleaseRead.Dispose();
         }
     }
 }

--- a/Testing/Shared.Core.Test/PackFiles/FolderProjectContainerTests.cs
+++ b/Testing/Shared.Core.Test/PackFiles/FolderProjectContainerTests.cs
@@ -642,7 +642,7 @@ public class FolderProjectContainerTests
                             "item.bin",
                             [9, 8, 7])),
                 ]),
-            Throws.TypeOf<IOException>());
+            Throws.TypeOf<FolderProjectFileConflictException>());
         Assert.That(
             File.ReadAllBytes(
                 Path.Combine(project.Path, "db", "item.bin")),


### PR DESCRIPTION
## 变更内容

- 将 RMV2、骨架 ANIM、全部动作 ANIM 和 DDS 输出先完整暂存在内存中，全部成功后一次性写入目标 Pack。
- 在任何写入前规范化全部资源路径并汇总冲突；冲突时停止导入，不覆盖、不自动改名。
- 增加结构化导入结果，向中文界面返回输出路径、警告、失败原因和异常信息。
- 保留带 `//skeleton//` 标识的原版游戏资产回导、已有骨架不重复写入以及后台线程安全写回行为。
- 加强文件夹工程提交阶段的并发保护：外部文件即使在最终原子移动前出现，也会被保留，整批输出回滚并报告结构化冲突。

## 用户影响

现有游戏资产的 glTF 回导行为保持兼容；失败或路径冲突不会留下只有模型、骨架、动作或贴图之一的半成品。成功和失败结果继续使用现有中文窗口、进度能力和语义图标展示。

## 验证

- `dotnet restore AssetEditor.CN.sln`
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore`
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity quiet`
- 完整 Release：2,909 通过，6 跳过，0 失败
- Shared Core：529/529 通过
- ImportExport：48/48 通过
- 真实小型 GLB 原子导入：6/6 通过
- 两路最终只读代码审查均无发现

构建仍会显示仓库既有警告；本次没有新增构建错误。

Closes #37