### PR TITLE
feat: 导入标准 OPAQUE glTF PBR 材质

### DIFF
--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/RmvMaterialBuilder.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/RmvMaterialBuilder.cs
@@ -1,20 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Security.Cryptography;
 using Editors.ImportExport.Importing.Importers.PngToDds;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
 using Shared.Core.Settings;
 using Shared.GameFormats.RigidModel;
 using Shared.GameFormats.RigidModel.Types;
-using SharpDX.DirectWrite;
 using SharpGLTF.Schema2;
 using TextureType = Shared.GameFormats.RigidModel.Types.TextureType;
-using Editors.ImportExport.Importing.Importers.GltfToRmv.Helper;
-using Microsoft.VisualBasic;
 
 namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper
 {
@@ -54,8 +52,8 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper
         {
             ValidateInput_BuildRmvFileMaterials(modelRoot, rmvFile);
 
-            var textureEntries = new Dictionary<string, NewPackFileEntry>(
-                StringComparer.OrdinalIgnoreCase);
+            var textureEntries = new List<NewPackFileEntry>();
+            var importedTexturePaths = new Dictionary<TextureCacheKey, string>();
             var meshSources = RmvMeshBuilder.GetMeshSources(modelRoot);
             for (int i = 0; i < meshSources.Count; i++)
             {
@@ -63,25 +61,26 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper
                     settings,
                     meshSources[i],
                     rmvFile.ModelList[0][i],
-                    textureEntries
+                    textureEntries,
+                    importedTexturePaths
                 );
             }
 
             rmvFile.RecalculateOffsets();
-            return textureEntries.Values.ToList();
+            return textureEntries;
         }
 
         private void BuildRmvModelMaterial(
             GltfImporterSettings settings,
             RmvMeshBuilder.MeshSource source,
             RmvModel rmvModel,
-            Dictionary<string, NewPackFileEntry> textureEntries)
+            ICollection<NewPackFileEntry> textureEntries,
+            IDictionary<TextureCacheKey, string> importedTexturePaths)
         {
             var gltfMaterial = source.Primitive.Material;
-            if (gltfMaterial == null || !gltfMaterial.Channels.Any())
-                return;
+            var assignedTextureTypes = new HashSet<TextureType>();
 
-            foreach (var itText in gltfMaterial.Channels)
+            foreach (var itText in gltfMaterial?.Channels ?? [])
             {
                 if (itText.Texture == null) continue;
 
@@ -108,15 +107,150 @@ namespace Editors.ImportExport.Importing.Importers.GltfToRmv.Helper
                     Path.GetFileName(texturePackFolder),
                     shouldConvert);
 
-                rmvModel.Material.SetTexture(textureType, texturePackFolder);
-
-                if (!textureEntries.ContainsKey(texturePackFolder))
-                {
-                    var newFile = new NewPackFileEntry(Path.GetDirectoryName(texturePackFolder) ?? "", ddsPackFile);
-                    textureEntries.Add(texturePackFolder, newFile);
-                }
-
+                AddTexture(
+                    rmvModel,
+                    textureEntries,
+                    importedTexturePaths,
+                    textureType,
+                    texturePackFolder,
+                    ddsPackFile,
+                    gameType,
+                    shouldConvert);
+                assignedTextureTypes.Add(textureType);
             }
+
+            if (settings.SelectedGame != GameTypeEnum.Warhammer3)
+                return;
+
+            AddNeutralTextureIfMissing(
+                settings,
+                source.ModelName,
+                rmvModel,
+                textureEntries,
+                importedTexturePaths,
+                assignedTextureTypes,
+                TextureType.BaseColour,
+                "base_colour");
+            AddNeutralTextureIfMissing(
+                settings,
+                source.ModelName,
+                rmvModel,
+                textureEntries,
+                importedTexturePaths,
+                assignedTextureTypes,
+                TextureType.Normal,
+                "normal");
+            AddNeutralTextureIfMissing(
+                settings,
+                source.ModelName,
+                rmvModel,
+                textureEntries,
+                importedTexturePaths,
+                assignedTextureTypes,
+                TextureType.MaterialMap,
+                "material_map");
+            AddNeutralTextureIfMissing(
+                settings,
+                source.ModelName,
+                rmvModel,
+                textureEntries,
+                importedTexturePaths,
+                assignedTextureTypes,
+                TextureType.Mask,
+                "mask");
+        }
+
+        private static void AddNeutralTextureIfMissing(
+            GltfImporterSettings settings,
+            string modelName,
+            RmvModel rmvModel,
+            ICollection<NewPackFileEntry> textureEntries,
+            IDictionary<TextureCacheKey, string> importedTexturePaths,
+            ISet<TextureType> assignedTextureTypes,
+            TextureType textureType,
+            string postFix)
+        {
+            if (assignedTextureTypes.Contains(textureType))
+                return;
+
+            var texturePath = GetTexturePackFolder(settings, modelName, postFix);
+            var shouldConvert = textureType is
+                TextureType.MaterialMap or TextureType.Normal;
+            using var imageStream = CreateNeutralTextureStream(textureType);
+            var ddsPackFile = PngToDdsImporter.Import(
+                imageStream,
+                textureType,
+                settings.SelectedGame,
+                Path.GetFileName(texturePath),
+                shouldConvert);
+            AddTexture(
+                rmvModel,
+                textureEntries,
+                importedTexturePaths,
+                textureType,
+                texturePath,
+                ddsPackFile,
+                settings.SelectedGame,
+                shouldConvert);
+        }
+
+        private static void AddTexture(
+            RmvModel rmvModel,
+            ICollection<NewPackFileEntry> textureEntries,
+            IDictionary<TextureCacheKey, string> importedTexturePaths,
+            TextureType textureType,
+            string texturePath,
+            PackFile ddsPackFile,
+            GameTypeEnum gameType,
+            bool shouldConvert)
+        {
+            var hash = Convert.ToHexString(SHA256.HashData(
+                ddsPackFile.DataSource.ReadData()));
+            var cacheKey = new TextureCacheKey(
+                gameType,
+                textureType,
+                shouldConvert,
+                hash);
+            if (importedTexturePaths.TryGetValue(cacheKey, out var importedPath))
+            {
+                rmvModel.Material.SetTexture(textureType, importedPath);
+                return;
+            }
+
+            rmvModel.Material.SetTexture(textureType, texturePath);
+            importedTexturePaths.Add(cacheKey, texturePath);
+            textureEntries.Add(new NewPackFileEntry(
+                Path.GetDirectoryName(texturePath) ?? "",
+                ddsPackFile));
+        }
+
+        private readonly record struct TextureCacheKey(
+            GameTypeEnum GameType,
+            TextureType TextureType,
+            bool ShouldConvert,
+            string ContentHash);
+
+        private static Stream CreateNeutralTextureStream(TextureType textureType)
+        {
+            var color = textureType switch
+            {
+                TextureType.BaseColour => Color.FromArgb(255, 255, 255, 255),
+                TextureType.Normal => Color.FromArgb(255, 128, 128, 255),
+                TextureType.MaterialMap => Color.FromArgb(255, 0, 255, 0),
+                TextureType.Mask => Color.FromArgb(255, 0, 0, 0),
+                _ => throw new ArgumentOutOfRangeException(nameof(textureType)),
+            };
+            using var bitmap = new Bitmap(4, 4, PixelFormat.Format32bppArgb);
+            for (var y = 0; y < bitmap.Height; y++)
+            {
+                for (var x = 0; x < bitmap.Width; x++)
+                    bitmap.SetPixel(x, y, color);
+            }
+
+            var stream = new MemoryStream();
+            bitmap.Save(stream, ImageFormat.Png);
+            stream.Position = 0;
+            return stream;
         }
 
         private static string GetTexturePackFolder(GltfImporterSettings settings, string meshName, string postFixString)

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/DDSFormatHelper.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/DDSFormatHelper.cs
@@ -40,7 +40,7 @@ namespace Editors.ImportExport.Importing.Importers.PngToDds.Helpers
 
             // metal-roughness material games            
             {(GameTypeEnum.Warhammer3, TextureType.BaseColour), DXGI_FORMAT.BC1_UNORM_SRGB},
-            {(GameTypeEnum.Warhammer3, TextureType.MaterialMap), DXGI_FORMAT.BC1_UNORM_SRGB},
+            {(GameTypeEnum.Warhammer3, TextureType.MaterialMap), DXGI_FORMAT.BC1_UNORM},
             {(GameTypeEnum.Warhammer3, TextureType.Normal), DXGI_FORMAT.BC3_UNORM},
             {(GameTypeEnum.Warhammer3, TextureType.Mask), DXGI_FORMAT.BC3_UNORM},
 

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/BlenderToWH3MaterialMapProcessor.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/BlenderToWH3MaterialMapProcessor.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using DirectXTexNet;
-using Editors.ImportExport.Common.Interfaces;
 
 namespace Editors.ImportExport.Common.Interfaces
 {
@@ -13,10 +8,19 @@ namespace Editors.ImportExport.Common.Interfaces
     {
         public ScratchImage Transform(ScratchImage scratchImage)
         {
-            if (!(scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM || scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM_SRGB))
+            var format = scratchImage.GetMetadata().Format;
+            if (format is not DXGI_FORMAT.B8G8R8A8_UNORM and
+                not DXGI_FORMAT.B8G8R8A8_UNORM_SRGB and
+                not DXGI_FORMAT.R8G8B8A8_UNORM and
+                not DXGI_FORMAT.R8G8B8A8_UNORM_SRGB)
             {
                 throw new Exception($"Error: image format is {scratchImage.GetMetadata().Format}  should be uncompressed RGBA8 (BC_B8G8R8A8_UNORM)");
             }
+
+            var isBgra = format is DXGI_FORMAT.B8G8R8A8_UNORM or
+                DXGI_FORMAT.B8G8R8A8_UNORM_SRGB;
+            var redOffset = isBgra ? 2 : 0;
+            var blueOffset = isBgra ? 0 : 2;
             
             var copyScratchImage = scratchImage.CreateImageCopy(0, false, CP_FLAGS.NONE);
             var srcImage = copyScratchImage.GetImage(0, 0, 0);
@@ -25,13 +29,12 @@ namespace Editors.ImportExport.Common.Interfaces
 
             for (int index = 0; index < srcImage.SlicePitch; index += 4)
             {
-                var r = rgbaBytes[index + 2];
                 var g = rgbaBytes[index + 1];
-                var b = rgbaBytes[index + 0];
+                var b = rgbaBytes[index + blueOffset];
                                 
-                rgbaBytes[index + 0] = r;
+                rgbaBytes[index + blueOffset] = 0;
                 rgbaBytes[index + 1] = g;
-                rgbaBytes[index + 2] = b;
+                rgbaBytes[index + redOffset] = b;
                 rgbaBytes[index + 3] = 255;
                 
             }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/BlueToOrangeNormalMapImageProcessor.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/BlueToOrangeNormalMapImageProcessor.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using DirectXTexNet;
 using Editors.ImportExport.Common.Interfaces;
-using Microsoft.Xna.Framework;
 
 namespace Editors.ImportExport.Importing.Importers.PngToDds.Helpers.ImageProcessor
 {
@@ -14,10 +9,19 @@ namespace Editors.ImportExport.Importing.Importers.PngToDds.Helpers.ImageProcess
     {
         public ScratchImage Transform(ScratchImage scratchImage)
         {
-            if (!(scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM || scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM_SRGB))
+            var format = scratchImage.GetMetadata().Format;
+            if (format is not DXGI_FORMAT.B8G8R8A8_UNORM and
+                not DXGI_FORMAT.B8G8R8A8_UNORM_SRGB and
+                not DXGI_FORMAT.R8G8B8A8_UNORM and
+                not DXGI_FORMAT.R8G8B8A8_UNORM_SRGB)
             {
                 throw new Exception($"Error: image format is {scratchImage.GetMetadata().Format}  should be uncompressed RGBA8 (BC_B8G8R8A8_UNORM)");
             }
+
+            var isBgra = format is DXGI_FORMAT.B8G8R8A8_UNORM or
+                DXGI_FORMAT.B8G8R8A8_UNORM_SRGB;
+            var redOffset = isBgra ? 2 : 0;
+            var blueOffset = isBgra ? 0 : 2;
 
             var copyScratchImage = scratchImage.CreateImageCopy(0, false, CP_FLAGS.NONE);
             var srcImage = copyScratchImage.GetImage(0, 0, 0);
@@ -28,15 +32,13 @@ namespace Editors.ImportExport.Importing.Importers.PngToDds.Helpers.ImageProcess
 
             for (int index = 0; index < srcImage.SlicePitch; index += 4)
             {
-                var x_red = rgbaBytes[index + 2];
+                var x_red = rgbaBytes[index + redOffset];
                 var y_green = rgbaBytes[index + 1];
 
-                rgbaBytes[index + 0] = 0;
+                rgbaBytes[index + blueOffset] = 0;
                 rgbaBytes[index + 1] = y_green;
-                rgbaBytes[index + 2] = 255;
+                rgbaBytes[index + redOffset] = 255;
                 rgbaBytes[index + 3] = x_red;
-
-                rgbaBytes[index + 1] = ColorChannels.GammaComponent(rgbaBytes[index + 1], 1 / 2.2f);
             }
 
             // copy processed pixel back to the image pixel pointer½

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/DefaultImageProcessor.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/Helpers/ImageProcessor/DefaultImageProcessor.cs
@@ -14,7 +14,11 @@ namespace Editors.ImportExport.Importing.Importers.PngToDds.Helpers.ImageProcess
     {
         public ScratchImage Transform(ScratchImage scratchImage)
         {          
-            if (!(scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM || scratchImage.GetMetadata().Format == DXGI_FORMAT.B8G8R8A8_UNORM_SRGB))
+            var format = scratchImage.GetMetadata().Format;
+            if (format is not DXGI_FORMAT.B8G8R8A8_UNORM and
+                not DXGI_FORMAT.B8G8R8A8_UNORM_SRGB and
+                not DXGI_FORMAT.R8G8B8A8_UNORM and
+                not DXGI_FORMAT.R8G8B8A8_UNORM_SRGB)
             {
                 throw new Exception($"Error: image format is {scratchImage.GetMetadata().Format}  should be uncompressed RGBA8 (BC_B8G8R8A8_UNORM)");
             }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/PngToDdsImporter.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/PngToDds/PngToDdsImporter.cs
@@ -19,7 +19,9 @@ namespace Editors.ImportExport.Importing.Importers.PngToDds
             string outFileName,
             bool convertSpecialTexture = true)
         {
-            using var scratchImagePng = TexHelper.Instance.LoadFromWICFile(inputPath, WIC_FLAGS.DEFAULT_SRGB);
+            using var scratchImagePng = TexHelper.Instance.LoadFromWICFile(
+                inputPath,
+                GetWicFlags(textureType));
             return Import(scratchImagePng, textureType, gameType, outFileName, convertSpecialTexture);
         }
 
@@ -39,7 +41,7 @@ namespace Editors.ImportExport.Importing.Importers.PngToDds
                 using var scratchImagePng = TexHelper.Instance.LoadFromWICMemory(
                     imageHandle.AddrOfPinnedObject(),
                     imageBytes.LongLength,
-                    WIC_FLAGS.DEFAULT_SRGB);
+                    GetWicFlags(textureType));
                 return Import(scratchImagePng, textureType, gameType, outFileName, convertSpecialTexture);
             }
             finally
@@ -63,7 +65,10 @@ namespace Editors.ImportExport.Importing.Importers.PngToDds
             {
                 var ddsFormat = DDSFormatHelper.GetDDSFormat(gameType, textureType);
                 using var ddsImage = imageWithMips.Compress(ddsFormat, TEX_COMPRESS_FLAGS.DEFAULT, 0.5f);
-                using var ddsMemStream = ddsImage.SaveToDDSMemory(DDS_FLAGS.NONE);
+                var ddsFlags = gameType == GameTypeEnum.Warhammer3
+                    ? DDS_FLAGS.FORCE_DX10_EXT
+                    : DDS_FLAGS.NONE;
+                using var ddsMemStream = ddsImage.SaveToDDSMemory(ddsFlags);
 
                 var ddsBytes = new byte[ddsMemStream.Length];
                 ddsMemStream.Read(ddsBytes, 0, ddsBytes.Length);
@@ -71,5 +76,10 @@ namespace Editors.ImportExport.Importing.Importers.PngToDds
                 return new PackFile(outFileName, new MemorySource(ddsBytes));
             }
         }
+
+        private static WIC_FLAGS GetWicFlags(TextureType textureType) =>
+            textureType is TextureType.BaseColour or TextureType.Diffuse or TextureType.Specular
+                ? WIC_FLAGS.DEFAULT_SRGB
+                : WIC_FLAGS.IGNORE_SRGB;
     }
 }

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfIToRmvImporterTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfIToRmvImporterTests.cs
@@ -40,7 +40,7 @@ namespace Test.ImportExport.Importing.Importers.GltfImporterTest
             public const int lod0MeshCount = 4;
             public const int Lod0Mesh0IndexCount = 25539;
             public const int Lod0Mesh0VertexCount = 6397;
-            public const int Lod0Mesh0TextureCount = 3;
+            public const int Lod0Mesh0TextureCount = 4;
         }
     }
 

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfImporterAtomicImportTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfImporterAtomicImportTests.cs
@@ -427,6 +427,9 @@ public class GltfImporterAtomicImportTests
                 Assert.That(result.OutputPaths, Is.EqualTo(new[]
                 {
                     @"tex\mesh_node_base_colour.dds",
+                    @"tex\mesh_node_normal.dds",
+                    @"tex\mesh_node_material_map.dds",
+                    @"tex\mesh_node_mask.dds",
                 }));
                 Assert.That(destination.FileList.Keys, Is.EquivalentTo(result.OutputPaths));
             });

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfPbrMaterialImportTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfPbrMaterialImportTests.cs
@@ -1,0 +1,579 @@
+﻿using System.Drawing;
+using System.Drawing.Imaging;
+using System.Numerics;
+using System.Text.Json;
+using DirectXTexNet;
+using Editors.ImportExport.Importing.Importers.GltfToRmv;
+using Editors.ImportExport.Importing.Importers.GltfToRmv.Helper;
+using GameWorld.Core.Services;
+using Moq;
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Services;
+using Shared.Core.Settings;
+using Shared.GameFormats.RigidModel;
+using Shared.GameFormats.RigidModel.Types;
+using Shared.TestUtility;
+using SharpGLTF.Geometry;
+using SharpGLTF.Geometry.VertexTypes;
+using SharpGLTF.Materials;
+using SharpGLTF.Schema2;
+
+namespace Test.ImportExport.Importing.Importers.GltfImporterTest;
+
+public class GltfPbrMaterialImportTests
+{
+    [SetUp]
+    public void SetUp() => new LocalizationManager().LoadLanguage();
+
+    [Test]
+    public void Import_OpaqueBaseColorGlb_WritesCompleteWh3MaterialWithCorrectColorSpaces()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+        try
+        {
+            var baseColorPath = CreatePng(
+                fixtureDirectory,
+                "base-color.png",
+                Color.FromArgb(255, 64, 128, 192));
+            var glbPath = CreateStaticModel(
+                fixtureDirectory,
+                "opaque.glb",
+                material => material.WithChannelImage(KnownChannel.BaseColor, baseColorPath));
+            var destination = new PackFileContainer("test");
+
+            var result = CreateImporter().Import(CreateSettings(glbPath, destination));
+            Assert.That(
+                result.Succeeded,
+                Is.True,
+                result.Exception?.ToString() ?? string.Join(Environment.NewLine, result.Errors));
+            var rmv = ModelFactory.Create().Load(
+                destination.FileList[@"models\opaque.rigid_model_v2"].DataSource.ReadData());
+            var material = rmv.ModelList[0][0].Material;
+            var observed = new
+            {
+                result.Succeeded,
+                TextureTypes = string.Join(",", material.GetAllTextures()
+                    .Select(texture => texture.TexureType)
+                    .OrderBy(type => type)),
+                BaseColourFormat = GetDdsFormat(
+                    destination.FileList[@"models\tex\mesh_node_base_colour.dds"]),
+                NormalFormat = GetDdsFormat(
+                    destination.FileList[@"models\tex\mesh_node_normal.dds"]),
+                MaterialMapFormat = GetDdsFormat(
+                    destination.FileList[@"models\tex\mesh_node_material_map.dds"]),
+                MaskFormat = GetDdsFormat(
+                    destination.FileList[@"models\tex\mesh_node_mask.dds"]),
+            };
+
+            Assert.That(observed, Is.EqualTo(new
+            {
+                Succeeded = true,
+                TextureTypes = string.Join(",", new[]
+                {
+                    TextureType.BaseColour,
+                    TextureType.MaterialMap,
+                    TextureType.Mask,
+                    TextureType.Normal,
+                }.OrderBy(type => type)),
+                BaseColourFormat = DXGI_FORMAT.BC1_UNORM_SRGB,
+                NormalFormat = DXGI_FORMAT.BC3_UNORM,
+                MaterialMapFormat = DXGI_FORMAT.BC1_UNORM,
+                MaskFormat = DXGI_FORMAT.BC3_UNORM,
+            }));
+        }
+        finally
+        {
+            Directory.Delete(fixtureDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Import_MissingGameMaps_WritesNeutralWh3DefaultsWhenConversionsAreDisabled()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+        try
+        {
+            var baseColorPath = CreatePng(
+                fixtureDirectory,
+                "base-color.png",
+                Color.CornflowerBlue);
+            var glbPath = CreateStaticModel(
+                fixtureDirectory,
+                "neutral.glb",
+                material => material.WithChannelImage(KnownChannel.BaseColor, baseColorPath));
+            var destination = new PackFileContainer("test");
+
+            var result = CreateImporter().Import(CreateSettings(
+                glbPath,
+                destination,
+                convertMaterial: false,
+                convertNormal: false));
+
+            Assert.That(
+                result.Succeeded,
+                Is.True,
+                result.Exception?.ToString() ?? string.Join(Environment.NewLine, result.Errors));
+            var normal = GetFirstPixel(destination.FileList[@"models\tex\mesh_node_normal.dds"]);
+            var materialMap = GetFirstPixel(destination.FileList[@"models\tex\mesh_node_material_map.dds"]);
+            var mask = GetFirstPixel(destination.FileList[@"models\tex\mesh_node_mask.dds"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(normal.R, Is.InRange(245, 255));
+                Assert.That(normal.G, Is.InRange(118, 138));
+                Assert.That(normal.B, Is.InRange(0, 10));
+                Assert.That(normal.A, Is.InRange(118, 138));
+                Assert.That(materialMap.R, Is.InRange(0, 10));
+                Assert.That(materialMap.G, Is.InRange(245, 255));
+                Assert.That(materialMap.B, Is.InRange(0, 10));
+                Assert.That(mask.R, Is.InRange(0, 10));
+                Assert.That(mask.G, Is.InRange(0, 10));
+                Assert.That(mask.B, Is.InRange(0, 10));
+                Assert.That(mask.A, Is.EqualTo(255));
+            });
+        }
+        finally
+        {
+            Directory.Delete(fixtureDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Import_BlueNormalGlb_ConvertsLinearChannelsToWh3OrangeNormal()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+        try
+        {
+            var normalPath = CreatePng(
+                fixtureDirectory,
+                "normal.png",
+                Color.FromArgb(255, 64, 128, 255),
+                PixelFormat.Format24bppRgb);
+            var glbPath = CreateStaticModel(
+                fixtureDirectory,
+                "normal.glb",
+                material => material.WithChannelImage(KnownChannel.Normal, normalPath));
+            var destination = new PackFileContainer("test");
+
+            var result = CreateImporter().Import(CreateSettings(glbPath, destination));
+
+            Assert.That(
+                result.Succeeded,
+                Is.True,
+                result.Exception?.ToString() ?? string.Join(Environment.NewLine, result.Errors));
+            var pixel = GetFirstPixel(destination.FileList[@"models\tex\mesh_node_normal.dds"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(pixel.R, Is.InRange(245, 255));
+                Assert.That(pixel.G, Is.InRange(118, 138));
+                Assert.That(pixel.B, Is.InRange(0, 10));
+                Assert.That(pixel.A, Is.InRange(54, 74));
+            });
+        }
+        finally
+        {
+            Directory.Delete(fixtureDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Import_MetallicRoughnessGlb_MapsBlueAndGreenChannelsToWh3MaterialMap()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+        try
+        {
+            var metallicRoughnessPath = CreatePng(
+                fixtureDirectory,
+                "metallic-roughness.png",
+                Color.FromArgb(255, 200, 96, 160),
+                PixelFormat.Format24bppRgb);
+            var glbPath = CreateStaticModel(
+                fixtureDirectory,
+                "material-map.glb",
+                material => material.WithChannelImage(
+                    KnownChannel.MetallicRoughness,
+                    metallicRoughnessPath));
+            var destination = new PackFileContainer("test");
+
+            var result = CreateImporter().Import(CreateSettings(glbPath, destination));
+
+            Assert.That(
+                result.Succeeded,
+                Is.True,
+                result.Exception?.ToString() ?? string.Join(Environment.NewLine, result.Errors));
+            var pixel = GetFirstPixel(destination.FileList[@"models\tex\mesh_node_material_map.dds"]);
+            Assert.Multiple(() =>
+            {
+                Assert.That(pixel.R, Is.InRange(150, 170));
+                Assert.That(pixel.G, Is.InRange(86, 106));
+                Assert.That(pixel.B, Is.InRange(0, 10));
+                Assert.That(pixel.A, Is.EqualTo(255));
+            });
+        }
+        finally
+        {
+            Directory.Delete(fixtureDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Import_GltfWithRelativeExternalImage_ImportsTexture()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+        try
+        {
+            var baseColorPath = CreatePng(
+                fixtureDirectory,
+                "external-base-color.png",
+                Color.CornflowerBlue);
+            var gltfPath = CreateStaticModel(
+                fixtureDirectory,
+                "external.gltf",
+                material => material.WithChannelImage(KnownChannel.BaseColor, baseColorPath));
+            var externalImages = GetExternalImagePaths(gltfPath);
+            var destination = new PackFileContainer("test");
+
+            var result = CreateImporter().Import(CreateSettings(gltfPath, destination));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(externalImages, Is.Not.Empty);
+                Assert.That(result.Succeeded, Is.True,
+                    result.Exception?.ToString() ?? string.Join(Environment.NewLine, result.Errors));
+                Assert.That(destination.FileList,
+                    Contains.Key(@"models\tex\mesh_node_base_colour.dds"));
+            });
+        }
+        finally
+        {
+            Directory.Delete(fixtureDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Import_GltfWithMissingExternalImage_FailsBeforeWritingPack()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+        try
+        {
+            var baseColorPath = CreatePng(
+                fixtureDirectory,
+                "missing-base-color.png",
+                Color.CornflowerBlue);
+            var gltfPath = CreateStaticModel(
+                fixtureDirectory,
+                "missing.gltf",
+                material => material.WithChannelImage(KnownChannel.BaseColor, baseColorPath));
+            var externalImages = GetExternalImagePaths(gltfPath);
+            Assert.That(externalImages, Is.Not.Empty);
+            foreach (var imagePath in externalImages)
+                File.Delete(imagePath);
+            var destination = new PackFileContainer("test");
+
+            var result = CreateImporter().Import(CreateSettings(gltfPath, destination));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Succeeded, Is.False);
+                Assert.That(result.Errors,
+                    Has.Some.Contains("无法读取 glTF/GLB 文件"));
+                Assert.That(destination.FileList, Is.Empty);
+            });
+        }
+        finally
+        {
+            Directory.Delete(fixtureDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Import_EquivalentDecodedImagesAndSemantic_WritesOneDdsPerSemantic()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+        try
+        {
+            var firstBaseColorPath = CreatePng(
+                fixtureDirectory,
+                "shared-base-color-32.png",
+                Color.CornflowerBlue);
+            var secondBaseColorPath = CreatePng(
+                fixtureDirectory,
+                "shared-base-color-24.png",
+                Color.CornflowerBlue,
+                PixelFormat.Format24bppRgb);
+            var glbPath = CreateTwoMeshModel(
+                fixtureDirectory,
+                "deduplicated.glb",
+                "first_node",
+                firstBaseColorPath,
+                "second_node",
+                secondBaseColorPath);
+            var destination = new PackFileContainer("test");
+
+            var result = CreateImporter().Import(CreateSettings(glbPath, destination));
+
+            Assert.That(
+                result.Succeeded,
+                Is.True,
+                result.Exception?.ToString() ?? string.Join(Environment.NewLine, result.Errors));
+            var rmv = ModelFactory.Create().Load(
+                destination.FileList[@"models\deduplicated.rigid_model_v2"].DataSource.ReadData());
+            var textureTypes = new[]
+            {
+                TextureType.BaseColour,
+                TextureType.Normal,
+                TextureType.MaterialMap,
+                TextureType.Mask,
+            };
+            Assert.Multiple(() =>
+            {
+                Assert.That(destination.FileList.Keys.Count(path =>
+                    path.EndsWith(".dds", StringComparison.OrdinalIgnoreCase)), Is.EqualTo(4));
+                foreach (var textureType in textureTypes)
+                {
+                    Assert.That(
+                        rmv.ModelList[0][0].Material.GetTexture(textureType)!.Value.Path,
+                        Is.EqualTo(rmv.ModelList[0][1].Material.GetTexture(textureType)!.Value.Path));
+                }
+            });
+        }
+        finally
+        {
+            Directory.Delete(fixtureDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Import_SamePixelsWithDifferentSemantics_WritesDistinctDdsFiles()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+        try
+        {
+            var sharedPath = CreatePng(
+                fixtureDirectory,
+                "shared.png",
+                Color.FromArgb(255, 64, 128, 192));
+            var glbPath = CreateStaticModel(
+                fixtureDirectory,
+                "semantic.glb",
+                material =>
+                {
+                    material.WithChannelImage(KnownChannel.BaseColor, sharedPath);
+                    material.WithChannelImage(KnownChannel.Normal, sharedPath);
+                });
+            var destination = new PackFileContainer("test");
+
+            var result = CreateImporter().Import(CreateSettings(glbPath, destination));
+
+            Assert.That(
+                result.Succeeded,
+                Is.True,
+                result.Exception?.ToString() ?? string.Join(Environment.NewLine, result.Errors));
+            var rmv = ModelFactory.Create().Load(
+                destination.FileList[@"models\semantic.rigid_model_v2"].DataSource.ReadData());
+            var baseColour = rmv.ModelList[0][0].Material.GetTexture(TextureType.BaseColour)!.Value.Path;
+            var normal = rmv.ModelList[0][0].Material.GetTexture(TextureType.Normal)!.Value.Path;
+            Assert.Multiple(() =>
+            {
+                Assert.That(baseColour, Is.Not.EqualTo(normal));
+                Assert.That(destination.FileList, Contains.Key(baseColour));
+                Assert.That(destination.FileList, Contains.Key(normal));
+            });
+        }
+        finally
+        {
+            Directory.Delete(fixtureDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public void Import_DifferentTexturesWithSameTargetPath_FailsWithoutPartialWrites()
+    {
+        var fixtureDirectory = CreateFixtureDirectory();
+        try
+        {
+            var firstPath = CreatePng(fixtureDirectory, "first.png", Color.Red);
+            var secondPath = CreatePng(fixtureDirectory, "second.png", Color.Blue);
+            var glbPath = CreateTwoMeshModel(
+                fixtureDirectory,
+                "conflict.glb",
+                "mesh?",
+                firstPath,
+                "mesh*",
+                secondPath);
+            var destination = new PackFileContainer("test");
+
+            var result = CreateImporter().Import(CreateSettings(glbPath, destination));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Succeeded, Is.False);
+                Assert.That(result.Errors, Has.Some.Contains("重复目标"));
+                Assert.That(destination.FileList, Is.Empty);
+            });
+        }
+        finally
+        {
+            Directory.Delete(fixtureDirectory, recursive: true);
+        }
+    }
+
+    private static GltfImporter CreateImporter() => new(
+        PackFileSerivceTestHelper.Create(TestData.InputPack),
+        Mock.Of<ISkeletonAnimationLookUpHelper>(),
+        new RmvMaterialBuilder());
+
+    private static GltfImporterSettings CreateSettings(
+        string gltfPath,
+        PackFileContainer destination,
+        bool convertMaterial = true,
+        bool convertNormal = true) => new(
+        gltfPath,
+        "models",
+        destination,
+        GameTypeEnum.Warhammer3,
+        true,
+        true,
+        convertMaterial,
+        convertNormal,
+        false,
+        20,
+        true);
+
+    private static string CreateStaticModel(
+        string directory,
+        string fileName,
+        Action<MaterialBuilder> configureMaterial)
+    {
+        var material = new MaterialBuilder("opaque_material")
+            .WithMetallicRoughness();
+        configureMaterial(material);
+        var geometry = new MeshBuilder<
+            VertexPositionNormalTangent,
+            VertexTexture1,
+            VertexJoints4>("mesh");
+        geometry.UsePrimitive(material).AddTriangle(
+            CreateVertex(0, 0),
+            CreateVertex(1, 0),
+            CreateVertex(0, 1));
+
+        var modelRoot = ModelRoot.CreateModel();
+        var mesh = modelRoot.CreateMesh(geometry);
+        modelRoot.UseScene("default").CreateNode("mesh_node").WithMesh(mesh);
+
+        var path = Path.Combine(directory, fileName);
+        modelRoot.Save(path);
+        return path;
+    }
+
+    private static string CreateTwoMeshModel(
+        string directory,
+        string fileName,
+        string firstNodeName,
+        string firstBaseColorPath,
+        string secondNodeName,
+        string secondBaseColorPath)
+    {
+        var modelRoot = ModelRoot.CreateModel();
+        var scene = modelRoot.UseScene("default");
+        AddMesh(modelRoot, scene, firstNodeName, firstBaseColorPath, 0);
+        AddMesh(modelRoot, scene, secondNodeName, secondBaseColorPath, 2);
+
+        var path = Path.Combine(directory, fileName);
+        modelRoot.Save(path);
+        return path;
+    }
+
+    private static void AddMesh(
+        ModelRoot modelRoot,
+        Scene scene,
+        string nodeName,
+        string baseColorPath,
+        float xOffset)
+    {
+        var material = new MaterialBuilder($"{nodeName}_material")
+            .WithMetallicRoughness()
+            .WithChannelImage(KnownChannel.BaseColor, baseColorPath);
+        var geometry = new MeshBuilder<
+            VertexPositionNormalTangent,
+            VertexTexture1,
+            VertexJoints4>(nodeName);
+        geometry.UsePrimitive(material).AddTriangle(
+            CreateVertex(xOffset, 0),
+            CreateVertex(xOffset + 1, 0),
+            CreateVertex(xOffset, 1));
+        scene.CreateNode(nodeName).WithMesh(modelRoot.CreateMesh(geometry));
+    }
+
+    private static VertexBuilder<
+        VertexPositionNormalTangent,
+        VertexTexture1,
+        VertexJoints4> CreateVertex(float x, float y)
+    {
+        var vertex = new VertexBuilder<
+            VertexPositionNormalTangent,
+            VertexTexture1,
+            VertexJoints4>();
+        vertex.Geometry.Position = new Vector3(x, y, 0);
+        vertex.Geometry.Normal = Vector3.UnitZ;
+        vertex.Geometry.Tangent = new Vector4(1, 0, 0, 1);
+        vertex.Material.TexCoord = new Vector2(x, y);
+        vertex.Skinning.SetBindings((0, 1), (0, 0), (0, 0), (0, 0));
+        return vertex;
+    }
+
+    private static string CreatePng(
+        string directory,
+        string fileName,
+        Color color,
+        PixelFormat pixelFormat = PixelFormat.Format32bppArgb)
+    {
+        var path = Path.Combine(directory, fileName);
+        using var bitmap = new Bitmap(4, 4, pixelFormat);
+        using var graphics = Graphics.FromImage(bitmap);
+        graphics.Clear(color);
+        bitmap.Save(path, ImageFormat.Png);
+        return path;
+    }
+
+    private static string CreateFixtureDirectory()
+    {
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            $"AssetEditorGltfPbr-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static IReadOnlyList<string> GetExternalImagePaths(string gltfPath)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(gltfPath));
+        return document.RootElement.GetProperty("images")
+            .EnumerateArray()
+            .Select(image => image.GetProperty("uri").GetString())
+            .Where(uri => !string.IsNullOrWhiteSpace(uri) &&
+                !uri.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            .Select(uri => Path.GetFullPath(
+                Path.Combine(
+                    Path.GetDirectoryName(gltfPath)!,
+                    Uri.UnescapeDataString(uri!))))
+            .ToList();
+    }
+
+    private static DXGI_FORMAT GetDdsFormat(PackFile packFile)
+    {
+        var data = packFile.DataSource.ReadData();
+        Assert.That(data, Has.Length.GreaterThanOrEqualTo(132));
+        Assert.That(BitConverter.ToUInt32(data, 84), Is.EqualTo(0x30315844));
+        return (DXGI_FORMAT)BitConverter.ToInt32(data, 128);
+    }
+
+    private static Color GetFirstPixel(PackFile packFile)
+    {
+        var png = MeshImportExport.TextureHelper.ConvertDdsToPng(
+            packFile.DataSource.ReadData());
+        using var stream = new MemoryStream(png);
+        using var bitmap = new Bitmap(stream);
+        return bitmap.GetPixel(0, 0);
+    }
+}

--- a/Editors/ImportExportEditor/Test.ImportExport/TestData/Gltf/README.md
+++ b/Editors/ImportExportEditor/Test.ImportExport/TestData/Gltf/README.md
@@ -6,4 +6,6 @@
 
 `vertex_limit.gltf` is a compact standard glTF 2.0 scene whose shared primitive is instanced twice and exceeds the RMV2 per-segment vertex limit without embedding a large binary buffer.
 
+The PBR import tests generate small standard OPAQUE GLB and `.gltf` fixtures at runtime from procedural triangles and solid-color images. They cover embedded and relative external images, base color, normal, metallic-roughness, equivalent decoded-image deduplication, and missing-image failure without carrying third-party assets.
+
 All fixtures were created specifically for this repository and are dedicated to the public domain under CC0-1.0: <https://creativecommons.org/publicdomain/zero/1.0/>.

--- a/Testing/AssetEditorTests/GltfImporterThreadingTests.cs
+++ b/Testing/AssetEditorTests/GltfImporterThreadingTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using System.Numerics;
 using System.Windows.Data;
+using Editors.ImportExport.Importing;
 using Editors.ImportExport.Importing.Importers.GltfToRmv;
 using Editors.ImportExport.Importing.Importers.GltfToRmv.Helper;
 using GameWorld.Core.Services;
@@ -8,6 +9,7 @@ using Moq;
 using NUnit.Framework;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
+using Shared.Core.Services;
 using Shared.Core.Settings;
 using Shared.GameFormats.Animation;
 using Shared.GameFormats.RigidModel.Transforms;
@@ -23,6 +25,9 @@ namespace AssetEditorTests;
 [NonParallelizable]
 public class GltfImporterThreadingTests
 {
+    [SetUp]
+    public void SetUp() => new LocalizationManager().LoadLanguage();
+
     [TestCase(PackWritePath.Model)]
     [TestCase(PackWritePath.Animation)]
     [TestCase(PackWritePath.Texture)]
@@ -32,7 +37,7 @@ public class GltfImporterThreadingTests
         var glbPath = CreateGlb(writePath);
         try
         {
-            var completion = new TaskCompletionSource<(Exception?, int)>(
+            var completion = new TaskCompletionSource<(Exception?, int, ImportResult?)>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
 
             WpfTestApplicationHost.Invoke(_application =>
@@ -78,9 +83,10 @@ public class GltfImporterThreadingTests
                 async Task RunImportAsync()
                 {
                     Exception? exception = null;
+                    ImportResult? importResult = null;
                     try
                     {
-                        await Task.Run(() => importer.Import(settings));
+                        importResult = await Task.Run(() => importer.Import(settings));
                     }
                     catch (Exception caughtException)
                     {
@@ -88,7 +94,7 @@ public class GltfImporterThreadingTests
                     }
 
                     GC.KeepAlive(collectionView);
-                    completion.TrySetResult((exception, uiCollection.Count));
+                    completion.TrySetResult((exception, uiCollection.Count, importResult));
                 }
             });
 
@@ -98,6 +104,11 @@ public class GltfImporterThreadingTests
             Assert.Multiple(() =>
             {
                 Assert.That(result.Item1, Is.Null);
+                Assert.That(
+                    result.Item3?.Succeeded,
+                    Is.True,
+                    result.Item3?.Exception?.ToString() ??
+                    string.Join(Environment.NewLine, result.Item3?.Errors ?? []));
                 Assert.That(result.Item2, Is.GreaterThan(0));
             });
         }


### PR DESCRIPTION
## 概要
- 按 glTF 材质语义和正确颜色空间转换 BaseColour、标准蓝法线与 metallic-roughness 贴图
- 为 WH3 补齐中性的 BaseColour、Normal、MaterialMap、Mask，并按内容、语义和转换选项安全去重
- 将贴图输出纳入导入前原子冲突检查，覆盖 GLB 内嵌图片、外部 glTF 相对图片和中文缺失错误
- 增加 CC0 程序化 PBR fixture 与后台线程回归测试

## 验证
- dotnet restore AssetEditor.CN.sln
- dotnet build AssetEditor.CN.sln --configuration Release --no-restore（0 错误）
- dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal（1159/1159 通过）
- Test.ImportExport（97/97 通过）
- GltfImporterThreadingTests（3/3 通过）

Closes #42