### PR TITLE
修复原版 glTF 动画回导的浮点缩放误判

### DIFF
--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/AnimationBuilder.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/AnimationBuilder.cs
@@ -196,6 +196,8 @@ public class AnimationBuilder
     private sealed class SkinAnimationRetargeter
     {
         private const float EquivalentBindTransformTolerance = 0.0001f;
+        private const float SourceScaleTolerance = 0.0001f;
+        private const float RetargetedScaleTolerance = 0.0002f;
 
         private sealed record JointBinding(
             Node Joint,
@@ -372,11 +374,18 @@ public class AnimationBuilder
                     throw new InvalidDataException(
                         $"glTF 动画在骨骼“{_skeleton.Bones[boneIndex].Name}”处无法分解为平移和旋转。");
                 }
-                if ((binding?.HasScaleChannel == true &&
-                     !IsUnitScale(
-                         binding.Joint.GetLocalTransform(animation, time).Scale,
-                         0.0001f)) ||
-                    !IsUnitScale(scale, 0.0001f))
+                var hasUnitSourceScale = binding?.HasScaleChannel != true ||
+                    IsUnitScale(
+                        binding.Joint.GetLocalTransform(animation, time).Scale,
+                        SourceScaleTolerance);
+                // Blender can emit explicit unit scale keys while tiny bind-pose
+                // differences force the animation through world-space retargeting.
+                var retargetedScaleTolerance =
+                    binding?.HasScaleChannel == true && hasUnitSourceScale
+                        ? RetargetedScaleTolerance
+                        : SourceScaleTolerance;
+                if (!hasUnitSourceScale ||
+                    !IsUnitScale(scale, retargetedScaleTolerance))
                 {
                     throw new InvalidDataException(
                         LocalizationManager.Instance.GetFormat(
@@ -451,7 +460,7 @@ public class AnimationBuilder
                 {
                     var sourceTransform = binding.Joint.GetLocalTransform(animation, time);
                     if (binding.HasScaleChannel &&
-                        !IsUnitScale(sourceTransform.Scale, 0.0001f))
+                        !IsUnitScale(sourceTransform.Scale, SourceScaleTolerance))
                     {
                         throw new InvalidDataException(
                             LocalizationManager.Instance.GetFormat(

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/AnimationBuilderTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/AnimationBuilderTests.cs
@@ -293,6 +293,68 @@ public class AnimationBuilderTests
     }
 
     [Test]
+    public void Build_UnitScaleKeysWithRetargetMatrixDrift_DoesNotRejectScale()
+    {
+        var modelRoot = ModelRoot.CreateModel();
+        var scene = modelRoot.UseScene("default");
+        var joint = scene.CreateNode("root");
+        var geometry = new MeshBuilder<
+            VertexPositionNormalTangent,
+            VertexTexture1,
+            VertexJoints4>("skinned_mesh");
+        geometry.UsePrimitive(
+                new MaterialBuilder("material").WithMetallicRoughness())
+            .AddTriangle(
+                CreateSkinnedVertex(Numerics.Vector3.Zero),
+                CreateSkinnedVertex(Numerics.Vector3.UnitX),
+                CreateSkinnedVertex(Numerics.Vector3.UnitY));
+        scene.CreateNode("mesh").WithSkinnedMesh(
+            modelRoot.CreateMesh(geometry),
+            (joint, Numerics.Matrix4x4.Identity));
+        var animation = modelRoot.CreateAnimation("Blender Roundtrip");
+        animation.CreateScaleChannel(joint, new Dictionary<float, Numerics.Vector3>
+        {
+            [0] = Numerics.Vector3.One,
+            [1] = new Numerics.Vector3(0.9999999f, 1, 1),
+        });
+        animation.CreateRotationChannel(joint, new Dictionary<float, Numerics.Quaternion>
+        {
+            [0] = Numerics.Quaternion.Identity,
+            [1] = Numerics.Quaternion.Identity,
+        });
+        var skeleton = CreateSingleBoneSkeleton();
+        var targetBindRotation = Numerics.Quaternion.CreateFromAxisAngle(
+            Numerics.Vector3.UnitZ,
+            MathF.PI / 2.0f);
+        const float storedQuaternionLength = 1.000078f;
+        skeleton.AnimationParts[0].DynamicFrames[0].Quaternion[0] =
+            new Shared.GameFormats.RigidModel.Transforms.RmvVector4(
+                targetBindRotation.X * storedQuaternionLength,
+                targetBindRotation.Y * storedQuaternionLength,
+                targetBindRotation.Z * storedQuaternionLength,
+                targetBindRotation.W * storedQuaternionLength);
+
+        var imported = AnimationBuilder.Build(
+            new AnimationBuilderSettings(
+                modelRoot,
+                "test",
+                1.0f,
+                new PackFileContainer("test"),
+                "animations",
+                false),
+            skeleton,
+            animation);
+
+        var rotation = imported.AnimationParts[0].DynamicFrames[0].Quaternion[0];
+        var rotationLength = MathF.Sqrt(
+            rotation.X * rotation.X +
+            rotation.Y * rotation.Y +
+            rotation.Z * rotation.Z +
+            rotation.W * rotation.W);
+        Assert.That(rotationLength, Is.EqualTo(1.0f).Within(0.000001f));
+    }
+
+    [Test]
     public void TrackSampler_PartialTranslationChannel_PreservesNodeRotation()
     {
         var modelRoot = ModelRoot.CreateModel();

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfExternalAnimationImportTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfExternalAnimationImportTests.cs
@@ -157,7 +157,7 @@ public class GltfExternalAnimationImportTests
                 new Dictionary<float, Vector3>
                 {
                     [0.00f] = Vector3.One,
-                    [0.05f] = new Vector3(2, 1, 1),
+                    [0.05f] = new Vector3(1.00015f, 1, 1),
                 });
         });
 
@@ -173,6 +173,7 @@ public class GltfExternalAnimationImportTests
                 Assert.That(result.Succeeded, Is.False);
                 Assert.That(result.Errors, Has.Some.Contains("Scaled Action"));
                 Assert.That(result.Errors, Has.Some.Contains("root"));
+                Assert.That(result.Errors, Has.Some.Contains("0.05"));
                 Assert.That(result.Errors, Has.Some.Contains("缩放"));
                 AssertDestinationUnchanged(destination, existingFile);
             });
@@ -180,6 +181,80 @@ public class GltfExternalAnimationImportTests
         finally
         {
             File.Delete(glbPath);
+        }
+    }
+
+    [TestCase(".gltf")]
+    [TestCase(".glb")]
+    public void Import_BlenderRoundTripWithUnitScaleKeys_CreatesAnimation(
+        string extension)
+    {
+        var fixture = CreateExistingGameSkeletonRoundTrip(extension);
+
+        try
+        {
+            var destination = new PackFileContainer("test");
+            var skeletonLookup = new Mock<ISkeletonAnimationLookUpHelper>();
+            skeletonLookup
+                .Setup(lookup => lookup.GetSkeletonFileFromName("test_skeleton"))
+                .Returns(fixture.Skeleton);
+            var importer = new GltfImporter(
+                PackFileSerivceTestHelper.Create(TestData.InputPack),
+                skeletonLookup.Object,
+                new RmvMaterialBuilder());
+
+            var result = importer.Import(CreateSettings(fixture.Path, destination));
+
+            Assert.That(
+                result.Succeeded,
+                Is.True,
+                result.Exception?.ToString() ??
+                string.Join(Environment.NewLine, result.Errors));
+            var animationPath = result.OutputPaths.Single(path =>
+                path.EndsWith(
+                    "_blender_roundtrip.anim",
+                    StringComparison.OrdinalIgnoreCase));
+            var imported = AnimationFile.Create(destination.FileList[animationPath]);
+            var frames = imported.AnimationParts[0].DynamicFrames;
+            var firstFrame = frames[0];
+            var rotation = firstFrame.Quaternion[0];
+            var rotationLength = MathF.Sqrt(
+                rotation.X * rotation.X +
+                rotation.Y * rotation.Y +
+                rotation.Z * rotation.Z +
+                rotation.W * rotation.W);
+            var storedRotation = fixture.Skeleton.AnimationParts[0]
+                .DynamicFrames[0].Quaternion[0];
+            var expectedRotation = Quaternion.Normalize(new Quaternion(
+                storedRotation.X,
+                storedRotation.Y,
+                storedRotation.Z,
+                storedRotation.W));
+            var actualRotation = Quaternion.Normalize(new Quaternion(
+                rotation.X,
+                rotation.Y,
+                rotation.Z,
+                rotation.W));
+            Assert.Multiple(() =>
+            {
+                Assert.That(rotationLength, Is.EqualTo(1.0f).Within(0.0001f));
+                Assert.That(
+                    MathF.Abs(Quaternion.Dot(expectedRotation, actualRotation)),
+                    Is.GreaterThan(0.9999f));
+                foreach (var frame in frames)
+                {
+                    Assert.That(frame.Transforms[0].X, Is.Zero.Within(0.000001f));
+                    Assert.That(frame.Transforms[0].Y, Is.Zero.Within(0.000001f));
+                    Assert.That(frame.Transforms[0].Z, Is.Zero.Within(0.000001f));
+                }
+                Assert.That(
+                    result.OutputPaths,
+                    Does.Not.Contain(@"animations\skeletons\test_skeleton.anim"));
+            });
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, true);
         }
     }
 
@@ -334,6 +409,99 @@ public class GltfExternalAnimationImportTests
         var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.glb");
         modelRoot.SaveGLB(path);
         return path;
+    }
+
+    private static (string Directory, string Path, AnimationFile Skeleton)
+        CreateExistingGameSkeletonRoundTrip(string extension)
+    {
+        var geometry = new MeshBuilder<
+            VertexPositionNormalTangent,
+            VertexTexture1,
+            VertexJoints4>("mesh");
+        geometry.UsePrimitive(
+                new MaterialBuilder("material").WithMetallicRoughness())
+            .AddTriangle(
+                CreateVertex(0, 0),
+                CreateVertex(1, 0),
+                CreateVertex(0, 1));
+        var modelRoot = ModelRoot.CreateModel();
+        var scene = modelRoot.UseScene("default");
+        scene.CreateNode("//skeleton//test_skeleton");
+        var joint = scene.CreateNode("root");
+        scene.CreateNode("mesh_node").WithSkinnedMesh(
+            modelRoot.CreateMesh(geometry),
+            (joint, Matrix4x4.Identity));
+        var animation = modelRoot.CreateAnimation("Blender Roundtrip");
+        animation.CreateScaleChannel(joint, new Dictionary<float, Vector3>
+        {
+            [0] = Vector3.One,
+            [1] = new Vector3(0.9999999f, 1, 1),
+        });
+        animation.CreateRotationChannel(joint, new Dictionary<float, Quaternion>
+        {
+            [0] = Quaternion.Identity,
+            [1] = Quaternion.Identity,
+        });
+
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"gltf_original_roundtrip_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, $"original_roundtrip{extension}");
+        if (string.Equals(extension, ".gltf", StringComparison.OrdinalIgnoreCase))
+            modelRoot.SaveGLTF(path);
+        else
+            modelRoot.SaveGLB(path);
+
+        return (directory, path, CreateStoredGameSkeleton());
+    }
+
+    private static AnimationFile CreateStoredGameSkeleton()
+    {
+        var targetBindRotation = Quaternion.CreateFromAxisAngle(
+            Vector3.UnitZ,
+            MathF.PI / 2.0f);
+        const float storedQuaternionLength = 1.000078f;
+        var frame = new AnimationFile.Frame
+        {
+            Transforms =
+            [
+                new Shared.GameFormats.RigidModel.Transforms.RmvVector3(0, 0, 0),
+            ],
+            Quaternion =
+            [
+                new Shared.GameFormats.RigidModel.Transforms.RmvVector4(
+                    targetBindRotation.X * storedQuaternionLength,
+                    targetBindRotation.Y * storedQuaternionLength,
+                    targetBindRotation.Z * storedQuaternionLength,
+                    targetBindRotation.W * storedQuaternionLength),
+            ],
+        };
+        var part = new AnimationFile.AnimationPart
+        {
+            DynamicFrames = [frame],
+        };
+        part.TranslationMappings.Add(new AnimationFile.AnimationBoneMapping(0));
+        part.RotationMappings.Add(new AnimationFile.AnimationBoneMapping(0));
+
+        return new AnimationFile
+        {
+            Header = new AnimationFile.AnimationHeader
+            {
+                FrameRate = 20,
+                SkeletonName = "test_skeleton",
+            },
+            Bones =
+            [
+                new AnimationFile.BoneInfo
+                {
+                    Id = 0,
+                    ParentId = -1,
+                    Name = "root",
+                },
+            ],
+            AnimationParts = [part],
+        };
     }
 
     private static VertexBuilder<


### PR DESCRIPTION
## 变更

- 将显式骨骼缩放键与世界空间重定向矩阵的数值误差分开校验
- 显式缩放仍保持原有 `0.0001` 安全阈值；仅当显式缩放已证明为单位缩放时，允许重定向矩阵最多 `0.0002` 的近单位误差
- 增加 glTF/GLB 回归覆盖，并锁定真实非单位缩放、剪切、Root 位移与旋转保持行为

## 验证

- 用户样例 `test.gltf` / `test.glb` + 当前 WH3 `heavyquadruped05.anim`：均成功生成 `hq05_attack_01.anim`
- `Test.ImportExport`：117 通过，0 失败
- `dotnet restore AssetEditor.CN.sln`：成功
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore`：成功，0 错误
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity minimal`：3019 通过，0 失败，6 跳过
- Standards / Spec 双轴审查：无代码问题；实际 AE 播放仍由用户人工验收

Refs #59