### PR TITLE
修复编辑器多行标签显示与关闭行为

### DIFF
--- a/AssetEditor/Themes/DesignSystem/Shell.xaml
+++ b/AssetEditor/Themes/DesignSystem/Shell.xaml
@@ -147,7 +147,7 @@
                 <ControlTemplate TargetType="{x:Type views:CachedTabControl}">
                     <Grid KeyboardNavigation.TabNavigation="Local">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="24" />
+                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <Border
@@ -156,7 +156,7 @@
                             BorderThickness="0,0,0,1">
                             <TabPanel
                                 x:Name="HeaderPanel"
-                                Height="{StaticResource AeSize.TabHeight}"
+                                MinHeight="{StaticResource AeSize.TabHeight}"
                                 IsItemsHost="True"
                                 KeyboardNavigation.TabIndex="1"
                                 Panel.ZIndex="1" />

--- a/AssetEditor/Views/MainWindow.xaml.cs
+++ b/AssetEditor/Views/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -108,6 +109,13 @@ namespace AssetEditor.Views
             {
                 if (e.ChangedButton == MouseButton.Left)
                 {
+                    if (e.OriginalSource is DependencyObject source &&
+                        FindParent<ButtonBase>(source) is not null)
+                    {
+                        _draggedItem = null;
+                        return;
+                    }
+
                     _lastMouseDown = e.GetPosition(EditorsTabControl);
 
                     var item = (TabItem)sender;
@@ -231,6 +239,21 @@ namespace AssetEditor.Views
                 if (childOfChild != null)
                     return childOfChild;
             }
+            return null;
+        }
+
+        private static T? FindParent<T>(DependencyObject child)
+            where T : DependencyObject
+        {
+            DependencyObject? current = child;
+            while (current is not null)
+            {
+                if (current is T match)
+                    return match;
+
+                current = VisualTreeHelper.GetParent(current);
+            }
+
             return null;
         }
     }

--- a/Testing/AssetEditorTests/FolderProjectGitWorkspaceViewModelTests.cs
+++ b/Testing/AssetEditorTests/FolderProjectGitWorkspaceViewModelTests.cs
@@ -1965,7 +1965,7 @@ public class FolderProjectGitWorkspaceViewModelTests
                 sidebarTabs.Attribute("Style")?.Value,
                 Is.EqualTo("{StaticResource AeShell.WorkspaceSidebar}"));
             NUnitAssert.That(
-                editorHeader.Attribute("Height")?.Value,
+                editorHeader.Attribute("MinHeight")?.Value,
                 Is.EqualTo("{StaticResource AeSize.TabHeight}"));
             NUnitAssert.That(
                 workspaceStyle.Descendants(presentation + "TabPanel"),
@@ -2017,6 +2017,9 @@ public class FolderProjectGitWorkspaceViewModelTests
             .Single(element =>
                 element.Attribute(xaml + "Key")?.Value ==
                 "AeShell.EditorTabs");
+        var editorHeaderRow = editorStyle
+            .Descendants(presentation + "RowDefinition")
+            .First();
         var splitterStyle = shell.Descendants(presentation + "Style")
             .Single(element =>
                 element.Attribute(xaml + "Key")?.Value ==
@@ -2041,8 +2044,11 @@ public class FolderProjectGitWorkspaceViewModelTests
                         setter.Attribute("Value")?.Value == "0"),
                 Is.True);
             NUnitAssert.That(
-                editorHeader.Attribute("Height")?.Value,
+                editorHeader.Attribute("MinHeight")?.Value,
                 Is.EqualTo("{StaticResource AeSize.TabHeight}"));
+            NUnitAssert.That(
+                editorHeaderRow.Attribute("Height")?.Value,
+                Is.EqualTo("Auto"));
             NUnitAssert.That(
                 editorHeader.Parent?.Attribute("Background")?.Value,
                 Is.EqualTo("{DynamicResource AeBrush.Surface1}"));

--- a/Testing/AssetEditorTests/UiMainShellGallery.cs
+++ b/Testing/AssetEditorTests/UiMainShellGallery.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -58,6 +59,256 @@ public class UiMainShellGallery
             services,
             () => Render(theme, variant, editorDatabase.Object));
     }
+
+    [TestCase(ThemeType.DarkTheme)]
+    [TestCase(ThemeType.LightTheme)]
+    [TestCase(ThemeType.HighContrastDark)]
+    [TestCase(ThemeType.HighContrastLight)]
+    public void EditorTabs_ShowAllWrappedRowsAndReturnToSingleRowAtWideWidth(
+        ThemeType theme) => WithWrappedEditorTabs(
+            theme,
+            (window, _, editors) =>
+            {
+                var headerPanel = (TabPanel)editors.Template.FindName(
+                    "HeaderPanel",
+                    editors);
+                var headerBand = (Border)VisualTreeHelper.GetParent(
+                    headerPanel);
+                var tabs = GetTabItems(editors);
+                var wrappedRows = RowOffsets(tabs, headerBand);
+
+                NUnitAssert.Multiple(() =>
+                {
+                    NUnitAssert.That(
+                        headerBand.ActualHeight,
+                        Is.EqualTo(49).Within(0.1));
+                    NUnitAssert.That(wrappedRows, Has.Count.EqualTo(2));
+                    NUnitAssert.That(wrappedRows[0], Is.GreaterThanOrEqualTo(0));
+                    NUnitAssert.That(
+                        wrappedRows[^1] + tabs[^1].ActualHeight,
+                        Is.LessThanOrEqualTo(headerBand.ActualHeight + 0.1));
+                });
+                SaveSnapshot(window, $"main-shell-wrapped-{theme}.png");
+
+                editors.Width = 1400;
+                window.UpdateLayout();
+
+                NUnitAssert.Multiple(() =>
+                {
+                    NUnitAssert.That(
+                        headerBand.ActualHeight,
+                        Is.EqualTo(25).Within(0.1));
+                    NUnitAssert.That(
+                        RowOffsets(tabs, headerBand),
+                        Has.Count.EqualTo(1));
+                });
+            });
+
+    [Test]
+    public void EditorTabCloseButton_DoesNotSelectBeforeClosingExactEditor() =>
+        WithWrappedEditorTabs(
+            ThemeType.DarkTheme,
+            (window, viewModel, editors) =>
+            {
+                var headerPanel = (TabPanel)editors.Template.FindName(
+                    "HeaderPanel",
+                    editors);
+                var selectedEditor =
+                    (ShellPreviewEditor)editors.SelectedItem;
+                var selectedTab = (TabItem)editors.ItemContainerGenerator
+                    .ContainerFromItem(selectedEditor);
+                var selectedRow = selectedTab.TranslatePoint(
+                    new Point(),
+                    headerPanel).Y;
+                var targetTab = GetTabItems(editors).First(tab =>
+                    !tab.IsSelected &&
+                    Math.Abs(tab.TranslatePoint(
+                        new Point(),
+                        headerPanel).Y - selectedRow) > 0.1);
+                var targetEditor = (ShellPreviewEditor)targetTab.DataContext;
+                var closeButton = FindVisualChild<Button>(targetTab)!;
+
+                RaiseLeftPreviewMouseDown(closeButton);
+                window.UpdateLayout();
+
+                NUnitAssert.Multiple(() =>
+                {
+                    NUnitAssert.That(
+                        editors.SelectedItem,
+                        Is.SameAs(selectedEditor));
+                    NUnitAssert.That(
+                        viewModel.EditorManager.CurrentEditorsList,
+                        Has.Count.EqualTo(5));
+                });
+
+                closeButton.Command.Execute(closeButton.CommandParameter);
+                window.UpdateLayout();
+
+                var itemsHolder = (Panel)editors.Template.FindName(
+                    "PART_ItemsHolder",
+                    editors);
+                NUnitAssert.Multiple(() =>
+                {
+                    NUnitAssert.That(
+                        viewModel.EditorManager.CurrentEditorsList,
+                        Has.Count.EqualTo(4));
+                    NUnitAssert.That(
+                        viewModel.EditorManager.CurrentEditorsList,
+                        Does.Not.Contain(targetEditor));
+                    NUnitAssert.That(
+                        editors.SelectedItem,
+                        Is.SameAs(selectedEditor));
+                    NUnitAssert.That(
+                        VisibleContent(itemsHolder),
+                        Is.SameAs(selectedEditor));
+                });
+
+                var nextSelectedTab = GetTabItems(editors)
+                    .First(tab => !tab.IsSelected);
+                var nextSelectedEditor =
+                    (ShellPreviewEditor)nextSelectedTab.DataContext;
+                RaiseLeftPreviewMouseDown(
+                    FindVisualChild<TextBlock>(nextSelectedTab)!);
+                window.UpdateLayout();
+                NUnitAssert.That(
+                    editors.SelectedItem,
+                    Is.SameAs(nextSelectedEditor));
+
+                var selectedCloseButton =
+                    FindVisualChild<Button>(nextSelectedTab)!;
+                selectedCloseButton.Command.Execute(
+                    selectedCloseButton.CommandParameter);
+                window.UpdateLayout();
+
+                NUnitAssert.Multiple(() =>
+                {
+                    NUnitAssert.That(
+                        viewModel.EditorManager.CurrentEditorsList,
+                        Has.Count.EqualTo(3));
+                    NUnitAssert.That(
+                        viewModel.EditorManager.CurrentEditorsList,
+                        Does.Not.Contain(nextSelectedEditor));
+                    NUnitAssert.That(editors.SelectedItem, Is.Not.Null);
+                    NUnitAssert.That(
+                        viewModel.EditorManager.CurrentEditorsList,
+                        Does.Contain(editors.SelectedItem));
+                    NUnitAssert.That(
+                        VisibleContent(itemsHolder),
+                        Is.SameAs(editors.SelectedItem));
+                });
+            });
+
+    private static void WithWrappedEditorTabs(
+        ThemeType theme,
+        Action<MainWindow, ShellPreviewViewModel, CachedTabControl> verify)
+    {
+        var settings = new ApplicationSettingsService();
+        var autoSaveService = new PackAutoSaveService(
+            Mock.Of<IPackFileService>(),
+            settings);
+        var editorDatabase = new Mock<IEditorDatabase>();
+        editorDatabase
+            .Setup(database => database.GetViewTypeFromViewModel(
+                typeof(ShellPreviewEditor)))
+            .Returns(typeof(MainShellPreviewEditorView));
+        using var services = new ServiceCollection()
+            .AddSingleton(LocalizationManager.Instance)
+            .AddSingleton(settings)
+            .AddSingleton(autoSaveService)
+            .BuildServiceProvider();
+
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            services,
+            () =>
+            {
+                var previousTheme = ThemesController.CurrentTheme;
+                MainWindow? window = null;
+                try
+                {
+                    ThemesController.SetTheme(theme);
+                    var viewModel = new ShellPreviewViewModel(
+                        editorDatabase.Object,
+                        includeEditors: false,
+                        isLoading: false,
+                        gitEnabled: true);
+                    foreach (var name in WrappedEditorNames)
+                    {
+                        viewModel.EditorManager.CurrentEditorsList.Add(
+                            new ShellPreviewEditor(name));
+                    }
+
+                    window = new MainWindow(
+                        ((IAssetEditorMain)Application.Current).ServiceProvider)
+                    {
+                        Width = 1800,
+                        Height = 760,
+                        WindowStyle = WindowStyle.None,
+                        ResizeMode = ResizeMode.NoResize,
+                        ShowActivated = false,
+                        ShowInTaskbar = false,
+                        DataContext = viewModel,
+                    };
+                    window.Show();
+                    window.UpdateLayout();
+
+                    var editors = (CachedTabControl)window.FindName(
+                        "EditorsTabControl");
+                    editors.Width = 720;
+                    editors.HorizontalAlignment = HorizontalAlignment.Left;
+                    editors.SelectedIndex = 0;
+                    editors.ApplyTemplate();
+                    window.UpdateLayout();
+                    verify(window, viewModel, editors);
+                }
+                finally
+                {
+                    window?.Close();
+                    ThemesController.SetTheme(previousTheme);
+                }
+            });
+    }
+
+    private static readonly string[] WrappedEditorNames =
+    {
+        "3k_dlc05_unit_wood_bandit_gang.variantmeshdefinition",
+        "3k_dlc05_unit_wood_tiger_guard.variantmeshdefinition",
+        "3k_dlc05_unit_metal_bandit_warriors.variantmeshdefinition",
+        "3k_dlc05_unit_water_bandit_hunters.variantmeshdefinition",
+        "3k_dlc05_unit_earth_handmaid_guard.variantmeshdefinition",
+    };
+
+    private static List<TabItem> GetTabItems(CachedTabControl editors) =>
+        Enumerable.Range(0, editors.Items.Count)
+            .Select(index => (TabItem)editors.ItemContainerGenerator
+                .ContainerFromIndex(index))
+            .ToList();
+
+    private static List<double> RowOffsets(
+        IEnumerable<TabItem> tabs,
+        UIElement relativeTo) => tabs
+            .Select(tab => Math.Round(
+                tab.TranslatePoint(new Point(), relativeTo).Y,
+                1))
+            .Distinct()
+            .Order()
+            .ToList();
+
+    private static void RaiseLeftPreviewMouseDown(UIElement element) =>
+        element.RaiseEvent(new MouseButtonEventArgs(
+            Mouse.PrimaryDevice,
+            Environment.TickCount,
+            MouseButton.Left)
+        {
+            RoutedEvent = Mouse.PreviewMouseDownEvent,
+            Source = element,
+        });
+
+    private static object VisibleContent(Panel itemsHolder) =>
+        itemsHolder.Children
+            .OfType<ContentPresenter>()
+            .Single(presenter =>
+                presenter.Visibility == Visibility.Visible)
+            .Content;
 
     private static void Render(
         ThemeType theme,
@@ -225,6 +476,52 @@ public class UiMainShellGallery
         return tree;
     }
 
+    private static T? FindVisualChild<T>(DependencyObject parent)
+        where T : DependencyObject
+    {
+        for (var index = 0;
+             index < VisualTreeHelper.GetChildrenCount(parent);
+             index++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, index);
+            if (child is T match)
+                return match;
+
+            var descendant = FindVisualChild<T>(child);
+            if (descendant is not null)
+                return descendant;
+        }
+
+        return null;
+    }
+
+    private static void SaveSnapshot(
+        FrameworkElement element,
+        string fileName)
+    {
+        var outputDirectory = Environment.GetEnvironmentVariable(
+            "AE_UI_QA_OUTPUT");
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+            return;
+
+        Directory.CreateDirectory(outputDirectory);
+        var dpi = VisualTreeHelper.GetDpi(element);
+        var bitmap = new RenderTargetBitmap(
+            (int)Math.Ceiling(element.ActualWidth * dpi.DpiScaleX),
+            (int)Math.Ceiling(element.ActualHeight * dpi.DpiScaleY),
+            dpi.PixelsPerInchX,
+            dpi.PixelsPerInchY,
+            PixelFormats.Pbgra32);
+        bitmap.Render(element);
+
+        using var stream = File.Create(Path.Combine(
+            outputDirectory,
+            fileName));
+        var encoder = new PngBitmapEncoder();
+        encoder.Frames.Add(BitmapFrame.Create(bitmap));
+        encoder.Save(stream);
+    }
+
     private static TreeViewItem TreeItem(
         string header,
         bool expanded = false) => new()
@@ -251,6 +548,7 @@ public class UiMainShellGallery
         public ShellPreviewGitWorkspace GitWorkspace { get; }
         public ShellPreviewEditorManager EditorManager { get; }
         public IEditorDatabase ToolsFactory { get; }
+        public ICommand CloseToolCommand { get; }
         public bool IsLoadingPacks { get; }
         public string LoadingStatusText { get; } = "正在读取 CA Pack";
         public string LoadingProgressDetailText { get; } =
@@ -268,6 +566,8 @@ public class UiMainShellGallery
             ToolsFactory = editorDatabase;
             GitWorkspace = new ShellPreviewGitWorkspace(gitEnabled);
             EditorManager = new ShellPreviewEditorManager();
+            CloseToolCommand = new ShellPreviewCommand(editor =>
+                EditorManager.CurrentEditorsList.Remove(editor));
             IsLoadingPacks = isLoading;
             LoadingProgressIsIndeterminate = isLoading;
 
@@ -297,6 +597,25 @@ public class UiMainShellGallery
         public ObservableCollection<ShellPreviewEditor>
             CurrentEditorsList { get; } = [];
         public int SelectedEditorIndex { get; set; }
+    }
+
+    private sealed class ShellPreviewCommand(
+        Action<ShellPreviewEditor> execute) : ICommand
+    {
+        public event EventHandler? CanExecuteChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public bool CanExecute(object? parameter) =>
+            parameter is ShellPreviewEditor;
+
+        public void Execute(object? parameter)
+        {
+            if (parameter is ShellPreviewEditor editor)
+                execute(editor);
+        }
     }
 }
 

--- a/Testing/AssetEditorTests/UiMainShellGallery.cs
+++ b/Testing/AssetEditorTests/UiMainShellGallery.cs
@@ -1,5 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
@@ -38,27 +40,8 @@ public class UiMainShellGallery
     [TestCase(ThemeType.HighContrastLight, "focus")]
     public void MainShell_RendersRequiredThemeAndWidth(
         ThemeType theme,
-        string variant)
-    {
-        var settings = new ApplicationSettingsService();
-        var autoSaveService = new PackAutoSaveService(
-            Mock.Of<IPackFileService>(),
-            settings);
-        var editorDatabase = new Mock<IEditorDatabase>();
-        editorDatabase
-            .Setup(database => database.GetViewTypeFromViewModel(
-                typeof(ShellPreviewEditor)))
-            .Returns(typeof(MainShellPreviewEditorView));
-        using var services = new ServiceCollection()
-            .AddSingleton(LocalizationManager.Instance)
-            .AddSingleton(settings)
-            .AddSingleton(autoSaveService)
-            .BuildServiceProvider();
-
-        WpfTestApplicationHost.InvokeWithThemeResources(
-            services,
-            () => Render(theme, variant, editorDatabase.Object));
-    }
+        string variant) => WithMainShellServices(
+            editorDatabase => Render(theme, variant, editorDatabase));
 
     [TestCase(ThemeType.DarkTheme)]
     [TestCase(ThemeType.LightTheme)]
@@ -141,7 +124,7 @@ public class UiMainShellGallery
                         Has.Count.EqualTo(5));
                 });
 
-                closeButton.Command.Execute(closeButton.CommandParameter);
+                InvokeButton(closeButton);
                 window.UpdateLayout();
 
                 var itemsHolder = (Panel)editors.Template.FindName(
@@ -176,8 +159,7 @@ public class UiMainShellGallery
 
                 var selectedCloseButton =
                     FindVisualChild<Button>(nextSelectedTab)!;
-                selectedCloseButton.Command.Execute(
-                    selectedCloseButton.CommandParameter);
+                InvokeButton(selectedCloseButton);
                 window.UpdateLayout();
 
                 NUnitAssert.Multiple(() =>
@@ -200,7 +182,57 @@ public class UiMainShellGallery
 
     private static void WithWrappedEditorTabs(
         ThemeType theme,
-        Action<MainWindow, ShellPreviewViewModel, CachedTabControl> verify)
+        Action<MainWindow, ShellPreviewViewModel, CachedTabControl> verify) =>
+        WithMainShellServices(editorDatabase =>
+        {
+            var previousTheme = ThemesController.CurrentTheme;
+            MainWindow? window = null;
+            try
+            {
+                ThemesController.SetTheme(theme);
+                var viewModel = new ShellPreviewViewModel(
+                    editorDatabase,
+                    includeEditors: false,
+                    isLoading: false,
+                    gitEnabled: true);
+                foreach (var name in s_wrappedEditorNames)
+                {
+                    viewModel.EditorManager.CurrentEditorsList.Add(
+                        new ShellPreviewEditor(name));
+                }
+
+                window = new MainWindow(
+                    ((IAssetEditorMain)Application.Current).ServiceProvider)
+                {
+                    Width = 1800,
+                    Height = 760,
+                    WindowStyle = WindowStyle.None,
+                    ResizeMode = ResizeMode.NoResize,
+                    ShowActivated = false,
+                    ShowInTaskbar = false,
+                    DataContext = viewModel,
+                };
+                window.Show();
+                window.UpdateLayout();
+
+                var editors = (CachedTabControl)window.FindName(
+                    "EditorsTabControl");
+                editors.Width = 720;
+                editors.HorizontalAlignment = HorizontalAlignment.Left;
+                editors.SelectedIndex = 0;
+                editors.ApplyTemplate();
+                window.UpdateLayout();
+                verify(window, viewModel, editors);
+            }
+            finally
+            {
+                window?.Close();
+                ThemesController.SetTheme(previousTheme);
+            }
+        });
+
+    private static void WithMainShellServices(
+        Action<IEditorDatabase> action)
     {
         var settings = new ApplicationSettingsService();
         var autoSaveService = new PackAutoSaveService(
@@ -219,56 +251,10 @@ public class UiMainShellGallery
 
         WpfTestApplicationHost.InvokeWithThemeResources(
             services,
-            () =>
-            {
-                var previousTheme = ThemesController.CurrentTheme;
-                MainWindow? window = null;
-                try
-                {
-                    ThemesController.SetTheme(theme);
-                    var viewModel = new ShellPreviewViewModel(
-                        editorDatabase.Object,
-                        includeEditors: false,
-                        isLoading: false,
-                        gitEnabled: true);
-                    foreach (var name in WrappedEditorNames)
-                    {
-                        viewModel.EditorManager.CurrentEditorsList.Add(
-                            new ShellPreviewEditor(name));
-                    }
-
-                    window = new MainWindow(
-                        ((IAssetEditorMain)Application.Current).ServiceProvider)
-                    {
-                        Width = 1800,
-                        Height = 760,
-                        WindowStyle = WindowStyle.None,
-                        ResizeMode = ResizeMode.NoResize,
-                        ShowActivated = false,
-                        ShowInTaskbar = false,
-                        DataContext = viewModel,
-                    };
-                    window.Show();
-                    window.UpdateLayout();
-
-                    var editors = (CachedTabControl)window.FindName(
-                        "EditorsTabControl");
-                    editors.Width = 720;
-                    editors.HorizontalAlignment = HorizontalAlignment.Left;
-                    editors.SelectedIndex = 0;
-                    editors.ApplyTemplate();
-                    window.UpdateLayout();
-                    verify(window, viewModel, editors);
-                }
-                finally
-                {
-                    window?.Close();
-                    ThemesController.SetTheme(previousTheme);
-                }
-            });
+            () => action(editorDatabase.Object));
     }
 
-    private static readonly string[] WrappedEditorNames =
+    private static readonly string[] s_wrappedEditorNames =
     {
         "3k_dlc05_unit_wood_bandit_gang.variantmeshdefinition",
         "3k_dlc05_unit_wood_tiger_guard.variantmeshdefinition",
@@ -302,6 +288,17 @@ public class UiMainShellGallery
             RoutedEvent = Mouse.PreviewMouseDownEvent,
             Source = element,
         });
+
+    private static void InvokeButton(Button button)
+    {
+        var peer = new ButtonAutomationPeer(button);
+        var provider = (IInvokeProvider)peer.GetPattern(
+            PatternInterface.Invoke);
+        provider.Invoke();
+        button.Dispatcher.Invoke(
+            () => { },
+            System.Windows.Threading.DispatcherPriority.ApplicationIdle);
+    }
 
     private static object VisibleContent(Panel itemsHolder) =>
         itemsHolder.Children
@@ -396,14 +393,7 @@ public class UiMainShellGallery
                 }
             });
 
-            var dpi = VisualTreeHelper.GetDpi(window);
-            var bitmap = new RenderTargetBitmap(
-                (int)Math.Ceiling(window.ActualWidth * dpi.DpiScaleX),
-                (int)Math.Ceiling(window.ActualHeight * dpi.DpiScaleY),
-                dpi.PixelsPerInchX,
-                dpi.PixelsPerInchY,
-                PixelFormats.Pbgra32);
-            bitmap.Render(window);
+            var bitmap = RenderToBitmap(window);
 
             NUnitAssert.Multiple(() =>
             {
@@ -411,19 +401,9 @@ public class UiMainShellGallery
                 NUnitAssert.That(bitmap.PixelHeight, Is.GreaterThan(0));
             });
 
-            var outputDirectory = Environment.GetEnvironmentVariable(
-                "AE_UI_QA_OUTPUT");
-            if (!string.IsNullOrWhiteSpace(outputDirectory))
-            {
-                Directory.CreateDirectory(outputDirectory);
-                var path = Path.Combine(
-                    outputDirectory,
-                    $"main-shell-{variant}-{theme}.png");
-                using var stream = File.Create(path);
-                var encoder = new PngBitmapEncoder();
-                encoder.Frames.Add(BitmapFrame.Create(bitmap));
-                encoder.Save(stream);
-            }
+            SaveSnapshot(
+                window,
+                $"main-shell-{variant}-{theme}.png");
 
             if (variant == "normal")
             {
@@ -505,6 +485,19 @@ public class UiMainShellGallery
             return;
 
         Directory.CreateDirectory(outputDirectory);
+        var bitmap = RenderToBitmap(element);
+
+        using var stream = File.Create(Path.Combine(
+            outputDirectory,
+            fileName));
+        var encoder = new PngBitmapEncoder();
+        encoder.Frames.Add(BitmapFrame.Create(bitmap));
+        encoder.Save(stream);
+    }
+
+    private static RenderTargetBitmap RenderToBitmap(
+        FrameworkElement element)
+    {
         var dpi = VisualTreeHelper.GetDpi(element);
         var bitmap = new RenderTargetBitmap(
             (int)Math.Ceiling(element.ActualWidth * dpi.DpiScaleX),
@@ -513,13 +506,7 @@ public class UiMainShellGallery
             dpi.PixelsPerInchY,
             PixelFormats.Pbgra32);
         bitmap.Render(element);
-
-        using var stream = File.Create(Path.Combine(
-            outputDirectory,
-            fileName));
-        var encoder = new PngBitmapEncoder();
-        encoder.Frames.Add(BitmapFrame.Create(bitmap));
-        encoder.Save(stream);
+        return bitmap;
     }
 
     private static TreeViewItem TreeItem(


### PR DESCRIPTION
## 变更

- 让编辑器标签标题区随换行数量自动增高，确保多行标签全部可见。
- 点击标签关闭按钮时不再提前切换或移动标签，关闭命令会作用于准确目标。
- 保留普通标签选择、拖拽排序、中键关闭、上下文菜单、未保存确认和缓存编辑器内容。
- 增加多行布局、按钮语义 Click、选中/未选中标签关闭及四主题回归测试。

## 根因

编辑器标签标题区原先固定为单行高度，`TabPanel` 换行后额外行会被后续内容遮挡。同时，标签容器的 `PreviewMouseDown` 会在关闭按钮按下时先强制聚焦标签，导致多行布局重新排列，按钮无法完成原本的点击关闭。

## 用户影响

打开多个长文件名时，所有标签行都会保持可见；点击任意标签的关闭按钮会关闭对应文件，不再只是跳转到该标签。

## 验证

- `dotnet restore AssetEditor.CN.sln`
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore`：0 错误
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal`：退出码 0；`AssetEditorTests` 1205/1205 通过
- 聚焦 UI 测试：17/17 通过
- Dark、Light、HighContrastDark、HighContrastLight 四主题视觉检查通过
- GitHub Actions `build-and-test` 通过

## 实机验收

- [x] 100% DPI
- [x] 125% DPI
- [x] 150% DPI

Closes #65
