### PR TITLE
修复重复打开文件时仍显示工具选择器

### DIFF
--- a/AssetEditor/Services/EditorManager.cs
+++ b/AssetEditor/Services/EditorManager.cs
@@ -66,8 +66,22 @@ namespace AssetEditor.Services
                 return null;
             }
 
-            var fullFileName = _packFileService.GetFullPath(file);
             var owner = _packFileService.GetPackFileContainer(file);
+            for (var i = 0; i < CurrentEditorsList.Count; i++)
+            {
+                var existingEditor = CurrentEditorsList[i];
+                if (existingEditor is IFileEditor existingFileEditor &&
+                    existingFileEditor.CurrentFile == file)
+                {
+                    _logger.Here().Information($"Attempting to open file '{file.Name}', but is is already open");
+                    if (owner != null)
+                        _editorOwners[existingEditor] = owner;
+                    SelectedEditorIndex = i;
+                    return existingEditor;
+                }
+            }
+
+            var fullFileName = _packFileService.GetFullPath(file);
             var editorViewModel = _editorDatabase.Create(fullFileName, preferedEditor);
             if (editorViewModel == null)
             {
@@ -79,23 +93,6 @@ namespace AssetEditor.Services
             // TODO: Ensure we can only get here if we have a fileEditor
             if (editorViewModel is IFileEditor fileEditor)
             {
-                // Ensure file is not already open
-                for (var i = 0; i < CurrentEditorsList.Count; i++)
-                {
-                    var existingEditor = CurrentEditorsList[i];
-                    if (existingEditor is IFileEditor existingFileEditor)
-                    {
-                        if (existingFileEditor.CurrentFile == file)
-                        {
-                            _logger.Here().Information($"Attempting to open file '{file.Name}', but is is already open");
-                            if (owner != null)
-                                _editorOwners[existingEditor] = owner;
-                            SelectedEditorIndex = i;
-                            return CurrentEditorsList[i];
-                        }
-                    }
-                }
-
                 // Open the file
                 _logger.Here().Information($"Opening {file.Name} with {editorViewModel?.GetType().Name}");
                 fileEditor.LoadFile(file);

--- a/Testing/AssetEditorTests/EditorManagerTests.cs
+++ b/Testing/AssetEditorTests/EditorManagerTests.cs
@@ -1,6 +1,8 @@
 using System.Windows;
 using AssetEditor.Services;
 using Moq;
+using Shared.Core.DependencyInjection;
+using Shared.Core.ErrorHandling;
 using Shared.Core.Events;
 using Shared.Core.Events.Global;
 using Shared.Core.PackFiles;
@@ -13,6 +15,128 @@ namespace AssetEditorTests
     [NUnit.Framework.TestFixture]
     public class EditorManagerTests
     {
+        [NUnit.Framework.Test]
+        [NUnit.Framework.NonParallelizable]
+        public void CreateFromFile_ReusesOpenEditorUntilItIsClosed()
+        {
+            var file = PackFile.CreateFromBytes(
+                "test.variantmeshdefinition",
+                [1]);
+            var container = new PackFileContainer("test.pack");
+            var firstEditor = new TestFileEditor();
+            var reopenedEditor = new TestFileEditor();
+            var scopeRepository = new Mock<IScopeRepository>();
+            scopeRepository
+                .SetupSequence(repository => repository.CreateScope(
+                    typeof(TestFileEditor)))
+                .Returns(firstEditor)
+                .Returns(reopenedEditor);
+            var toolSelector = new Mock<IToolSelectorUiProvider>();
+            toolSelector
+                .Setup(provider => provider.CreateAndShow(
+                    It.IsAny<IEnumerable<EditorEnums>>()))
+                .Returns(EditorEnums.Kitbash_Editor);
+            var editorDatabase = new EditorDatabase(
+                scopeRepository.Object,
+                toolSelector.Object);
+            EditorInfoBuilder
+                .Create<TestFileEditor, object>(
+                    EditorEnums.XML_VariantMesh_Editor)
+                .AddExtention(".variantmeshdefinition", 100)
+                .Build(editorDatabase);
+            EditorInfoBuilder
+                .Create<TestFileEditor, object>(
+                    EditorEnums.Kitbash_Editor)
+                .AddExtention(".variantmeshdefinition", 50)
+                .Build(editorDatabase);
+            var packFileService = new Mock<IPackFileService>();
+            packFileService
+                .Setup(service => service.GetFullPath(file, null))
+                .Returns("variantmeshes/test.variantmeshdefinition");
+            packFileService
+                .Setup(service => service.GetPackFileContainer(file))
+                .Returns(container);
+            var manager = new EditorManager(
+                Mock.Of<IGlobalEventHub>(),
+                packFileService.Object,
+                editorDatabase,
+                (_, _, _) => MessageBoxResult.Yes);
+            var initialOpenCount =
+                ApplicationStateRecorder.GetNumberOfOpenedEditors();
+
+            var firstResult = manager.CreateFromFile(
+                file,
+                EditorEnums.XML_VariantMesh_Editor);
+            manager.SelectedEditorIndex = -1;
+            var repeatedResult = manager.CreateFromFile(file, null);
+            var differentPreferredResult = manager.CreateFromFile(
+                file,
+                EditorEnums.Kitbash_Editor);
+
+            NUnit.Framework.Assert.Multiple(() =>
+            {
+                NUnit.Framework.Assert.That(
+                    firstResult,
+                    NUnit.Framework.Is.SameAs(firstEditor));
+                NUnit.Framework.Assert.That(
+                    repeatedResult,
+                    NUnit.Framework.Is.SameAs(firstEditor));
+                NUnit.Framework.Assert.That(
+                    differentPreferredResult,
+                    NUnit.Framework.Is.SameAs(firstEditor));
+                NUnit.Framework.Assert.That(
+                    manager.CurrentEditorsList,
+                    NUnit.Framework.Is.EqualTo(new[] { firstEditor }));
+                NUnit.Framework.Assert.That(
+                    manager.SelectedEditorIndex,
+                    NUnit.Framework.Is.Zero);
+                NUnit.Framework.Assert.That(
+                    ApplicationStateRecorder.GetNumberOfOpenedEditors(),
+                    NUnit.Framework.Is.EqualTo(initialOpenCount + 1));
+            });
+            toolSelector.Verify(
+                provider => provider.CreateAndShow(
+                    It.IsAny<IEnumerable<EditorEnums>>()),
+                Times.Never);
+            scopeRepository.Verify(
+                repository => repository.CreateScope(
+                    typeof(TestFileEditor)),
+                Times.Once);
+
+            manager.CloseTool(firstEditor);
+            var reopenedResult = manager.CreateFromFile(file, null);
+
+            NUnit.Framework.Assert.Multiple(() =>
+            {
+                NUnit.Framework.Assert.That(
+                    reopenedResult,
+                    NUnit.Framework.Is.SameAs(reopenedEditor));
+                NUnit.Framework.Assert.That(
+                    manager.CurrentEditorsList,
+                    NUnit.Framework.Is.EqualTo(new[] { reopenedEditor }));
+                NUnit.Framework.Assert.That(
+                    manager.SelectedEditorIndex,
+                    NUnit.Framework.Is.Zero);
+                NUnit.Framework.Assert.That(
+                    ApplicationStateRecorder.GetNumberOfOpenedEditors(),
+                    NUnit.Framework.Is.EqualTo(initialOpenCount + 2));
+            });
+            toolSelector.Verify(
+                provider => provider.CreateAndShow(
+                    It.IsAny<IEnumerable<EditorEnums>>()),
+                Times.Once);
+            scopeRepository.Verify(
+                repository => repository.CreateScope(
+                    typeof(TestFileEditor)),
+                Times.Exactly(2));
+            scopeRepository.Verify(
+                repository => repository.RemoveScope(firstEditor),
+                Times.Once);
+            NUnit.Framework.Assert.That(
+                firstEditor.CloseCount,
+                NUnit.Framework.Is.EqualTo(1));
+        }
+
         [NUnit.Framework.Test]
         public void BeforePackFileContainerRemoved_DefersClosingUntilUnloadIsApproved()
         {
@@ -436,6 +560,17 @@ namespace AssetEditorTests
             }
 
             return editor;
+        }
+
+        private sealed class TestFileEditor : IEditorInterface, IFileEditor
+        {
+            public string DisplayName { get; set; } = "Test editor";
+            public PackFile CurrentFile { get; private set; } = null!;
+            public int CloseCount { get; private set; }
+
+            public void LoadFile(PackFile file) => CurrentFile = file;
+
+            public void Close() => CloseCount++;
         }
     }
 }


### PR DESCRIPTION
## 变更

- 在创建编辑器和显示工具选择器前，先检查同一个 `PackFile` 是否已经打开。
- 重复打开时直接选中并复用原编辑器，即使请求指定了不同的首选编辑器。
- 关闭原编辑器后，再次打开仍按原有首选编辑器或工具选择器流程处理。
- 增加回归测试，覆盖编辑器列表、选择状态、工具选择器调用、作用域生命周期和编辑器打开计数。

## 根因

`EditorManager.CreateFromFile` 原先先调用 `IEditorDatabase` 选择并创建新编辑器，之后才检查文件是否已经打开。因此重复打开会先弹出工具选择器并创建一个不会进入标签页、也不会正常销毁的临时作用域。

## 用户影响

重复打开已经占用的文件不再反复弹出工具选择器，也不会遗留隐藏编辑器作用域；现有“同一文件只允许一个编辑器”的策略保持不变。

## 验证

- `EditorManagerTests`：11/11 通过
- Release 全量构建：通过，0 个错误
- Release 全量测试：1206/1206 通过，0 失败、0 跳过
- Standards 审查：0 项发现
- Spec 审查：0 项发现

Closes #63
