### PR TITLE
工具选择器支持双击选项直接打开

### DIFF
--- a/Shared/SharedUI/BaseDialogs/ToolSelector/ToolSelectorWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/ToolSelector/ToolSelectorWindow.xaml
@@ -30,6 +30,7 @@
                 <Style TargetType="ListViewItem">
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                     <Setter Property="Background" Value="Transparent" />
+                    <EventSetter Event="MouseDoubleClick" Handler="PossibleTool_MouseDoubleClick" />
                    
                 </Style>
             </ListView.ItemContainerStyle>

--- a/Shared/SharedUI/BaseDialogs/ToolSelector/ToolSelectorWindow.xaml.cs
+++ b/Shared/SharedUI/BaseDialogs/ToolSelector/ToolSelectorWindow.xaml.cs
@@ -1,5 +1,8 @@
 using CommonControls;
 ﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Shared.Core.ToolCreation;
 
 namespace CommonControls.BaseDialogs.ToolSelector
 {
@@ -14,7 +17,26 @@ namespace CommonControls.BaseDialogs.ToolSelector
             DarkTitleBarHelper.Enable(this);
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e)
+        private void PossibleTool_MouseDoubleClick(
+            object sender,
+            MouseButtonEventArgs e)
+        {
+            if (sender is not ListViewItem item ||
+                item.Content is not EditorEnums selectedEditor ||
+                selectedEditor == EditorEnums.None)
+            {
+                return;
+            }
+
+            PossibleTools.SelectedItem = selectedEditor;
+            ConfirmSelection();
+            e.Handled = true;
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs e) =>
+            ConfirmSelection();
+
+        private void ConfirmSelection()
         {
             DialogResult = true;
             Close();

--- a/Testing/AssetEditorTests/ToolSelectorWindowTests.cs
+++ b/Testing/AssetEditorTests/ToolSelectorWindowTests.cs
@@ -1,4 +1,4 @@
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
@@ -198,14 +198,7 @@ public class ToolSelectorWindowTests
     }
 
     private static void RaiseDoubleClick(UIElement element) =>
-        element.RaiseEvent(new MouseButtonEventArgs(
-            Mouse.PrimaryDevice,
-            Environment.TickCount,
-            MouseButton.Left)
-        {
-            RoutedEvent = Control.MouseDoubleClickEvent,
-            Source = element,
-        });
+        RaiseMouseButtonEvent(element, Control.MouseDoubleClickEvent);
 
     private static void RaiseSingleClick(
         ToolSelectorWindow window,

--- a/Testing/AssetEditorTests/ToolSelectorWindowTests.cs
+++ b/Testing/AssetEditorTests/ToolSelectorWindowTests.cs
@@ -1,0 +1,268 @@
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Threading;
+using CommonControls.BaseDialogs.ToolSelector;
+using NUnit.Framework;
+using Shared.Core.ToolCreation;
+using Shared.Ui.BaseDialogs.ToolSelector;
+using NUnitAssert = NUnit.Framework.Assert;
+
+namespace AssetEditorTests;
+
+[NonParallelizable]
+public class ToolSelectorWindowTests
+{
+    [Test]
+    public void CreateAndShow_DoubleClickingEditorReturnsThatEditor()
+    {
+        var result = EditorEnums.None;
+
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () => result = RunDialog(window =>
+                RaiseDoubleClick(window, EditorEnums.Kitbash_Editor)));
+
+        NUnitAssert.That(result, Is.EqualTo(EditorEnums.Kitbash_Editor));
+    }
+
+    [Test]
+    public void CreateAndShow_DoubleClickingEmptySpaceDoesNotConfirm()
+    {
+        var result = EditorEnums.None;
+        var remainedOpen = false;
+
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () => result = RunDialog(window =>
+            {
+                RaiseDoubleClick(window.PossibleTools);
+                remainedOpen = window.IsVisible;
+            }));
+
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(remainedOpen, Is.True);
+            NUnitAssert.That(result, Is.EqualTo(EditorEnums.None));
+        });
+    }
+
+    [Test]
+    public void CreateAndShow_DoubleClickingNoneDoesNotConfirm()
+    {
+        var result = EditorEnums.XML_Editor;
+        var remainedOpen = false;
+
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () => result = RunDialog(window =>
+            {
+                RaiseDoubleClick(window, EditorEnums.None);
+                remainedOpen = window.IsVisible;
+            }));
+
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(remainedOpen, Is.True);
+            NUnitAssert.That(result, Is.EqualTo(EditorEnums.None));
+        });
+    }
+
+    [Test]
+    public void CreateAndShow_SingleClickSelectsWithoutConfirming()
+    {
+        var result = EditorEnums.XML_Editor;
+        var selectedEditor = EditorEnums.None;
+        var remainedOpen = false;
+
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () => result = RunDialog(window =>
+            {
+                RaiseSingleClick(window, EditorEnums.Kitbash_Editor);
+                selectedEditor = (EditorEnums)
+                    window.PossibleTools.SelectedItem;
+                remainedOpen = window.IsVisible;
+            }));
+
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(
+                selectedEditor,
+                Is.EqualTo(EditorEnums.Kitbash_Editor));
+            NUnitAssert.That(remainedOpen, Is.True);
+            NUnitAssert.That(result, Is.EqualTo(EditorEnums.None));
+        });
+    }
+
+    [Test]
+    public void CreateAndShow_OpenButtonReturnsSelectedEditor()
+    {
+        var result = EditorEnums.None;
+
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () => result = RunDialog(window =>
+            {
+                window.PossibleTools.SelectedItem =
+                    EditorEnums.Kitbash_Editor;
+                InvokeOpenButton(window);
+            }));
+
+        NUnitAssert.That(result, Is.EqualTo(EditorEnums.Kitbash_Editor));
+    }
+
+    [Test]
+    public void CreateAndShow_ClosingWindowReturnsNone()
+    {
+        var result = EditorEnums.XML_Editor;
+
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () => result = RunDialog(_ => { }));
+
+        NUnitAssert.That(result, Is.EqualTo(EditorEnums.None));
+    }
+
+    [Test]
+    public void CreateAndShow_OpenButtonWithNoneReturnsNone()
+    {
+        var result = EditorEnums.XML_Editor;
+
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () => result = RunDialog(window =>
+            {
+                window.PossibleTools.SelectedItem = EditorEnums.None;
+                InvokeOpenButton(window);
+            }));
+
+        NUnitAssert.That(result, Is.EqualTo(EditorEnums.None));
+    }
+
+    private static EditorEnums RunDialog(
+        Action<ToolSelectorWindow> interaction)
+    {
+        var application = Application.Current;
+        var previousMainWindow = application.MainWindow;
+        var owner = new Window
+        {
+            ShowActivated = false,
+            ShowInTaskbar = false,
+            WindowStyle = WindowStyle.None,
+            Left = -10000,
+            Top = -10000,
+        };
+
+        try
+        {
+            owner.Show();
+            application.MainWindow = owner;
+            application.Dispatcher.BeginInvoke(
+                DispatcherPriority.ApplicationIdle,
+                () =>
+                {
+                    var window = application.Windows
+                        .OfType<ToolSelectorWindow>()
+                        .Single(candidate =>
+                            candidate.IsVisible &&
+                            candidate.Owner == owner);
+                    window.UpdateLayout();
+                    interaction(window);
+                    if (window.IsVisible)
+                        window.Close();
+                });
+
+            return new ToolSelectorUiProvider().CreateAndShow(
+                [
+                    EditorEnums.XML_VariantMesh_Editor,
+                    EditorEnums.Kitbash_Editor,
+                ]);
+        }
+        finally
+        {
+            application.MainWindow = previousMainWindow;
+            owner.Close();
+        }
+    }
+
+    private static void RaiseDoubleClick(
+        ToolSelectorWindow window,
+        EditorEnums editor)
+    {
+        var item = GetItem(window, editor);
+        RaiseDoubleClick(item);
+    }
+
+    private static void RaiseDoubleClick(UIElement element) =>
+        element.RaiseEvent(new MouseButtonEventArgs(
+            Mouse.PrimaryDevice,
+            Environment.TickCount,
+            MouseButton.Left)
+        {
+            RoutedEvent = Control.MouseDoubleClickEvent,
+            Source = element,
+        });
+
+    private static void RaiseSingleClick(
+        ToolSelectorWindow window,
+        EditorEnums editor)
+    {
+        var item = GetItem(window, editor);
+        RaiseMouseButtonEvent(item, UIElement.MouseLeftButtonDownEvent);
+        RaiseMouseButtonEvent(item, UIElement.MouseLeftButtonUpEvent);
+        window.Dispatcher.Invoke(
+            () => { },
+            DispatcherPriority.ApplicationIdle);
+    }
+
+    private static void RaiseMouseButtonEvent(
+        UIElement element,
+        RoutedEvent routedEvent) =>
+        element.RaiseEvent(new MouseButtonEventArgs(
+            Mouse.PrimaryDevice,
+            Environment.TickCount,
+            MouseButton.Left)
+        {
+            RoutedEvent = routedEvent,
+            Source = element,
+        });
+
+    private static void InvokeOpenButton(ToolSelectorWindow window)
+    {
+        var button = FindVisualChildren<Button>(window).Single();
+        var peer = new ButtonAutomationPeer(button);
+        var provider = (IInvokeProvider)peer.GetPattern(
+            PatternInterface.Invoke);
+        provider.Invoke();
+        window.Dispatcher.Invoke(
+            () => { },
+            DispatcherPriority.ApplicationIdle);
+    }
+
+    private static ListViewItem GetItem(
+        ToolSelectorWindow window,
+        EditorEnums editor) =>
+        (ListViewItem)window.PossibleTools.ItemContainerGenerator
+            .ContainerFromItem(editor);
+
+    private static IEnumerable<T> FindVisualChildren<T>(
+        DependencyObject parent)
+        where T : DependencyObject
+    {
+        for (var index = 0;
+             index < VisualTreeHelper.GetChildrenCount(parent);
+             index++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, index);
+            if (child is T match)
+                yield return match;
+
+            foreach (var descendant in FindVisualChildren<T>(child))
+                yield return descendant;
+        }
+    }
+}


### PR DESCRIPTION
## 变更

- 为工具选择器的真实编辑器行增加双击确认行为。
- 双击时先选中被点击的编辑器，再复用底部“打开”按钮的确认路径。
- 保持单击、空白区域、取消、`EditorEnums.None`、中文文案及 Provider 返回契约不变。
- 添加真实 WPF 模态交互回归测试，覆盖双击、单击、按钮、取消和 `None` 路径。

## 原因

当一个文件可由多个编辑器打开时，原界面只能先选择选项再点击底部“打开”。本次修改让用户能够直接双击目标编辑器完成相同操作。

## 验证

- `dotnet restore AssetEditor.CN.sln`：通过。
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore --verbosity minimal`：0 错误；仓库既有警告 2251 条。
- 工具选择器交互测试：7/7 通过。
- 相关 UI 与四主题离屏渲染测试：6/6 通过。
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal`：1213/1213 通过，0 失败，0 跳过。
- Standards 与 Issue Spec 最终审查：均无发现。

## 人工验收

尚未在真实桌面窗口中人工双击验收；Draft 阶段建议确认真实鼠标双击体验后再转为 Ready。

Closes #64
