### PR TITLE
兼容 WSModel surface_map 材质贴图槽位

### DIFF
--- a/Shared/GameFiles/WsModel/WsModelMaterialFile.cs
+++ b/Shared/GameFiles/WsModel/WsModelMaterialFile.cs
@@ -146,7 +146,8 @@ namespace Shared.GameFormats.WsModel
                     Textures[TextureType.Specular] = texturePath;
                 if (textureSlotName.Contains("base_colour", StringComparison.InvariantCultureIgnoreCase))
                     Textures[TextureType.BaseColour] = texturePath;
-                if (textureSlotName.Contains("material_map", StringComparison.InvariantCultureIgnoreCase))
+                if (textureSlotName.Contains("material_map", StringComparison.InvariantCultureIgnoreCase) ||
+                    textureSlotName.Contains("surface_map", StringComparison.InvariantCultureIgnoreCase))
                     Textures[TextureType.MaterialMap] = texturePath;
                 if (textureSlotName.Contains("xml_blood_map", StringComparison.InvariantCultureIgnoreCase))
                     Textures[TextureType.Blood] = texturePath;

--- a/Testing/GameWorld.Core.Test/Rendering/Materials/Serialization/WsModelMaterialFileTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/Materials/Serialization/WsModelMaterialFileTests.cs
@@ -1,0 +1,31 @@
+﻿using Shared.GameFormats.RigidModel.Types;
+using Shared.GameFormats.WsModel;
+
+namespace GameWorld.Core.Test.Rendering.Materials.Serialization
+{
+    internal class WsModelMaterialFileTests
+    {
+        [TestCase("s_xml_surface_map")]
+        [TestCase("t_xml_material_map")]
+        public void Constructor_MapsMaterialTextureSlots(string slotName)
+        {
+            const string texturePath = "VariantMeshes/_VariantModels/character/material_map.dds";
+            var materialXml = $"""
+                <material>
+                  <textures>
+                    <texture>
+                      <slot version="2">{slotName}</slot>
+                      <source>{texturePath}</source>
+                    </texture>
+                  </textures>
+                </material>
+                """;
+
+            var material = new WsModelMaterialFile(materialXml);
+
+            Assert.That(
+                material.Textures[TextureType.MaterialMap],
+                Is.EqualTo(texturePath));
+        }
+    }
+}


### PR DESCRIPTION
﻿## 修改内容

- 将 WSModel 材质中的 `surface_map` 槽位识别为 Material Map
- 保留现有 `material_map` 兼容行为
- 新增覆盖 `s_xml_surface_map` 与 `t_xml_material_map` 的回归测试

## 原因

部分原版材质使用 `s_xml_surface_map`。AE 之前只识别名称中包含 `material_map` 的槽位，因此 Kitbash 编辑器不能直接从 WSModel 材质读取该贴图，只能在 RMV2 中手动填写后通过备用路径生效。

## 影响

AE 现在可以直接读取 `surface_map`，无需修改贴图资源路径的大小写，也无需依赖 RMV2 的备用材质路径。

## 验证

- 修复前回归测试：`surface_map` 失败、`material_map` 通过
- 修复后定向测试：2/2 通过
- 相关材质测试：20/20 通过
- `Test.GameWorld.Core`：424/424 通过，0 失败、0 跳过
- 最终差异检查：通过
