### PR TITLE
fix: migrate in-app updates to Gitee

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@
 - 用户数据必须隔离在 `%USERPROFILE%\AssetEditor.CN`。
 - 本地应用数据、配置、缓存、日志、更新目录和备份不得与上游版本共用。
 - IPC 管道必须保持为 `AssetEditor.CN.Ipc`。
-- 更新源必须保持为 `Szy-Cathay/TheAssetEditor-CN`。
+- 程序内置更新检查与安装包下载源必须保持为 Gitee 仓库 `szy-cathay/AssetEditor-CN-Downloads`；源码、问题跟踪和 GitHub Release 仍使用 `Szy-Cathay/TheAssetEditor-CN`。
 - 用户可见界面仅保留中文；新增界面文本必须接入 `AssetEditor/Language_Cn.json`。
 - 不重新引入语言选择器、英文或法文运行时本地化入口。
 - 保留现有 C# 命名空间和 `RootNamespace`，不得进行全仓命名空间替换。

--- a/AssetEditor/UiCommands/OpenUpdaterWindowCommand.cs
+++ b/AssetEditor/UiCommands/OpenUpdaterWindowCommand.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using AssetEditor.ViewModels;
 using AssetEditor.Views.Updater;
 using Microsoft.Extensions.DependencyInjection;
-using Octokit;
 using Shared.Core.Events;
+using Shared.Core.Services;
 
 namespace AssetEditor.UiCommands
 {
@@ -12,7 +12,7 @@ namespace AssetEditor.UiCommands
     {
         private readonly IServiceProvider _serviceProvider = serviceProvider;
 
-        public void Execute(List<Release> newerReleases)
+        public void Execute(List<UpdateRelease> newerReleases)
         {
             var window = _serviceProvider.GetRequiredService<UpdaterWindow>();
             var viewModel = _serviceProvider.GetRequiredService<UpdaterViewModel>();

--- a/AssetEditor/ViewModels/UpdaterViewModel.cs
+++ b/AssetEditor/ViewModels/UpdaterViewModel.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Octokit;
 using Serilog;
 using Shared.Core.ErrorHandling;
 using Shared.Core.Services;
@@ -13,10 +12,10 @@ using Application = System.Windows.Application;
 
 namespace AssetEditor.ViewModels
 {
-    public class ReleaseNoteItem(Release release)
+    public class ReleaseNoteItem(UpdateRelease release)
     {
         public string ReleaseName { get; } = $"## [{release.Name}]({release.HtmlUrl})";
-        public string PublishedAt { get; } = $"{release.PublishedAt!.Value:dd MMM yyyy}";
+        public string PublishedAt { get; } = release.PublishedAt?.ToString("dd MMM yyyy") ?? string.Empty;
         public string ReleaseNotes { get; } = release.Body;
     }
 
@@ -30,12 +29,12 @@ namespace AssetEditor.ViewModels
         private const string AssetEditorUpdaterExe = "AssetEditor.CN.Updater.exe";
         private const string UpdaterDirectoryName = "Updater";
 
-        private List<Release> _newerReleases = [];
+        private List<UpdateRelease> _newerReleases = [];
 
         [ObservableProperty] private ObservableCollection<ReleaseNoteItem> _releaseNotesItems = [];
         [ObservableProperty] private string _updateInfo = string.Empty;
 
-        public void SetReleaseInfo(List<Release> newerReleases)
+        public void SetReleaseInfo(List<UpdateRelease> newerReleases)
         {
             _newerReleases = newerReleases;
 

--- a/AssetEditorUpdater/AssetEditorUpdater.cs
+++ b/AssetEditorUpdater/AssetEditorUpdater.cs
@@ -1,5 +1,5 @@
 ﻿using System.Diagnostics;
-using Octokit;
+using System.Text.Json;
 using FileMode = System.IO.FileMode;
 
 namespace AssetEditorUpdater
@@ -11,8 +11,8 @@ namespace AssetEditorUpdater
 
     public class AssetEditorUpdater
     {
-        private const string GitHubOwner = "Szy-Cathay";
-        private const string GitHubRepository = "TheAssetEditor-CN";
+        private static readonly Uri s_latestReleaseUri = new(
+            "https://gitee.com/api/v5/repos/szy-cathay/AssetEditor-CN-Downloads/releases/latest");
         private const string AssetEditorExe = "AssetEditor.CN.exe";
         private const string AssetEditorUpdaterExe = "AssetEditor.CN.Updater.exe";
          
@@ -272,7 +272,8 @@ namespace AssetEditorUpdater
                 installationDirectory,
                 workspace);
             var updateDirectory = workspace.UpdateDirectory;
-            var latestRelease = await GetLatestReleaseAsync();
+            using var httpClient = CreateHttpClient();
+            var latestRelease = await GetLatestReleaseAsync(httpClient);
             if (latestRelease == null)
                 return;
 
@@ -286,14 +287,18 @@ namespace AssetEditorUpdater
 
             Console.WriteLine($"正在将 Asset Editor 国区版从 {installedVersion} 更新到 {latestVersion}。");
 
-            var asset = GetAsset(latestRelease);
+            var downloadPlan = await GetDownloadPlanAsync(httpClient, latestRelease);
+            if (downloadPlan == null)
+                return;
+
             workspace = UpdateInstaller.ValidateWorkspace(
                 installationDirectory,
                 workspace);
             updateDirectory = workspace.UpdateDirectory;
-            var assetPath = GetAssetDownloadPath(updateDirectory, asset.Name);
+            var assetPath = GetAssetDownloadPath(updateDirectory, downloadPlan.ArchiveName);
             var downloadResult = await DownloadAssetAsync(
-                asset.BrowserDownloadUrl,
+                httpClient,
+                downloadPlan,
                 assetPath,
                 installationDirectory,
                 workspace);
@@ -312,17 +317,41 @@ namespace AssetEditorUpdater
             Console.ReadKey();
         }
 
-        private static async Task<Release?> GetLatestReleaseAsync()
+        private static async Task<GiteeRelease?> GetLatestReleaseAsync(HttpClient httpClient)
         {
             try
             {
-                var gitHubClient = new GitHubClient(new ProductHeaderValue("AssetEditor.CN"));
-                var releases = await gitHubClient.Repository.Release.GetAll(GitHubOwner, GitHubRepository);
-                return releases.Count > 0 ? releases[0] : null;
+                return await GiteeUpdateSource.GetLatestReleaseAsync(
+                    httpClient,
+                    s_latestReleaseUri);
             }
-            catch (ApiException exception)
+            catch (Exception exception) when (
+                exception is HttpRequestException
+                or JsonException
+                or TaskCanceledException
+                or NotSupportedException)
             {
-                Console.WriteLine($"无法从 GitHub 获取最新版本：{exception.Message}");
+                Console.WriteLine($"无法从 Gitee 获取最新版本：{exception.Message}");
+                return null;
+            }
+        }
+
+        private static async Task<GiteeDownloadPlan?> GetDownloadPlanAsync(
+            HttpClient httpClient,
+            GiteeRelease latestRelease)
+        {
+            try
+            {
+                return await GiteeUpdateSource.CreateDownloadPlanAsync(httpClient, latestRelease);
+            }
+            catch (Exception exception) when (
+                exception is HttpRequestException
+                or JsonException
+                or InvalidDataException
+                or TaskCanceledException
+                or NotSupportedException)
+            {
+                Console.WriteLine($"Gitee 更新文件清单无效：{exception.Message}");
                 return null;
             }
         }
@@ -345,19 +374,6 @@ namespace AssetEditorUpdater
         {
             var cleanedVersion = tagName.Trim().TrimStart('v', 'V');
             return new Version(cleanedVersion);
-        }
-
-        private static ReleaseAsset GetAsset(Release latestRelease)
-        {
-            if (latestRelease.Assets.Count != 1)
-                throw new InvalidOperationException($"Expected 1 asset, found {latestRelease.Assets.Count}.");
-
-            var asset = latestRelease.Assets[0];
-            var extension = Path.GetExtension(asset.Name);
-            if (!IsZipAssetName(asset.Name))
-                throw new InvalidOperationException($"Asset has extension {extension}, expected .zip.");
-
-            return asset;
         }
 
         internal static bool IsZipAssetName(string assetName)
@@ -510,7 +526,8 @@ namespace AssetEditorUpdater
         }
 
         private static async Task<bool> DownloadAssetAsync(
-            string downloadUrl,
+            HttpClient httpClient,
+            GiteeDownloadPlan downloadPlan,
             string downloadPath,
             string installationDirectory,
             UpdaterWorkspace workspace)
@@ -519,15 +536,9 @@ namespace AssetEditorUpdater
 
             try
             {
-                using var client = new HttpClient();
-                client.DefaultRequestHeaders.UserAgent.ParseAdd("AssetEditor.CN");
-
-                using var response = await client.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead);
-                response.EnsureSuccessStatusCode();
-
-                await using var responseStream = await response.Content.ReadAsStreamAsync();
-                await CopyAssetDownloadAsync(
-                    responseStream,
+                await GiteeUpdateSource.DownloadArchiveAsync(
+                    httpClient,
+                    downloadPlan,
                     downloadPath,
                     installationDirectory,
                     workspace);
@@ -536,9 +547,17 @@ namespace AssetEditorUpdater
             }
             catch
             {
-                Console.WriteLine("无法从 GitHub 下载最新版本。");
+                Console.WriteLine("无法从 Gitee 下载并校验最新版本。");
                 return false;
             }
+        }
+
+        private static HttpClient CreateHttpClient()
+        {
+            var httpClient = new HttpClient();
+            httpClient.Timeout = TimeSpan.FromMinutes(30);
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("AssetEditor.CN");
+            return httpClient;
         }
 
         private static void LaunchAssetEditor(string installationDirectory, string assetEditorPath)

--- a/AssetEditorUpdater/AssetEditorUpdater.csproj
+++ b/AssetEditorUpdater/AssetEditorUpdater.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="SharpCompress" Version="0.50.1" />
   </ItemGroup>

--- a/AssetEditorUpdater/GiteeUpdateSource.cs
+++ b/AssetEditorUpdater/GiteeUpdateSource.cs
@@ -1,0 +1,308 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AssetEditorUpdater;
+
+internal sealed record GiteeRelease(
+    [property: JsonPropertyName("tag_name")] string TagName,
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("body")] string Body,
+    [property: JsonPropertyName("assets")] IReadOnlyList<GiteeAsset> Assets);
+
+internal sealed record GiteeAsset(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("browser_download_url")] string BrowserDownloadUrl);
+
+internal sealed record GiteeUpdateManifest(
+    [property: JsonPropertyName("version")] string Version,
+    [property: JsonPropertyName("archive")] string Archive,
+    [property: JsonPropertyName("size")] long Size,
+    [property: JsonPropertyName("sha256")] string Sha256,
+    [property: JsonPropertyName("parts")] IReadOnlyList<GiteeUpdatePart> Parts);
+
+internal sealed record GiteeUpdatePart(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("size")] long Size,
+    [property: JsonPropertyName("sha256")] string Sha256);
+
+internal sealed record GiteePartDownload(string Name, long Size, string Sha256, Uri DownloadUri);
+
+internal sealed record GiteeDownloadPlan(
+    string ArchiveName,
+    long Size,
+    string Sha256,
+    IReadOnlyList<GiteePartDownload> Parts);
+
+internal static class GiteeUpdateSource
+{
+    private const string ManifestSuffix = ".manifest.json";
+
+    internal static async Task<GiteeRelease?> GetLatestReleaseAsync(
+        HttpClient httpClient,
+        Uri latestReleaseUri)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(latestReleaseUri);
+
+        using var response = await httpClient.GetAsync(latestReleaseUri);
+        response.EnsureSuccessStatusCode();
+        await using var responseStream = await response.Content.ReadAsStreamAsync();
+        return await JsonSerializer.DeserializeAsync<GiteeRelease>(responseStream);
+    }
+
+    internal static async Task<GiteeDownloadPlan> CreateDownloadPlanAsync(
+        HttpClient httpClient,
+        GiteeRelease release)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(release);
+        ValidateReleaseMetadata(release);
+
+        var manifestAssets = release.Assets
+            .Where(asset => asset.Name.EndsWith(ManifestSuffix, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (manifestAssets.Count != 1)
+            throw new InvalidDataException($"Expected 1 update manifest, found {manifestAssets.Count}.");
+
+        var manifestUri = ValidateDownloadUri(manifestAssets[0].BrowserDownloadUrl);
+        using var response = await httpClient.GetAsync(manifestUri);
+        response.EnsureSuccessStatusCode();
+        await using var responseStream = await response.Content.ReadAsStreamAsync();
+        var manifest = await JsonSerializer.DeserializeAsync<GiteeUpdateManifest>(responseStream)
+            ?? throw new InvalidDataException("The update manifest is empty.");
+        return CreateDownloadPlan(release, manifest);
+    }
+
+    internal static GiteeDownloadPlan CreateDownloadPlan(
+        GiteeRelease release,
+        GiteeUpdateManifest manifest)
+    {
+        ArgumentNullException.ThrowIfNull(release);
+        ArgumentNullException.ThrowIfNull(manifest);
+        ValidateReleaseMetadata(release);
+
+        var releaseVersion = release.TagName.Trim().TrimStart('v', 'V');
+        if (!string.Equals(manifest.Version, releaseVersion, StringComparison.Ordinal))
+            throw new InvalidDataException("The update manifest version does not match the release tag.");
+
+        ValidateSafeLeaf(manifest.Archive, requireZip: true);
+        ValidateHash(manifest.Sha256, "archive");
+        if (manifest.Size <= 0)
+            throw new InvalidDataException("The archive size must be positive.");
+        if (manifest.Parts == null
+            || manifest.Parts.Count == 0
+            || manifest.Parts.Any(part => part is null))
+            throw new InvalidDataException("The update manifest does not contain any parts.");
+
+        var assetsByName = release.Assets
+            .GroupBy(asset => asset.Name, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.Ordinal);
+        var partNames = new HashSet<string>(StringComparer.Ordinal);
+        var partDownloads = new List<GiteePartDownload>(manifest.Parts.Count);
+        long totalSize = 0;
+        foreach (var part in manifest.Parts)
+        {
+            ValidateSafeLeaf(part.Name, requireZip: true);
+            ValidateHash(part.Sha256, part.Name);
+            if (part.Size <= 0)
+                throw new InvalidDataException($"The update part size must be positive: {part.Name}");
+            if (!partNames.Add(part.Name))
+                throw new InvalidDataException($"The update manifest contains a duplicate part: {part.Name}");
+            if (!assetsByName.TryGetValue(part.Name, out var matchingAssets)
+                || matchingAssets.Count != 1)
+            {
+                throw new InvalidDataException($"Expected 1 release asset named {part.Name}.");
+            }
+
+            totalSize = checked(totalSize + part.Size);
+            partDownloads.Add(new GiteePartDownload(
+                part.Name,
+                part.Size,
+                part.Sha256,
+                ValidateDownloadUri(matchingAssets[0].BrowserDownloadUrl)));
+        }
+
+        if (totalSize != manifest.Size)
+            throw new InvalidDataException("The update part sizes do not match the archive size.");
+
+        return new GiteeDownloadPlan(manifest.Archive, manifest.Size, manifest.Sha256, partDownloads);
+    }
+
+    internal static async Task DownloadArchiveAsync(
+        HttpClient httpClient,
+        GiteeDownloadPlan plan,
+        string downloadPath,
+        string installationDirectory,
+        UpdaterWorkspace workspace,
+        string? localApplicationDataRoot = null,
+        string? commonApplicationDataRoot = null)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentException.ThrowIfNullOrWhiteSpace(downloadPath);
+        ArgumentNullException.ThrowIfNull(workspace);
+
+        var validatedWorkspace = UpdateInstaller.ValidateWorkspace(
+            installationDirectory,
+            workspace,
+            localApplicationDataRoot,
+            commonApplicationDataRoot);
+        var paths = UpdaterWorkspaceFactory.GetTransactionPaths(validatedWorkspace.UpdateDirectory);
+        var canonicalDownloadPath = AssetEditorUpdater.GetAssetDownloadPath(
+            paths.UpdateDirectory,
+            plan.ArchiveName);
+        if (!PathsEqual(downloadPath, canonicalDownloadPath))
+            throw new InvalidDataException("The release asset path is outside the validated Update directory.");
+
+        using var transactionIdentity = WindowsPathIdentity.OpenExistingDirectory(
+            paths.TransactionRoot,
+            nameof(workspace),
+            WindowsDirectoryLeaseMode.Pinned);
+        using var updateIdentity = WindowsPathIdentity.OpenExistingDirectory(
+            paths.UpdateDirectory,
+            nameof(workspace),
+            WindowsDirectoryLeaseMode.Pinned);
+        WindowsPathIdentity.RequireDirectChild(
+            transactionIdentity,
+            updateIdentity,
+            "Update must be a direct child of the transaction root.");
+
+        var destinationCreated = false;
+        try
+        {
+            await using var destination = new FileStream(
+                canonicalDownloadPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None);
+            destinationCreated = true;
+            using var archiveHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            var buffer = new byte[81920];
+            long archiveSize = 0;
+
+            foreach (var part in plan.Parts)
+            {
+                using var response = await httpClient.GetAsync(
+                    part.DownloadUri,
+                    HttpCompletionOption.ResponseHeadersRead);
+                response.EnsureSuccessStatusCode();
+                if (response.Content.Headers.ContentLength is long contentLength
+                    && contentLength != part.Size)
+                {
+                    throw new InvalidDataException($"The downloaded part has an unexpected size: {part.Name}");
+                }
+
+                await using var source = await response.Content.ReadAsStreamAsync();
+                using var partHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+                long partSize = 0;
+                int bytesRead;
+                while ((bytesRead = await source.ReadAsync(buffer)) > 0)
+                {
+                    await destination.WriteAsync(buffer.AsMemory(0, bytesRead));
+                    partHash.AppendData(buffer, 0, bytesRead);
+                    archiveHash.AppendData(buffer, 0, bytesRead);
+                    partSize = checked(partSize + bytesRead);
+                    archiveSize = checked(archiveSize + bytesRead);
+                }
+
+                if (partSize != part.Size || !HashMatches(partHash.GetHashAndReset(), part.Sha256))
+                    throw new InvalidDataException($"The downloaded part failed verification: {part.Name}");
+            }
+
+            destination.Flush(flushToDisk: true);
+            if (archiveSize != plan.Size || !HashMatches(archiveHash.GetHashAndReset(), plan.Sha256))
+                throw new InvalidDataException("The assembled update archive failed verification.");
+        }
+        catch
+        {
+            if (destinationCreated)
+            {
+                try
+                {
+                    UpdateInstaller.DeleteOwnedArchive(
+                        validatedWorkspace,
+                        canonicalDownloadPath,
+                        transactionIdentity,
+                        updateIdentity);
+                }
+                catch (Exception cleanupException)
+                {
+                    Console.Error.WriteLine(
+                        $"Updater cleanup failed; preserving the original failure: {cleanupException}");
+                }
+            }
+
+            throw;
+        }
+    }
+
+    private static void ValidateSafeLeaf(string fileName, bool requireZip)
+    {
+        if (string.IsNullOrWhiteSpace(fileName)
+            || Path.IsPathRooted(fileName)
+            || Path.IsPathFullyQualified(fileName)
+            || fileName is "." or ".."
+            || fileName.Contains(Path.DirectorySeparatorChar)
+            || fileName.Contains(Path.AltDirectorySeparatorChar)
+            || fileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || fileName.EndsWith('.')
+            || fileName.EndsWith(' ')
+            || (requireZip && !AssetEditorUpdater.IsZipAssetName(fileName)))
+        {
+            throw new InvalidDataException($"The update file name is not a safe leaf: {fileName}");
+        }
+    }
+
+    private static void ValidateReleaseMetadata(GiteeRelease release)
+    {
+        if (string.IsNullOrWhiteSpace(release.TagName)
+            || release.Assets == null
+            || release.Assets.Any(asset =>
+                asset is null
+                || string.IsNullOrWhiteSpace(asset.Name)
+                || string.IsNullOrWhiteSpace(asset.BrowserDownloadUrl)))
+        {
+            throw new InvalidDataException("The Gitee release metadata is incomplete.");
+        }
+    }
+
+    private static Uri ValidateDownloadUri(string downloadUrl)
+    {
+        if (!Uri.TryCreate(downloadUrl, UriKind.Absolute, out var uri)
+            || uri.Scheme != Uri.UriSchemeHttps
+            || !string.Equals(uri.Host, "gitee.com", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException("The update download URL is not an HTTPS Gitee URL.");
+        }
+
+        return uri;
+    }
+
+    private static void ValidateHash(string sha256, string itemName)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(sha256)
+                || Convert.FromHexString(sha256).Length != 32)
+                throw new InvalidDataException($"The SHA-256 value is invalid: {itemName}");
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidDataException($"The SHA-256 value is invalid: {itemName}", exception);
+        }
+    }
+
+    private static bool HashMatches(byte[] actualHash, string expectedHash)
+    {
+        return CryptographicOperations.FixedTimeEquals(actualHash, Convert.FromHexString(expectedHash));
+    }
+
+    private static bool PathsEqual(string firstPath, string secondPath)
+    {
+        return string.Equals(
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(firstPath)),
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(secondPath)),
+            StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporter.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/GltfImporter.cs
@@ -5,7 +5,6 @@ using Editors.ImportExport.Misc;
 using Editors.Shared.Core.Services;
 using GameWorld.Core.SceneNodes;
 using GameWorld.Core.Services;
-using Octokit;
 using Serilog;
 using Shared.Core.ErrorHandling;
 using Shared.Core.PackFiles;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Asset Editor 国区版
 
-[下载最新版本](https://github.com/Szy-Cathay/TheAssetEditor-CN/releases/latest) · [查看上游项目](https://github.com/donkeyProgramming/TheAssetEditor) · [问题反馈](https://github.com/Szy-Cathay/TheAssetEditor-CN/issues)
+[下载完整安装包](https://github.com/Szy-Cathay/TheAssetEditor-CN/releases/latest) · [国内更新源](https://gitee.com/szy-cathay/AssetEditor-CN-Downloads/releases) · [查看上游项目](https://github.com/donkeyProgramming/TheAssetEditor) · [问题反馈](https://github.com/Szy-Cathay/TheAssetEditor-CN/issues)
 
 > **仓库来源**
 >
@@ -27,7 +27,8 @@ Asset Editor 国区版是一款运行在 Windows 上的《全面战争》系列�
 - 更新器：`AssetEditor.CN.Updater.exe`
 - 用户数据目录：`%USERPROFILE%\AssetEditor.CN`
 - IPC 接口：`AssetEditor.CN.Ipc`
-- 更新来源：`Szy-Cathay/TheAssetEditor-CN`
+- 程序更新来源：Gitee `szy-cathay/AssetEditor-CN-Downloads`
+- 源码与问题跟踪：GitHub `Szy-Cathay/TheAssetEditor-CN`
 - 用户界面：仅提供中文
 
 国区版可以和原版 Asset Editor 同时安装。两者不共用配置、缓存、日志、更新目录或 IPC 接口。

--- a/Shared/SharedCore/Services/VersionChecker.cs
+++ b/Shared/SharedCore/Services/VersionChecker.cs
@@ -1,19 +1,30 @@
 ﻿using System.Reflection;
-using Octokit;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Shared.Core.ErrorHandling;
 
 namespace Shared.Core.Services
 {
+    public sealed record UpdateRelease(
+        string TagName,
+        string Name,
+        string Body,
+        string HtmlUrl,
+        DateTimeOffset? PublishedAt);
+
     public class VersionChecker
     {
         private static readonly ILogger s_logger = Logging.Create<VersionChecker>();
 
-        private const string GitHubOwner = "Szy-Cathay";
-        private const string GitHubRepository = "TheAssetEditor-CN";
+        private const string GiteeOwner = "szy-cathay";
+        private const string GiteeRepository = "AssetEditor-CN-Downloads";
+        private static readonly Uri s_releasesApiUri = new(
+            $"https://gitee.com/api/v5/repos/{GiteeOwner}/{GiteeRepository}/releases?per_page=100");
+        private static readonly HttpClient s_httpClient = CreateHttpClient();
 
-        public static async Task<List<Release>?> GetNewerReleases()
+        public static async Task<List<UpdateRelease>?> GetNewerReleases()
         {
-            var releases = await GetReleasesAsync();
+            var releases = await GetReleasesAsync(s_httpClient);
             if (releases == null || releases.Count == 0)
                 return null;
 
@@ -25,24 +36,48 @@ namespace Shared.Core.Services
             return null;
         }
 
-        private static async Task<IReadOnlyList<Release>?> GetReleasesAsync()
+        internal static async Task<IReadOnlyList<UpdateRelease>?> GetReleasesAsync(
+            HttpClient httpClient)
         {
+            ArgumentNullException.ThrowIfNull(httpClient);
+
             try
             {
-                var gitHubClient = new GitHubClient(new ProductHeaderValue("AssetEditor.CN"));
-                var releases = await gitHubClient.Repository.Release.GetAll(GitHubOwner, GitHubRepository);
-                return releases.Count > 0 ? releases : null;
+                using var response = await httpClient.GetAsync(s_releasesApiUri);
+                response.EnsureSuccessStatusCode();
+                await using var responseStream = await response.Content.ReadAsStreamAsync();
+                var releases = await JsonSerializer.DeserializeAsync<List<GiteeRelease>>(
+                    responseStream);
+                if (releases == null || releases.Count == 0)
+                    return null;
+
+                return releases
+                    .Where(release => TryParseReleaseVersion(release.TagName, out _))
+                    .Select(release => new UpdateRelease(
+                        release.TagName!,
+                        string.IsNullOrWhiteSpace(release.Name) ? release.TagName! : release.Name,
+                        release.Body ?? string.Empty,
+                        $"https://gitee.com/{GiteeOwner}/{GiteeRepository}/releases/tag/{Uri.EscapeDataString(release.TagName!)}",
+                        release.CreatedAt))
+                    .OrderByDescending(release => ParseReleaseVersion(release.TagName))
+                    .ToList();
             }
-            catch (ApiException exception)
+            catch (Exception exception) when (
+                exception is HttpRequestException
+                or JsonException
+                or TaskCanceledException
+                or NotSupportedException)
             {
-                s_logger.Information($"Unable to retrieve latest release from GitHub: {exception.Message}");
+                s_logger.Information($"Unable to retrieve latest release from Gitee: {exception.Message}");
                 return null;
             }
         }
 
-        private static List<Release> GetReleasesSinceCurrentVersion(IReadOnlyList<Release> releases, Version currentVersion)
+        private static List<UpdateRelease> GetReleasesSinceCurrentVersion(
+            IReadOnlyList<UpdateRelease> releases,
+            Version currentVersion)
         {
-            var newerReleases = new List<Release>();
+            var newerReleases = new List<UpdateRelease>();
             foreach (var release in releases)
             {
                 var releaseVersion = ParseReleaseVersion(release.TagName);
@@ -76,5 +111,28 @@ namespace Shared.Core.Services
             var cleanedVersion = tagName.Trim().TrimStart('v', 'V');
             return new Version(cleanedVersion);
         }
+
+        private static bool TryParseReleaseVersion(string? tagName, out Version? version)
+        {
+            version = null;
+            if (string.IsNullOrWhiteSpace(tagName))
+                return false;
+
+            return Version.TryParse(tagName.Trim().TrimStart('v', 'V'), out version);
+        }
+
+        private static HttpClient CreateHttpClient()
+        {
+            var httpClient = new HttpClient();
+            httpClient.Timeout = TimeSpan.FromSeconds(30);
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("AssetEditor.CN");
+            return httpClient;
+        }
+
+        private sealed record GiteeRelease(
+            [property: JsonPropertyName("tag_name")] string? TagName,
+            [property: JsonPropertyName("name")] string? Name,
+            [property: JsonPropertyName("body")] string? Body,
+            [property: JsonPropertyName("created_at")] DateTimeOffset? CreatedAt);
     }
 }

--- a/Shared/SharedCore/Shared.Core.csproj
+++ b/Shared/SharedCore/Shared.Core.csproj
@@ -21,7 +21,6 @@
         <PackageReference Include="FluentValidation" Version="12.1.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.4.0" />
-        <PackageReference Include="Octokit" Version="14.0.0" />
         <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.4.1" />
         <PackageReference Include="Pfim" Version="0.11.4" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />

--- a/Testing/AssetEditorUpdaterTests/GiteeUpdateSourceTests.cs
+++ b/Testing/AssetEditorUpdaterTests/GiteeUpdateSourceTests.cs
@@ -1,0 +1,275 @@
+using System.Net;
+using System.Security.Cryptography;
+using AssetEditorUpdater;
+using UpdaterProgram = AssetEditorUpdater.AssetEditorUpdater;
+
+namespace AssetEditorUpdaterTests;
+
+public class GiteeUpdateSourceTests
+{
+    [Test]
+    public void CreateDownloadPlan_UsesManifestOrderAndRequiresEveryPart()
+    {
+        var first = "first"u8.ToArray();
+        var second = "second"u8.ToArray();
+        var archive = first.Concat(second).ToArray();
+        var release = CreateRelease("v2.4.2", "part02.zip", "part01.zip");
+        var manifest = new GiteeUpdateManifest(
+            "2.4.2",
+            "AssetEditor-CN-v2.4.2.zip",
+            archive.Length,
+            Hash(archive),
+            [
+                new GiteeUpdatePart("part01.zip", first.Length, Hash(first)),
+                new GiteeUpdatePart("part02.zip", second.Length, Hash(second))
+            ]);
+
+        var plan = GiteeUpdateSource.CreateDownloadPlan(release, manifest);
+
+        Assert.That(
+            plan.Parts.Select(part => part.Name),
+            Is.EqualTo(new[] { "part01.zip", "part02.zip" }));
+
+        var missingPartRelease = CreateRelease("v2.4.2", "part01.zip");
+        Assert.Throws<InvalidDataException>(() =>
+            GiteeUpdateSource.CreateDownloadPlan(missingPartRelease, manifest));
+    }
+
+    [Test]
+    public async Task DownloadArchiveAsync_AssemblesPartsAndVerifiesHashes()
+    {
+        var root = CreateTemporaryDirectory();
+        try
+        {
+            var testData = CreateTestDownload(root);
+            using var client = new HttpClient(new PartResponseHandler(testData.Responses));
+
+            await GiteeUpdateSource.DownloadArchiveAsync(
+                client,
+                testData.Plan,
+                testData.ArchivePath,
+                testData.InstallationDirectory,
+                testData.Workspace,
+                testData.LocalRoot,
+                testData.CommonRoot);
+
+            Assert.That(
+                await File.ReadAllBytesAsync(testData.ArchivePath),
+                Is.EqualTo(testData.Archive));
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void DownloadArchiveAsync_HashFailureDeletesPartialArchive(bool corruptArchiveHash)
+    {
+        var root = CreateTemporaryDirectory();
+        try
+        {
+            var testData = CreateTestDownload(root, corruptArchiveHash);
+            if (!corruptArchiveHash)
+                testData.Responses[new Uri("https://gitee.com/download/part02.zip")][0] ^= 0xff;
+            using var client = new HttpClient(new PartResponseHandler(testData.Responses));
+
+            Assert.ThrowsAsync<InvalidDataException>(async () =>
+                await GiteeUpdateSource.DownloadArchiveAsync(
+                    client,
+                    testData.Plan,
+                    testData.ArchivePath,
+                    testData.InstallationDirectory,
+                    testData.Workspace,
+                    testData.LocalRoot,
+                    testData.CommonRoot));
+
+            Assert.That(File.Exists(testData.ArchivePath), Is.False);
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Test]
+    [Explicit("Downloads and installs the current public Gitee release.")]
+    public async Task LiveGiteeRelease_DownloadsVerifiesAndInstallsInIsolation()
+    {
+        var root = CreateTemporaryDirectory();
+        try
+        {
+            var localRoot = Directory.CreateDirectory(Path.Combine(root, "local")).FullName;
+            var commonRoot = Directory.CreateDirectory(Path.Combine(root, "common")).FullName;
+            var installationDirectory = Directory.CreateDirectory(
+                Path.Combine(root, "installation")).FullName;
+            File.WriteAllText(Path.Combine(installationDirectory, "old-only.txt"), "old");
+            var workspace = UpdaterWorkspaceFactory.Create(
+                UpdaterWorkspaceFactory.GetLayout(
+                    false,
+                    Guid.Empty,
+                    localRoot,
+                    commonRoot));
+            using var client = new HttpClient();
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("AssetEditor.CN.Updater.Tests");
+            var latestRelease = await GiteeUpdateSource.GetLatestReleaseAsync(
+                client,
+                new Uri(
+                    "https://gitee.com/api/v5/repos/szy-cathay/AssetEditor-CN-Downloads/releases/latest"));
+            Assert.That(latestRelease, Is.Not.Null);
+            var plan = await GiteeUpdateSource.CreateDownloadPlanAsync(client, latestRelease!);
+            var archivePath = UpdaterProgram.GetAssetDownloadPath(
+                workspace.UpdateDirectory,
+                plan.ArchiveName);
+
+            await GiteeUpdateSource.DownloadArchiveAsync(
+                client,
+                plan,
+                archivePath,
+                installationDirectory,
+                workspace,
+                localRoot,
+                commonRoot);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(new FileInfo(archivePath).Length, Is.EqualTo(plan.Size));
+                Assert.That(Hash(File.ReadAllBytes(archivePath)), Is.EqualTo(plan.Sha256));
+            });
+
+            UpdateInstaller.Install(
+                archivePath,
+                installationDirectory,
+                workspace,
+                UpdateInstaller.CopyDirectory,
+                localRoot,
+                commonRoot);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    File.Exists(Path.Combine(installationDirectory, "AssetEditor.CN.exe")),
+                    Is.True);
+                Assert.That(
+                    File.Exists(Path.Combine(
+                        installationDirectory,
+                        "Updater",
+                        "AssetEditor.CN.Updater.exe")),
+                    Is.True);
+                Assert.That(
+                    File.Exists(Path.Combine(installationDirectory, "old-only.txt")),
+                    Is.False);
+            });
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    private static TestDownload CreateTestDownload(string root, bool corruptArchiveHash = false)
+    {
+        var localRoot = Directory.CreateDirectory(Path.Combine(root, "local")).FullName;
+        var commonRoot = Directory.CreateDirectory(Path.Combine(root, "common")).FullName;
+        var installationDirectory = Directory.CreateDirectory(
+            Path.Combine(root, "installation")).FullName;
+        var workspace = UpdaterWorkspaceFactory.Create(
+            UpdaterWorkspaceFactory.GetLayout(
+                false,
+                Guid.Empty,
+                localRoot,
+                commonRoot));
+        var first = "first-part-"u8.ToArray();
+        var second = "second-part"u8.ToArray();
+        var archive = first.Concat(second).ToArray();
+        var archiveHash = corruptArchiveHash ? new string('0', 64) : Hash(archive);
+        var plan = new GiteeDownloadPlan(
+            "AssetEditor-CN-v2.4.2.zip",
+            archive.Length,
+            archiveHash,
+            [
+                new GiteePartDownload(
+                    "part01.zip",
+                    first.Length,
+                    Hash(first),
+                    new Uri("https://gitee.com/download/part01.zip")),
+                new GiteePartDownload(
+                    "part02.zip",
+                    second.Length,
+                    Hash(second),
+                    new Uri("https://gitee.com/download/part02.zip"))
+            ]);
+        var responses = new Dictionary<Uri, byte[]>
+        {
+            [new Uri("https://gitee.com/download/part01.zip")] = first,
+            [new Uri("https://gitee.com/download/part02.zip")] = second
+        };
+        var archivePath = UpdaterProgram.GetAssetDownloadPath(
+            workspace.UpdateDirectory,
+            plan.ArchiveName);
+        return new TestDownload(
+            localRoot,
+            commonRoot,
+            workspace,
+            installationDirectory,
+            archivePath,
+            archive,
+            plan,
+            responses);
+    }
+
+    private static GiteeRelease CreateRelease(string tagName, params string[] partNames)
+    {
+        return new GiteeRelease(
+            tagName,
+            tagName,
+            string.Empty,
+            partNames.Select(name => new GiteeAsset(
+                name,
+                $"https://gitee.com/download/{name}"))
+                .Append(new GiteeAsset(
+                    "release.manifest.json",
+                    "https://gitee.com/download/release.manifest.json"))
+                .ToList());
+    }
+
+    private static string Hash(byte[] contents)
+    {
+        return Convert.ToHexString(SHA256.HashData(contents)).ToLowerInvariant();
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        return Directory.CreateDirectory(
+            Path.Combine(Path.GetTempPath(), $"gitee-update-{Guid.NewGuid():N}"))
+            .FullName;
+    }
+
+    private sealed class PartResponseHandler(IReadOnlyDictionary<Uri, byte[]> responses)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.RequestUri == null || !responses.TryGetValue(request.RequestUri, out var bytes))
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(bytes)
+            });
+        }
+    }
+
+    private sealed record TestDownload(
+        string LocalRoot,
+        string CommonRoot,
+        UpdaterWorkspace Workspace,
+        string InstallationDirectory,
+        string ArchivePath,
+        byte[] Archive,
+        GiteeDownloadPlan Plan,
+        Dictionary<Uri, byte[]> Responses);
+}

--- a/Testing/Shared.Core.Test/Services/VersionCheckerTests.cs
+++ b/Testing/Shared.Core.Test/Services/VersionCheckerTests.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Text;
 using Shared.Core.Services;
 
 namespace Test.Shared.Core.Services
@@ -15,6 +17,68 @@ namespace Test.Shared.Core.Services
                 Assert.That(currentVersion.ToString(), Is.EqualTo("1.1.0"));
                 Assert.That(currentVersion, Is.EqualTo(releaseVersion));
             });
+        }
+
+        [Test]
+        public async Task GetReleasesAsync_MapsGiteeReleasesAndSortsByVersion()
+        {
+            const string json = """
+                [
+                  {
+                    "tag_name": "v2.4.2",
+                    "name": "Second",
+                    "body": "Notes 2",
+                    "created_at": "2026-08-13T10:00:00+08:00"
+                  },
+                  {
+                    "tag_name": "v2.5.0",
+                    "name": "First",
+                    "body": "Notes 1",
+                    "created_at": "2026-08-13T11:00:00+08:00"
+                  }
+                ]
+                """;
+            using var client = new HttpClient(new StaticResponseHandler(json));
+
+            var releases = await VersionChecker.GetReleasesAsync(client);
+
+            Assert.That(releases, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(releases![0].TagName, Is.EqualTo("v2.5.0"));
+                Assert.That(releases[0].HtmlUrl, Is.EqualTo(
+                    "https://gitee.com/szy-cathay/AssetEditor-CN-Downloads/releases/tag/v2.5.0"));
+                Assert.That(releases[0].Body, Is.EqualTo("Notes 1"));
+                Assert.That(releases[0].PublishedAt, Is.EqualTo(
+                    DateTimeOffset.Parse("2026-08-13T11:00:00+08:00")));
+            });
+        }
+
+        [Test]
+        public async Task GetReleasesAsync_RequestFailureReturnsNull()
+        {
+            using var client = new HttpClient(new StaticResponseHandler(
+                "failure",
+                HttpStatusCode.ServiceUnavailable));
+
+            var releases = await VersionChecker.GetReleasesAsync(client);
+
+            Assert.That(releases, Is.Null);
+        }
+
+        private sealed class StaticResponseHandler(
+            string content,
+            HttpStatusCode statusCode = HttpStatusCode.OK) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new HttpResponseMessage(statusCode)
+                {
+                    Content = new StringContent(content, Encoding.UTF8, "application/json")
+                });
+            }
         }
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,7 @@
 ### 更新器
 
 - 主程序只启动发布包内的独立更新器；国区版运行时身份以根 `AGENTS.md` 为准。
+- 主程序从 Gitee `szy-cathay/AssetEditor-CN-Downloads` 检查版本；更新器读取同一发行版中的清单，按清单顺序下载小于 Gitee 单附件限制的 ZIP 分片，合并后校验每个分片和完整 ZIP 的 SHA-256。
 - 更新安装必须验证安装目录与事务目录不重叠，拒绝重解析点、路径别名重叠和非自有事务工作区。
 - updater payload 复制后逐文件复核 SHA-256；安装在事务目录完成暂存、备份和替换，失败时尝试回滚并保留原始错误。
 - 发布布局同时由 `AssetEditor/AssetEditor.csproj` 的 `PublishUpdater` 目标和 `AssetEditor/Properties/PublishProfiles/FolderProfile.pubxml` 决定。


### PR DESCRIPTION
## 变更内容

- 将主程序的版本检查源从 GitHub Release 切换到 Gitee 国内更新仓库
- 将独立更新器改为读取 Gitee Release 清单，按顺序下载分片并校验每片及完整 ZIP 的 SHA-256
- 移除不再需要的 Octokit 依赖，并同步中文项目规则、README 与架构说明
- 增加 Gitee Release 映射、分片组装、哈希失败清理及公网隔离安装测试

## 原因与影响

国内用户访问 GitHub Release 不稳定，导致在线检查和下载经常失败。迁移后，程序内更新检查和安装包下载都走 Gitee；GitHub 继续承载源码、问题跟踪和完整安装包。

## 验证

- `dotnet restore AssetEditor.CN.sln`
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore`（0 警告，0 错误）
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal`（退出码 0）
- `LiveGiteeRelease_DownloadsVerifiesAndInstallsInIsolation`（1/1，通过；从公开 Gitee Release 下载、校验、重组并隔离安装）
- `git diff --check`