### PR TITLE
整理 SuperView 预览构建并输出结构化诊断

### DIFF
--- a/AssetEditor/Language_Cn.json
+++ b/AssetEditor/Language_Cn.json
@@ -1296,6 +1296,12 @@
   "SuperView.Time.JumpEnd": "跳到结束",
   "SuperView.Time.JumpStartTip": "暂停动画并跳到所选 META 的开始时间",
   "SuperView.Time.JumpEndTip": "暂停动画并跳到所选 META 的结束时间",
+  "SuperView.Diagnostics.MissingModel": "找不到预览模型",
+  "SuperView.Diagnostics.MissingAnimation": "找不到预览动画",
+  "SuperView.Diagnostics.MissingBone": "找不到预览所需骨骼",
+  "SuperView.Diagnostics.MissingEffect": "找不到预览特效",
+  "SuperView.Diagnostics.PreviewUnavailable": "无法建立三维预览",
+  "SuperView.Diagnostics.RuleUnavailable": "无法建立动画预览规则",
 
   "MetaData.TagDesc.TIME": "通用时间标记",
   "MetaData.TagDesc.DISABLE_PERSISTENT": "禁用持久动画元数据",

--- a/Editors/AnimationMeta/Test.AnimationMeta/MetaDataBuildResultTests.cs
+++ b/Editors/AnimationMeta/Test.AnimationMeta/MetaDataBuildResultTests.cs
@@ -1,0 +1,537 @@
+using Editors.AnimationMeta.SuperView.Visualisation;
+using Editors.AnimationMeta.SuperView.Visualisation.Rules;
+using Editors.Shared.Core.Common;
+using GameWorld.Core.Animation;
+using GameWorld.Core.SceneNodes;
+using Microsoft.Xna.Framework;
+using Moq;
+using Shared.Core.PackFiles;
+using Shared.GameFormats.Animation;
+using Shared.GameFormats.AnimationMeta.Definitions;
+using Shared.GameFormats.AnimationMeta.Parsing;
+using Shared.GameFormats.AnimationPack;
+using Shared.GameFormats.RigidModel.Transforms;
+
+namespace Test.AnimationMeta
+{
+    [TestFixture]
+    public class MetaDataBuildResultTests
+    {
+        [Test]
+        public void Build_MissingModel_ReturnsFallbackAndStructuredDiagnostic()
+        {
+            const string missingModel =
+                @"variantmeshes\missing\codex_missing_model.rigid_model_v2";
+            var prop = new Prop_v14
+            {
+                Name = "PROP",
+                Version = 14,
+                ModelName = missingModel,
+                StartTime = 1,
+                EndTime = 2,
+                Position = new Vector3(4, 5, 6),
+            };
+            var metadata = new ParsedMetadataFile
+            {
+                Version = 14,
+                Attributes =
+                [
+                    prop,
+                    new ImpactPosition_v10
+                    {
+                        Name = "IMPACT_POS",
+                        Version = 10,
+                        Position = new Vector3(1, 2, 3),
+                    },
+                ]
+            };
+            var skeleton = new Mock<ISkeletonProvider>();
+            skeleton.SetupGet(value => value.Skeleton).Returns(
+                CreateSkeleton("root"));
+            var builder = new MetaDataBuilder(
+                null!,
+                null!,
+                null!,
+                Mock.Of<IPackFileService>(),
+                null!);
+
+            var result = builder.Build(
+                null,
+                metadata,
+                null,
+                new GroupNode("root"),
+                skeleton.Object,
+                new AnimationPlayer(),
+                null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Instances, Has.Count.EqualTo(2));
+                Assert.That(result.AnimationRules, Is.Empty);
+                Assert.That(result.Diagnostics, Has.Count.EqualTo(1));
+            });
+            var diagnostic = result.Diagnostics.Single();
+            Assert.Multiple(() =>
+            {
+                Assert.That(diagnostic.Source, Is.SameAs(prop));
+                Assert.That(
+                    diagnostic.Owner,
+                    Is.EqualTo(MetaDataDocumentOwner.Animation));
+                Assert.That(
+                    diagnostic.Severity,
+                    Is.EqualTo(MetaDataDiagnosticSeverity.Warning));
+                Assert.That(
+                    diagnostic.ReasonKey,
+                    Is.EqualTo("SuperView.Diagnostics.MissingModel"));
+                Assert.That(
+                    diagnostic.TimeRange,
+                    Is.EqualTo(new MetaDataTimeRange(
+                        1,
+                        2,
+                        MetaDataZeroRangeBehavior.WholeAnimation)));
+                Assert.That(
+                    diagnostic.Position,
+                    Is.EqualTo(new Vector3(4, 5, 6)));
+                Assert.That(diagnostic.ResourcePath, Is.EqualTo(missingModel));
+            });
+        }
+
+        [Test]
+        public void Build_PersistentThenAnimation_PreservesReferenceAndRuleOrder()
+        {
+            var persistentPreview = new ImpactPosition_v10
+            {
+                Name = "IMPACT_POS",
+                Version = 10,
+                Position = new Vector3(1, 2, 3),
+            };
+            var persistentRule = new Transform_v10
+            {
+                Name = "TRANSFORM",
+                Version = 10,
+                TargetNode = 0,
+            };
+            var animationPreview = new TargetPos_10
+            {
+                Name = "TARGET_POS",
+                Version = 10,
+                Position = new Vector3(4, 5, 6),
+            };
+            var animationRule = new Transform_v10
+            {
+                Name = "TRANSFORM",
+                Version = 10,
+                TargetNode = 1,
+            };
+            var builder = CreateBuilder();
+            var skeleton = new Mock<ISkeletonProvider>();
+            skeleton.SetupGet(value => value.Skeleton).Returns(
+                CreateSkeleton("root", "target"));
+
+            var result = builder.Build(
+                new ParsedMetadataFile
+                {
+                    Version = 10,
+                    Attributes = [persistentPreview, persistentRule],
+                },
+                new ParsedMetadataFile
+                {
+                    Version = 10,
+                    Attributes = [animationPreview, animationRule],
+                },
+                null,
+                new GroupNode("root"),
+                skeleton.Object,
+                new AnimationPlayer(),
+                null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    result.Instances.Cast<IMetaDataPreview>()
+                        .Select(preview => preview.Source),
+                    Is.EqualTo(new ParsedMetadataAttribute[]
+                    {
+                        persistentPreview,
+                        persistentRule,
+                        animationPreview,
+                        animationRule,
+                    }));
+                Assert.That(
+                    result.AnimationRules,
+                    Has.All.TypeOf<TransformBoneRule>());
+                Assert.That(result.AnimationRules, Has.Count.EqualTo(2));
+                Assert.That(result.Diagnostics, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void Build_DisablePersistent_ExcludesPersistentInstancesAndRules()
+        {
+            var persistentPreview = new ImpactPosition_v10
+            {
+                Name = "IMPACT_POS",
+                Version = 10,
+            };
+            var persistentRule = new Transform_v10
+            {
+                Name = "TRANSFORM",
+                Version = 10,
+            };
+            var animationPreview = new TargetPos_10
+            {
+                Name = "TARGET_POS",
+                Version = 10,
+            };
+            var builder = CreateBuilder();
+
+            var result = builder.Build(
+                new ParsedMetadataFile
+                {
+                    Version = 10,
+                    Attributes = [persistentPreview, persistentRule],
+                },
+                new ParsedMetadataFile
+                {
+                    Version = 10,
+                    Attributes =
+                    [
+                        new DisablePersistant_v10
+                        {
+                            Name = "DISABLE_PERSISTENT",
+                            Version = 10,
+                        },
+                        animationPreview,
+                    ],
+                },
+                null,
+                new GroupNode("root"),
+                null!,
+                new AnimationPlayer(),
+                null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    result.Instances.Cast<IMetaDataPreview>().Single().Source,
+                    Is.SameAs(animationPreview));
+                Assert.That(result.AnimationRules, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void Build_UnsupportedAttribute_PreservesSourceWithoutDiagnostic()
+        {
+            var unknown = new ParsedUnknownMetadataAttribute
+            {
+                Name = "CODEX_UNKNOWN",
+                Version = 99,
+                Data = [1, 2, 3],
+            };
+            var originalData = unknown.Data.ToArray();
+            var metadata = new ParsedMetadataFile
+            {
+                Version = 99,
+                Attributes = [unknown],
+            };
+
+            var result = CreateBuilder().Build(
+                null,
+                metadata,
+                null,
+                new GroupNode("root"),
+                null!,
+                new AnimationPlayer(),
+                null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Instances, Is.Empty);
+                Assert.That(result.AnimationRules, Is.Empty);
+                Assert.That(result.Diagnostics, Is.Empty);
+                Assert.That(metadata.Attributes.Single(), Is.SameAs(unknown));
+                Assert.That(unknown.Data, Is.EqualTo(originalData));
+            });
+        }
+
+        [Test]
+        public void Build_MissingDockAnimation_ReturnsDiagnosticAndOtherRule()
+        {
+            var dock = new DockEquipmentRWaist_v10
+            {
+                Name = "DOCK_EQPT_RWAIST",
+                Version = 10,
+            };
+            var transform = new Transform_v10
+            {
+                Name = "TRANSFORM",
+                Version = 10,
+            };
+            var fragment = new Mock<IAnimationBinGenericFormat>();
+            fragment.SetupGet(value => value.Entries).Returns(
+            [
+                new AnimationBinEntryGenericFormat
+                {
+                    SlotName = "DOCK_EQUIPMENT_RIGHT_WAIST",
+                    AnimationFile = @"animations\missing\dock.anim",
+                }
+            ]);
+            var skeleton = new Mock<ISkeletonProvider>();
+            skeleton.SetupGet(value => value.Skeleton).Returns(
+                CreateSkeleton("root"));
+
+            var result = CreateBuilder().Build(
+                null,
+                new ParsedMetadataFile
+                {
+                    Version = 10,
+                    Attributes = [dock, transform],
+                },
+                null,
+                new GroupNode("root"),
+                skeleton.Object,
+                new AnimationPlayer(),
+                fragment.Object);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    result.AnimationRules.Single(),
+                    Is.TypeOf<TransformBoneRule>());
+                Assert.That(result.Diagnostics, Has.Count.EqualTo(1));
+                Assert.That(result.Diagnostics.Single().Source, Is.SameAs(dock));
+                Assert.That(
+                    result.Diagnostics.Single().ReasonKey,
+                    Is.EqualTo("SuperView.Diagnostics.MissingAnimation"));
+            });
+        }
+
+        [Test]
+        public void Build_MissingEffectAndBone_ReturnsDiagnosticsAndOtherPreview()
+        {
+            var effect = new Effect_v11
+            {
+                Name = "EFFECT",
+                Version = 11,
+                VfxName = "codex_missing_effect",
+                Tracking = true,
+                NodeIndex = 9,
+                Position = new Vector3(4, 5, 6),
+                Orientation = new Vector4(0, 0, 0, 1),
+            };
+            var impact = new ImpactPosition_v10
+            {
+                Name = "IMPACT_POS",
+                Version = 10,
+                Position = new Vector3(1, 2, 3),
+            };
+            var skeleton = new Mock<ISkeletonProvider>();
+            skeleton.SetupGet(value => value.Skeleton).Returns(
+                CreateSkeleton("root"));
+
+            var result = CreateBuilder().Build(
+                null,
+                new ParsedMetadataFile
+                {
+                    Version = 10,
+                    Attributes = [effect, impact],
+                },
+                null,
+                new GroupNode("root"),
+                skeleton.Object,
+                new AnimationPlayer(),
+                null);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Instances, Has.Count.EqualTo(2));
+                Assert.That(
+                    result.Diagnostics.Select(diagnostic =>
+                        diagnostic.ReasonKey),
+                    Is.EquivalentTo(new[]
+                    {
+                        "SuperView.Diagnostics.MissingEffect",
+                        "SuperView.Diagnostics.MissingBone",
+                    }));
+                Assert.That(
+                    result.Diagnostics,
+                    Has.All.Property(nameof(MetaDataBuildDiagnostic.Source))
+                        .SameAs(effect));
+                Assert.That(
+                    result.Diagnostics,
+                    Has.All.Property(nameof(MetaDataBuildDiagnostic.Owner))
+                        .EqualTo(MetaDataDocumentOwner.Animation));
+            });
+        }
+
+        [Test]
+        public void Build_RuleReadFailure_ReturnsDiagnosticAndOtherRule()
+        {
+            var dock = new DockEquipmentRWaist_v10
+            {
+                Name = "DOCK_EQPT_RWAIST",
+                Version = 10,
+            };
+            var transform = new Transform_v10
+            {
+                Name = "TRANSFORM",
+                Version = 10,
+            };
+            var fragment = new Mock<IAnimationBinGenericFormat>();
+            fragment.SetupGet(value => value.Entries)
+                .Throws(new InvalidOperationException("codex test failure"));
+            var skeleton = new Mock<ISkeletonProvider>();
+            skeleton.SetupGet(value => value.Skeleton).Returns(
+                CreateSkeleton("root"));
+
+            var result = CreateBuilder().Build(
+                null,
+                new ParsedMetadataFile
+                {
+                    Version = 10,
+                    Attributes = [dock, transform],
+                },
+                null,
+                new GroupNode("root"),
+                skeleton.Object,
+                new AnimationPlayer(),
+                fragment.Object);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    result.AnimationRules.Single(),
+                    Is.TypeOf<TransformBoneRule>());
+                Assert.That(result.Diagnostics, Has.Count.EqualTo(1));
+                Assert.That(result.Diagnostics.Single().Source, Is.SameAs(dock));
+                Assert.That(
+                    result.Diagnostics.Single().ReasonKey,
+                    Is.EqualTo("SuperView.Diagnostics.RuleUnavailable"));
+            });
+        }
+
+        [Test]
+        public void Build_DiagnosticContextReadFailure_StillReturnsDiagnostics()
+        {
+            var effect = new ThrowingEffectMeta
+            {
+                Name = "EFFECT",
+                Version = 99,
+            };
+
+            MetaDataBuildResult? result = null;
+            Assert.DoesNotThrow(() =>
+            {
+                result = CreateBuilder().Build(
+                    null,
+                    new ParsedMetadataFile
+                    {
+                        Version = 99,
+                        Attributes = [effect],
+                    },
+                    null,
+                    new GroupNode("root"),
+                    null!,
+                    new AnimationPlayer(),
+                    null);
+            });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result!.Instances, Has.Count.EqualTo(1));
+                Assert.That(
+                    result.Diagnostics.Select(diagnostic => diagnostic.ReasonKey),
+                    Is.EqualTo(new[] { "SuperView.Diagnostics.MissingEffect" }));
+                Assert.That(
+                    result.Diagnostics,
+                    Has.All.Property(nameof(MetaDataBuildDiagnostic.Source))
+                        .SameAs(effect));
+                Assert.That(result.Diagnostics.Single().Position, Is.Null);
+            });
+        }
+
+        [TestCaseSource(nameof(RulePreviewSources))]
+        public void BuildPreview_RuleSource_RequiresFullBuild(
+            ParsedMetadataAttribute source)
+        {
+            var result = CreateBuilder().BuildPreview(
+                source,
+                MetaDataDocumentOwner.Animation,
+                false,
+                new GroupNode("root"),
+                null!,
+                new AnimationPlayer());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsSupported, Is.False);
+                Assert.That(result.Instance, Is.Null);
+                Assert.That(result.Diagnostics, Is.Empty);
+            });
+        }
+
+        private static IEnumerable<ParsedMetadataAttribute>
+            RulePreviewSources()
+        {
+            yield return new Transform_v10
+            {
+                Name = "TRANSFORM",
+                Version = 10,
+            };
+            yield return new DockEquipmentRWaist_v10
+            {
+                Name = "DOCK_EQPT_RWAIST",
+                Version = 10,
+            };
+        }
+
+        private static MetaDataBuilder CreateBuilder() => new(
+            null!,
+            null!,
+            null!,
+            Mock.Of<IPackFileService>(),
+            null!);
+
+        private static GameSkeleton CreateSkeleton(params string[] boneNames)
+        {
+            var skeletonFile = new AnimationFile
+            {
+                Header = new AnimationFile.AnimationHeader
+                {
+                    SkeletonName = "TestSkeleton"
+                },
+                Bones = boneNames.Select((name, index) =>
+                    new AnimationFile.BoneInfo
+                    {
+                        Name = name,
+                        ParentId = index - 1,
+                    }).ToArray(),
+            };
+            var skeletonFrame = new AnimationFile.Frame();
+            foreach (var _ in boneNames)
+            {
+                skeletonFrame.Transforms.Add(new RmvVector3(Vector3.Zero));
+                skeletonFrame.Quaternion.Add(new RmvVector4(0, 0, 0, 1));
+            }
+            var skeletonPart = new AnimationFile.AnimationPart();
+            skeletonPart.DynamicFrames.Add(skeletonFrame);
+            skeletonFile.AnimationParts.Add(skeletonPart);
+            return new GameSkeleton(skeletonFile, null!);
+        }
+
+        private sealed class ThrowingEffectMeta : ParsedMetadataAttribute, IEffectMeta
+        {
+            public string VfxName { get; set; } = "codex_missing_effect";
+            public int NodeIndex { get; set; }
+            public bool Tracking { get; set; }
+            public Vector3 Position
+            {
+                get => throw new InvalidOperationException("codex test failure");
+                set { }
+            }
+            public Vector4 Orientation { get; set; }
+            public float EffectStartTime { get; set; }
+            public float EffectEndTime { get; set; }
+        }
+    }
+}

--- a/Editors/AnimationMeta/Test.AnimationMeta/MetaDataBuilderMissingResourceTests.cs
+++ b/Editors/AnimationMeta/Test.AnimationMeta/MetaDataBuilderMissingResourceTests.cs
@@ -17,7 +17,7 @@ namespace Test.AnimationMeta
     public class MetaDataBuilderMissingResourceTests
     {
         [Test]
-        public void Create_MissingAnimatedPropModel_UsesSpatialMarkerFallback()
+        public void Build_MissingAnimatedPropModel_UsesSpatialMarkerFallback()
         {
             const string missingModel =
                 @"variantmeshes\missing\codex_missing_model.rigid_model_v2";
@@ -57,14 +57,14 @@ namespace Test.AnimationMeta
             var skeleton = new Mock<ISkeletonProvider>();
             skeleton.SetupGet(value => value.Skeleton).Returns(
                 CreateSkeleton("root"));
-            var instances = builder.Create(
+            var instances = builder.Build(
                 null,
                 metadata,
                 null,
                 new GroupNode("root"),
                 skeleton.Object,
                 new AnimationPlayer(),
-                null!);
+                null!).Instances;
 
             Assert.That(
                 instances.OfType<ISpatialMetaDataPreview>().Count(),
@@ -78,7 +78,7 @@ namespace Test.AnimationMeta
         }
 
         [Test]
-        public void Create_MissingOrdinaryPropModel_UsesSpatialMarkerFallback()
+        public void Build_MissingOrdinaryPropModel_UsesSpatialMarkerFallback()
         {
             const string missingModel =
                 @"variantmeshes\missing\ordinary_prop.rigid_model_v2";
@@ -108,14 +108,14 @@ namespace Test.AnimationMeta
             var skeleton = new Mock<ISkeletonProvider>();
             skeleton.SetupGet(value => value.Skeleton).Returns(
                 CreateSkeleton("root"));
-            var instances = builder.Create(
+            var instances = builder.Build(
                 null,
                 metadata,
                 null,
                 new GroupNode("root"),
                 skeleton.Object,
                 new AnimationPlayer(),
-                null!);
+                null!).Instances;
 
             Assert.That(
                 instances.OfType<ISpatialMetaDataPreview>().Count(),
@@ -126,7 +126,7 @@ namespace Test.AnimationMeta
         }
 
         [Test]
-        public void Create_MissingDockAnimation_SkipsOnlyDockRule()
+        public void Build_MissingDockAnimation_SkipsOnlyDockRule()
         {
             const string missingAnimation =
                 @"animations\missing\dock_equipment.anim";
@@ -163,22 +163,23 @@ namespace Test.AnimationMeta
             skeleton.SetupGet(value => value.Skeleton).Returns(
                 CreateSkeleton("root"));
 
-            Assert.DoesNotThrow(() => builder.Create(
+            var result = builder.Build(
                 null,
                 metadata,
                 null,
                 new GroupNode("root"),
                 skeleton.Object,
                 rootPlayer,
-                fragment.Object));
+                fragment.Object);
             Assert.That(rootPlayer.AnimationRules, Is.Empty);
+            Assert.That(result.AnimationRules, Is.Empty);
             packFileService.Verify(
                 service => service.FindFile(missingAnimation, null),
                 Times.Once);
         }
 
         [Test]
-        public void Create_InvalidSplashAttack_PreservesValidLocatorPreview()
+        public void Build_InvalidSplashAttack_PreservesValidLocatorPreview()
         {
             var builder = new MetaDataBuilder(
                 null!,
@@ -209,20 +210,20 @@ namespace Test.AnimationMeta
                 ]
             };
 
-            var instances = builder.Create(
+            var instances = builder.Build(
                 null,
                 metadata,
                 null,
                 new GroupNode("root"),
                 null!,
                 new AnimationPlayer(),
-                null!);
+                null!).Instances;
 
             Assert.That(instances, Has.Count.EqualTo(1));
         }
 
         [Test]
-        public void Create_TimedCombatLocators_AreVisibleOnlyDuringGameplayWindow()
+        public void Build_TimedCombatLocators_AreVisibleOnlyDuringGameplayWindow()
         {
             var builder = new MetaDataBuilder(
                 null!,
@@ -274,14 +275,14 @@ namespace Test.AnimationMeta
             };
             var root = new GroupNode("root");
 
-            var instances = builder.Create(
+            var instances = builder.Build(
                 null,
                 metadata,
                 null,
                 root,
                 null!,
                 new AnimationPlayer(),
-                null);
+                null).Instances;
             Assert.Multiple(() =>
             {
                 Assert.That(instances, Has.Count.EqualTo(4));
@@ -302,7 +303,7 @@ namespace Test.AnimationMeta
         }
 
         [Test]
-        public void Create_InstantCombatLocators_AreVisibleForOneAnimationFrame()
+        public void Build_InstantCombatLocators_AreVisibleForOneAnimationFrame()
         {
             var builder = new MetaDataBuilder(
                 null!,
@@ -360,14 +361,14 @@ namespace Test.AnimationMeta
             clip.PlayTimeInSec = 1;
             player.SetAnimation(clip, null!);
 
-            var instances = builder.Create(
+            var instances = builder.Build(
                 null,
                 metadata,
                 null,
                 root,
                 null!,
                 player,
-                null);
+                null).Instances;
 
             foreach (var instance in instances)
                 instance.Update(0.49f);
@@ -391,7 +392,7 @@ namespace Test.AnimationMeta
         }
 
         [Test]
-        public void Create_LegacyCombatLocators_CreatesEverySupportedPreview()
+        public void Build_LegacyCombatLocators_CreatesEverySupportedPreview()
         {
             var builder = new MetaDataBuilder(
                 null!,
@@ -441,14 +442,14 @@ namespace Test.AnimationMeta
             };
             var root = new GroupNode("root");
 
-            var instances = builder.Create(
+            var instances = builder.Build(
                 null,
                 metadata,
                 null,
                 root,
                 null!,
                 new AnimationPlayer(),
-                null);
+                null).Instances;
 
             Assert.Multiple(() =>
             {
@@ -468,7 +469,7 @@ namespace Test.AnimationMeta
         }
 
         [Test]
-        public void Create_CombatLocators_ExposeIndependentVisibilityAndFocusPositions()
+        public void Build_CombatLocators_ExposeIndependentVisibilityAndFocusPositions()
         {
             var builder = new MetaDataBuilder(
                 null!,
@@ -518,14 +519,14 @@ namespace Test.AnimationMeta
             };
             var root = new GroupNode("root");
 
-            var instances = builder.Create(
+            var instances = builder.Build(
                 null,
                 metadata,
                 null,
                 root,
                 null!,
                 new AnimationPlayer(),
-                null);
+                null).Instances;
             var previews = instances.Cast<ICombatMetaDataPreview>().ToList();
             var impact = previews.Single(
                 preview => preview.Category == CombatMetaDataPreviewCategory.Impact);
@@ -579,7 +580,7 @@ namespace Test.AnimationMeta
         }
 
         [Test]
-        public void Create_SplashAttack_UsesOneLiveCoordinateSpace()
+        public void Build_SplashAttack_UsesOneLiveCoordinateSpace()
         {
             var builder = new MetaDataBuilder(
                 null!,
@@ -597,7 +598,7 @@ namespace Test.AnimationMeta
                 WidthForCorridor = 1,
             };
             var root = new GroupNode("root");
-            var instance = builder.Create(
+            var instance = builder.Build(
                     null,
                     new ParsedMetadataFile
                     {
@@ -608,7 +609,7 @@ namespace Test.AnimationMeta
                     root,
                     null!,
                     new AnimationPlayer(),
-                    null)
+                    null).Instances
                 .Single();
             var preview = (ICombatMetaDataPreview)instance;
             var node = root.Children.Single();
@@ -636,7 +637,7 @@ namespace Test.AnimationMeta
         }
 
         [Test]
-        public void Create_TrackedEffect_UsesLiveBoneRelativeLocatorPosition()
+        public void Build_TrackedEffect_UsesLiveBoneRelativeLocatorPosition()
         {
             var builder = new MetaDataBuilder(
                 null!,
@@ -665,14 +666,14 @@ namespace Test.AnimationMeta
             skeleton.SetupGet(value => value.Skeleton).Returns(
                 CreateSkeleton("effect_bone", boneTranslation));
 
-            var preview = builder.Create(
+            var preview = builder.Build(
                     null,
                     metadata,
                     effect,
                     new GroupNode("root"),
                     skeleton.Object,
                     new AnimationPlayer(),
-                    null)
+                    null).Instances
                 .OfType<ISpatialMetaDataPreview>()
                 .Single();
 

--- a/Editors/AnimationMeta/Test.AnimationMeta/MetaDataEditorViewModelTests.cs
+++ b/Editors/AnimationMeta/Test.AnimationMeta/MetaDataEditorViewModelTests.cs
@@ -1300,6 +1300,125 @@ namespace Test.AnimationMeta
         }
 
         [Test]
+        public void SuperView_FullRebuild_ReplacesInstancesRulesAndDiagnostics()
+        {
+            const string firstPath =
+                @"animations\battle\codex\preview_lifecycle_first.anm.meta";
+            const string secondPath =
+                @"animations\battle\codex\preview_lifecycle_second.anm.meta";
+            var runner = new AssetEditorTestRunner();
+            runner.CreateOutputPack();
+            var editorCreator =
+                runner.ServiceProvider.GetRequiredService<IEditorCreator>();
+            var superView = (SuperViewViewModel)editorCreator.Create(
+                EditorEnums.SuperView_Editor);
+
+            try
+            {
+                var parser = runner.GetRequiredServiceInCurrentEditorScope<
+                    MetaDataFileParser>();
+                var fileSaveService =
+                    runner.GetRequiredServiceInCurrentEditorScope<
+                        IFileSaveService>();
+                var sceneObjectEditor =
+                    runner.GetRequiredServiceInCurrentEditorScope<
+                        SceneObjectEditor>();
+                var first = new ParsedMetadataFile
+                {
+                    Version = 2,
+                    Attributes =
+                    [
+                        new Effect_v2
+                        {
+                            Name = "EFFECT",
+                            Version = 2,
+                            VfxName = "codex_missing_lifecycle_effect",
+                            Position = new Vector3(1, 2, 3),
+                            Orientation = new Vector4(0, 0, 0, 1),
+                            NodeIndex = -1,
+                        },
+                        new Transform_v10
+                        {
+                            Name = "TRANSFORM",
+                            Version = 10,
+                        },
+                    ],
+                };
+                var second = new ParsedMetadataFile
+                {
+                    Version = 2,
+                    Attributes =
+                    [
+                        new TargetPos_10
+                        {
+                            Name = "TARGET_POS",
+                            Version = 10,
+                            Position = new Vector3(7, 8, 9),
+                        },
+                    ],
+                };
+                var firstFile = fileSaveService.Save(
+                    firstPath,
+                    parser.GenerateBytes(first.Version, first),
+                    false);
+                var secondFile = fileSaveService.Save(
+                    secondPath,
+                    parser.GenerateBytes(second.Version, second),
+                    false);
+                var sceneObject = superView.SceneObjects.Single();
+
+                sceneObjectEditor.SetMetaFile(
+                    sceneObject.Data,
+                    firstFile,
+                    null);
+                var oldInstances = sceneObject.Data.MetaDataItems.ToList();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(oldInstances, Has.Count.EqualTo(1));
+                    Assert.That(
+                        sceneObject.Data.Player.AnimationRules,
+                        Has.Count.EqualTo(1));
+                    Assert.That(
+                        superView.MetaDataDiagnostics,
+                        Has.Count.EqualTo(2));
+                });
+
+                sceneObjectEditor.SetMetaFile(
+                    sceneObject.Data,
+                    secondFile,
+                    null);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(
+                        sceneObject.Data.MetaDataItems,
+                        Has.Count.EqualTo(1));
+                    Assert.That(
+                        sceneObject.Data.MetaDataItems,
+                        Has.None.Matches<object>(item =>
+                            oldInstances.Contains(item)));
+                    Assert.That(
+                        sceneObject.Data.Player.AnimationRules,
+                        Is.Empty);
+                    Assert.That(superView.MetaDataDiagnostics, Is.Empty);
+                    Assert.That(
+                        sceneObject.Data.MainNode.Children.Select(node =>
+                            node.Name),
+                        Has.None.EqualTo(
+                            "Effect:codex_missing_lifecycle_effect"));
+                    Assert.That(
+                        sceneObject.Data.MainNode.Children.Select(node =>
+                            node.Name),
+                        Has.None.EqualTo("TRANSFORM"));
+                });
+            }
+            finally
+            {
+                superView.Close();
+            }
+        }
+
+        [Test]
         public void SuperView_SelectingAndEditingEffect_LeavesOtherPreviewsIntact()
         {
             const string metaPath =

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/SuperViewViewModel.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/SuperViewViewModel.cs
@@ -45,6 +45,7 @@ namespace Editors.AnimationMeta.SuperView
         private readonly HashSet<ParsedMetadataAttribute>
             _threeDimensionalEditingSources = new(
                 ReferenceEqualityComparer.Instance);
+        private List<MetaDataBuildDiagnostic> _metaDataDiagnostics = [];
 
         [ObservableProperty] MetaDataEditorViewModel _persistentMetaEditor = null!;
         [ObservableProperty] MetaDataEditorViewModel _metaEditor = null!;
@@ -231,6 +232,8 @@ namespace Editors.AnimationMeta.SuperView
             SelectedTabControllerIndex == 0
                 ? PersistentMetaEditor.SelectedAttribute
                 : MetaEditor.SelectedAttribute;
+        public IReadOnlyList<MetaDataBuildDiagnostic> MetaDataDiagnostics =>
+            _metaDataDiagnostics;
         public bool CanFocusSelectedMetaData =>
             GetSelectedSpatialPreview() != null;
         public bool CanEditSelectedCombatMetaData =>
@@ -519,7 +522,19 @@ namespace Editors.AnimationMeta.SuperView
             _threeDimensionalEditingSources.RemoveWhere(source =>
                 !currentSources.Contains(source));
 
-            _asset.Data.MetaDataItems = _metaDataFactory.Create(persist, meta, SelectedPreviewAttribute, _asset.Data.MainNode, _asset.Data, _asset.Data.Player, _asset.FragAndSlotSelection.FragmentList.SelectedItem);
+            var buildResult = _metaDataFactory.Build(
+                persist,
+                meta,
+                SelectedPreviewAttribute,
+                _asset.Data.MainNode,
+                _asset.Data,
+                _asset.Data.Player,
+                _asset.FragAndSlotSelection.FragmentList.SelectedItem);
+            _asset.Data.MetaDataItems = buildResult.Instances.ToList();
+            _asset.Data.Player.AnimationRules.AddRange(
+                buildResult.AnimationRules);
+            _metaDataDiagnostics = buildResult.Diagnostics.ToList();
+            OnPropertyChanged(nameof(MetaDataDiagnostics));
             _appliedSelectedPreviewAttribute = SelectedPreviewAttribute;
             ApplyCombatPreviewVisibility();
             OnPropertyChanged(nameof(CanFocusSelectedMetaData));
@@ -559,16 +574,20 @@ namespace Editors.AnimationMeta.SuperView
         private bool RefreshMetaDataPreview(
             ParsedMetadataAttribute attribute)
         {
-            if (!_metaDataFactory.TryCreateMetaDataPreview(
+            if (!TryGetDocumentOwner(attribute, out var owner))
+                return false;
+
+            var buildResult = _metaDataFactory.BuildPreview(
                 attribute,
+                owner,
                 ReferenceEquals(attribute, SelectedPreviewAttribute),
                 _asset.Data.MainNode,
                 _asset.Data,
-                _asset.Data.Player,
-                out var replacement))
-            {
+                _asset.Data.Player);
+            if (!buildResult.IsSupported)
                 return false;
-            }
+
+            var replacement = buildResult.Instance;
 
             var currentIndex = _asset.Data.MetaDataItems.FindIndex(item =>
                 item is IMetaDataPreview preview &&
@@ -589,10 +608,37 @@ namespace Editors.AnimationMeta.SuperView
                         replacement);
             }
 
+            _metaDataDiagnostics.RemoveAll(diagnostic =>
+                ReferenceEquals(diagnostic.Source, attribute));
+            _metaDataDiagnostics.AddRange(buildResult.Diagnostics);
+            OnPropertyChanged(nameof(MetaDataDiagnostics));
+
             ApplyCombatPreviewVisibility();
             OnPropertyChanged(nameof(CanFocusSelectedMetaData));
             OnPropertyChanged(nameof(CanConfigureSelectedMetaDataDisplayTime));
             return true;
+        }
+
+        private bool TryGetDocumentOwner(
+            ParsedMetadataAttribute attribute,
+            out MetaDataDocumentOwner owner)
+        {
+            if (PersistentMetaEditor.ParsedFile?.Attributes.Any(item =>
+                    ReferenceEquals(item, attribute)) == true)
+            {
+                owner = MetaDataDocumentOwner.Persistent;
+                return true;
+            }
+
+            if (MetaEditor.ParsedFile?.Attributes.Any(item =>
+                    ReferenceEquals(item, attribute)) == true)
+            {
+                owner = MetaDataDocumentOwner.Animation;
+                return true;
+            }
+
+            owner = default;
+            return false;
         }
 
         private void ApplyCombatPreviewVisibility()

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataBuildResult.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataBuildResult.cs
@@ -1,0 +1,51 @@
+using Editors.Shared.Core.Common;
+using GameWorld.Core.Animation.AnimationChange;
+using Microsoft.Xna.Framework;
+using Shared.GameFormats.AnimationMeta.Parsing;
+
+namespace Editors.AnimationMeta.SuperView.Visualisation
+{
+    public enum MetaDataDocumentOwner
+    {
+        Persistent,
+        Animation,
+    }
+
+    public enum MetaDataDiagnosticSeverity
+    {
+        Warning,
+        Error,
+    }
+
+    public sealed record MetaDataBuildDiagnostic(
+        ParsedMetadataAttribute Source,
+        MetaDataDocumentOwner Owner,
+        MetaDataDiagnosticSeverity Severity,
+        string ReasonKey,
+        MetaDataTimeRange? TimeRange = null,
+        Vector3? Position = null,
+        string? ResourcePath = null,
+        string? BoneName = null);
+
+    public sealed class MetaDataBuildResult
+    {
+        public IReadOnlyList<IMetaDataInstance> Instances { get; }
+        public IReadOnlyList<IAnimationChangeRule> AnimationRules { get; }
+        public IReadOnlyList<MetaDataBuildDiagnostic> Diagnostics { get; }
+
+        public MetaDataBuildResult(
+            IReadOnlyList<IMetaDataInstance> instances,
+            IReadOnlyList<IAnimationChangeRule> animationRules,
+            IReadOnlyList<MetaDataBuildDiagnostic> diagnostics)
+        {
+            Instances = instances.ToArray();
+            AnimationRules = animationRules.ToArray();
+            Diagnostics = diagnostics.ToArray();
+        }
+    }
+
+    public sealed record MetaDataPreviewBuildResult(
+        bool IsSupported,
+        IMetaDataInstance? Instance,
+        IReadOnlyList<MetaDataBuildDiagnostic> Diagnostics);
+}

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataBuilder.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataBuilder.cs
@@ -23,20 +23,123 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
 {
     public interface IMetaDataBuilder
     {
-        List<IMetaDataInstance> Create(ParsedMetadataFile? persistent, ParsedMetadataFile? metaData, ParsedMetadataAttribute? selectedMetaDataAttribute, SceneNode root, ISkeletonProvider skeleton, AnimationPlayer rootPlayer, IAnimationBinGenericFormat? fragment);
-        bool TryCreateMetaDataPreview(ParsedMetadataAttribute attribute,
-            bool isSelected, SceneNode root, ISkeletonProvider skeleton,
+        MetaDataBuildResult Build(
+            ParsedMetadataFile? persistent,
+            ParsedMetadataFile? metaData,
+            ParsedMetadataAttribute? selectedMetaDataAttribute,
+            SceneNode root,
+            ISkeletonProvider skeleton,
             AnimationPlayer rootPlayer,
-            out IMetaDataInstance? preview);
+            IAnimationBinGenericFormat? fragment);
+        MetaDataPreviewBuildResult BuildPreview(
+            ParsedMetadataAttribute attribute,
+            MetaDataDocumentOwner owner,
+            bool isSelected,
+            SceneNode root,
+            ISkeletonProvider skeleton,
+            AnimationPlayer rootPlayer);
     }
 
     public class MetaDataBuilder : IMetaDataBuilder
     {
-        private readonly ILogger _logger = Logging.Create<MetaDataBuilder>();
+        private readonly MetaDataPreviewBuilder _previewBuilder;
+        private readonly MetaDataRuleBuilder _ruleBuilder;
+
+        public MetaDataBuilder(
+            ComplexMeshLoader complexMeshLoader,
+            RenderEngineComponent resourceLibrary,
+            ISkeletonAnimationLookUpHelper skeletonAnimationLookUpHelper,
+            IPackFileService packFileService,
+            AnimationsContainerComponent animationsContainerComponent)
+        {
+            var resourceResolver = new MetaDataResourceResolver(
+                packFileService);
+            _previewBuilder = new(
+                complexMeshLoader,
+                resourceLibrary,
+                skeletonAnimationLookUpHelper,
+                resourceResolver,
+                animationsContainerComponent);
+            _ruleBuilder = new(resourceResolver);
+        }
+
+        public MetaDataBuildResult Build(
+            ParsedMetadataFile? persistent,
+            ParsedMetadataFile? metaData,
+            ParsedMetadataAttribute? selectedMetaDataAttribute,
+            SceneNode root,
+            ISkeletonProvider skeleton,
+            AnimationPlayer rootPlayer,
+            IAnimationBinGenericFormat? fragment)
+        {
+            var instances = new List<IMetaDataInstance>();
+            var rules = new List<GameWorld.Core.Animation.AnimationChange.IAnimationChangeRule>();
+            var diagnostics = new List<MetaDataBuildDiagnostic>();
+
+            if (metaData == null ||
+                metaData.GetItemsOfType<DisablePersistant_v10>().Count == 0)
+            {
+                _previewBuilder.AppendInstances(
+                    persistent,
+                    MetaDataDocumentOwner.Persistent,
+                    selectedMetaDataAttribute,
+                    root,
+                    skeleton,
+                    rootPlayer,
+                    instances,
+                    diagnostics);
+                _ruleBuilder.AppendRules(
+                    persistent,
+                    MetaDataDocumentOwner.Persistent,
+                    fragment,
+                    skeleton,
+                    rules,
+                    diagnostics);
+            }
+
+            _previewBuilder.AppendInstances(
+                metaData,
+                MetaDataDocumentOwner.Animation,
+                selectedMetaDataAttribute,
+                root,
+                skeleton,
+                rootPlayer,
+                instances,
+                diagnostics);
+            _ruleBuilder.AppendRules(
+                metaData,
+                MetaDataDocumentOwner.Animation,
+                fragment,
+                skeleton,
+                rules,
+                diagnostics);
+
+            return new(instances, rules, diagnostics);
+        }
+
+        public MetaDataPreviewBuildResult BuildPreview(
+            ParsedMetadataAttribute attribute,
+            MetaDataDocumentOwner owner,
+            bool isSelected,
+            SceneNode root,
+            ISkeletonProvider skeleton,
+            AnimationPlayer rootPlayer) =>
+            _previewBuilder.BuildPreview(
+                attribute,
+                owner,
+                isSelected,
+                root,
+                skeleton,
+                rootPlayer);
+    }
+
+    internal sealed class MetaDataPreviewBuilder
+    {
+        private readonly ILogger _logger = Logging.Create<MetaDataPreviewBuilder>();
         private readonly ComplexMeshLoader _complexMeshLoader;
         private readonly RenderEngineComponent _resourceLibrary;
         private readonly ISkeletonAnimationLookUpHelper _skeletonAnimationLookUpHelper;
-        private readonly IPackFileService _packFileService;
+        private readonly MetaDataResourceResolver _resourceResolver;
         private readonly AnimationsContainerComponent _animationsContainerComponent;
 
         private static Color s_color = Color.Black;
@@ -68,54 +171,68 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             float WidthForCorridor,
             float AngleForCone);
 
-        public MetaDataBuilder(ComplexMeshLoader complexMeshLoader,
+        public MetaDataPreviewBuilder(ComplexMeshLoader complexMeshLoader,
             RenderEngineComponent resourceLibrary,
             ISkeletonAnimationLookUpHelper skeletonAnimationLookUpHelper,
-            IPackFileService packFileService,
+            MetaDataResourceResolver resourceResolver,
             AnimationsContainerComponent animationsContainerComponent)
         {
             _complexMeshLoader = complexMeshLoader;
             _resourceLibrary = resourceLibrary;
             _skeletonAnimationLookUpHelper = skeletonAnimationLookUpHelper;
-            _packFileService = packFileService;
+            _resourceResolver = resourceResolver;
             _animationsContainerComponent = animationsContainerComponent;
         }
 
-        public List<IMetaDataInstance> Create(ParsedMetadataFile? persistent,
-            ParsedMetadataFile? metaData, ParsedMetadataAttribute? selectedMetaDataAttribute,
-            SceneNode root, ISkeletonProvider skeleton, AnimationPlayer rootPlayer, IAnimationBinGenericFormat? fragment)
+        public void AppendInstances(
+            ParsedMetadataFile? file,
+            MetaDataDocumentOwner owner,
+            ParsedMetadataAttribute? selectedMetaDataAttribute,
+            SceneNode root,
+            ISkeletonProvider skeleton,
+            AnimationPlayer rootPlayer,
+            ICollection<IMetaDataInstance> output,
+            ICollection<MetaDataBuildDiagnostic> diagnostics)
         {
-            // Clear all
-            var output = new List<IMetaDataInstance>();
-
-            // Apply persistent meta data, if no disable is given.
-            if (metaData == null || metaData.GetItemsOfType<DisablePersistant_v10>().Count == 0)
-            {
-                var metaDataPersistent = ApplyMetaData(persistent, selectedMetaDataAttribute, root, skeleton, rootPlayer, fragment);
-                output.AddRange(metaDataPersistent);
-            }
-
-            var metaDataInstances = ApplyMetaData(metaData, selectedMetaDataAttribute, root, skeleton, rootPlayer, fragment);
-            output.AddRange(metaDataInstances);
-            return output;
+            ApplyMetaData(
+                file,
+                owner,
+                selectedMetaDataAttribute,
+                root,
+                skeleton,
+                rootPlayer,
+                output,
+                diagnostics);
         }
 
-        private IEnumerable<IMetaDataInstance> ApplyMetaData(ParsedMetadataFile? file, ParsedMetadataAttribute? selectedAttribute, SceneNode root, ISkeletonProvider skeleton, AnimationPlayer rootPlayer, IAnimationBinGenericFormat? fragment)
+        private void ApplyMetaData(
+            ParsedMetadataFile? file,
+            MetaDataDocumentOwner owner,
+            ParsedMetadataAttribute? selectedAttribute,
+            SceneNode root,
+            ISkeletonProvider skeleton,
+            AnimationPlayer rootPlayer,
+            ICollection<IMetaDataInstance> output,
+            ICollection<MetaDataBuildDiagnostic> diagnostics)
         {
-            var output = new List<IMetaDataInstance>();
             if (file == null)
-                return output;
+                return;
 
             foreach (var animatedProp in file.GetItemsOfType<IAnimatedPropMeta>())
                 TryAddPreview(
                     output,
-                    animatedProp.GetType().Name,
+                    diagnostics,
+                    owner,
+                    (ParsedMetadataAttribute)animatedProp,
+                    root,
                     () => CreateAnimatedProp(
                         animatedProp,
                         root,
                         skeleton,
                         selectedAttribute,
-                        rootPlayer));
+                        rootPlayer,
+                        owner,
+                        diagnostics));
 
             foreach (var attribute in file.Attributes
                 .OfType<ParsedMetadataAttribute>())
@@ -124,20 +241,28 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                 {
                     TryAddPreview(
                         output,
-                        attribute.Name,
+                        diagnostics,
+                        owner,
+                        attribute,
+                        root,
                         () => CreateOrdinaryProp(
                             propData,
                             root,
                             skeleton,
                             selectedAttribute,
-                            rootPlayer));
+                            rootPlayer,
+                            owner,
+                            diagnostics));
                 }
             }
 
             foreach (var item in file.GetItemsOfType<ImpactPosition_v2>())
                 TryAddPreview(
                     output,
-                    item.Name,
+                    diagnostics,
+                    owner,
+                    item,
+                    root,
                     () => CreateStaticLocator(
                         item,
                         root,
@@ -150,7 +275,10 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             foreach (var item in file.GetItemsOfType<ImpactPosition_v10>())
                 TryAddPreview(
                     output,
-                    item.Name,
+                    diagnostics,
+                    owner,
+                    item,
+                    root,
                     () => CreateStaticLocator(
                         item,
                         root,
@@ -163,7 +291,10 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             foreach (var item in file.GetItemsOfType<TargetPos_0>())
                 TryAddPreview(
                     output,
-                    item.Name,
+                    diagnostics,
+                    owner,
+                    item,
+                    root,
                     () => CreateStaticLocator(
                         item,
                         root,
@@ -176,7 +307,10 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             foreach (var item in file.GetItemsOfType<TargetPos_10>())
                 TryAddPreview(
                     output,
-                    item.Name,
+                    diagnostics,
+                    owner,
+                    item,
+                    root,
                     () => CreateStaticLocator(
                         item,
                         root,
@@ -189,7 +323,10 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             foreach (var item in file.GetItemsOfType<FirePos_v0>())
                 TryAddPreview(
                     output,
-                    item.Name,
+                    diagnostics,
+                    owner,
+                    item,
+                    root,
                     () => CreateFireLocator(
                         item,
                         root,
@@ -201,7 +338,10 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             foreach (var item in file.GetItemsOfType<FirePos_v2>())
                 TryAddPreview(
                     output,
-                    item.Name,
+                    diagnostics,
+                    owner,
+                    item,
+                    root,
                     () => CreateFireLocator(
                         item,
                         root,
@@ -213,7 +353,10 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             foreach (var item in file.GetItemsOfType<FirePos_v10>())
                 TryAddPreview(
                     output,
-                    item.Name,
+                    diagnostics,
+                    owner,
+                    item,
+                    root,
                     () => CreateFireLocator(
                         item,
                         root,
@@ -225,7 +368,10 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             foreach (var item in file.GetItemsOfType<SplashAttack_v3>())
                 TryAddPreview(
                     output,
-                    item.Name,
+                    diagnostics,
+                    owner,
+                    item,
+                    root,
                     () => CreateSplashAttack(
                         CreateSplashPreviewData(item),
                         root,
@@ -237,7 +383,10 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             foreach (var item in file.GetItemsOfType<SplashAttack_v10>())
                 TryAddPreview(
                     output,
-                    item.Name,
+                    diagnostics,
+                    owner,
+                    item,
+                    root,
                     () => CreateSplashAttack(
                         CreateSplashPreviewData(item),
                         root,
@@ -249,8 +398,17 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             foreach (var item in file.GetItemsOfType<IEffectMeta>())
                 TryAddPreview(
                     output,
-                    item.GetType().Name,
-                    () => CreateEffect(item, root, skeleton, selectedAttribute));
+                    diagnostics,
+                    owner,
+                    (ParsedMetadataAttribute)item,
+                    root,
+                    () => CreateEffect(
+                        item,
+                        root,
+                        skeleton,
+                        selectedAttribute,
+                        owner,
+                        diagnostics));
 
             foreach (var attribute in file.Attributes
                 .OfType<ParsedMetadataAttribute>())
@@ -262,7 +420,10 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                 {
                     TryAddPreview(
                         output,
-                        attribute.Name,
+                        diagnostics,
+                        owner,
+                        attribute,
+                        root,
                         () => CreateSpatialMarker(
                             spatialBinding,
                             root,
@@ -270,43 +431,49 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                             selectedAttribute));
                 }
 
-                if (TryCreateBoneOnlyPreview(
+                if (IsBoneOnlyMetaData(attribute))
+                {
+                    TryAddPreview(
+                        output,
+                        diagnostics,
+                        owner,
                         attribute,
                         root,
-                        skeleton,
-                        selectedAttribute,
-                        out var bonePreview) &&
-                    bonePreview != null)
-                {
-                    output.Add(bonePreview);
+                        () =>
+                        {
+                            TryCreateBoneOnlyPreview(
+                                attribute,
+                                root,
+                                skeleton,
+                                selectedAttribute,
+                                out var bonePreview);
+                            if (bonePreview == null)
+                            {
+                                diagnostics.Add(
+                                    MetaDataDiagnosticFactory.Create(
+                                        attribute,
+                                        owner,
+                                        "SuperView.Diagnostics.MissingBone"));
+                            }
+                            return bonePreview;
+                        });
                 }
             }
-
-            foreach (var meteDataItem in file.GetItemsOfType<DockEquipment>())
-                TryAddRule(
-                    meteDataItem.Name,
-                    () => CreateEquipmentDock(
-                        meteDataItem,
-                        fragment,
-                        skeleton,
-                        rootPlayer));
-
-            foreach (var meteDataItem in file.GetItemsOfType<Transform_v10>())
-                TryAddRule(
-                    meteDataItem.Name,
-                    () => CreateTransform(meteDataItem, rootPlayer));
-
-            return output;
         }
 
-        public bool TryCreateMetaDataPreview(
+        public MetaDataPreviewBuildResult BuildPreview(
             ParsedMetadataAttribute attribute,
+            MetaDataDocumentOwner owner,
             bool isSelected,
             SceneNode root,
             ISkeletonProvider skeleton,
-            AnimationPlayer rootPlayer,
-            out IMetaDataInstance? preview)
+            AnimationPlayer rootPlayer)
         {
+            var diagnostics = new List<MetaDataBuildDiagnostic>();
+            if (attribute is Transform_v10 or DockEquipment)
+                return new(false, null, diagnostics);
+
+            var existingChildren = root.Children.ToHashSet();
             Func<IMetaDataInstance?>? create;
             if (attribute is IAnimatedPropMeta animatedProp)
             {
@@ -315,7 +482,9 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                     root,
                     skeleton,
                     isSelected ? attribute : null,
-                    rootPlayer);
+                    rootPlayer,
+                    owner,
+                    diagnostics);
             }
             else if (TryGetOrdinaryPropData(attribute, out var propData))
             {
@@ -324,7 +493,9 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                     root,
                     skeleton,
                     isSelected ? attribute : null,
-                    rootPlayer);
+                    rootPlayer,
+                    owner,
+                    diagnostics);
             }
             else
             {
@@ -401,7 +572,9 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                         item,
                         root,
                         skeleton,
-                        isSelected ? attribute : null),
+                        isSelected ? attribute : null,
+                        owner,
+                        diagnostics),
                     _ => null
                 };
             }
@@ -431,30 +604,42 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                 };
             }
             if (create == null)
-            {
-                preview = null;
-                return false;
-            }
+                return new(false, null, diagnostics);
 
             try
             {
-                preview = create();
+                var preview = create();
+                if (preview == null && IsBoneOnlyMetaData(attribute))
+                {
+                    diagnostics.Add(MetaDataDiagnosticFactory.Create(
+                        attribute,
+                        owner,
+                        "SuperView.Diagnostics.MissingBone"));
+                }
+                return new(true, preview, diagnostics);
             }
             catch (Exception e)
             {
+                RemoveNewChildren(root, existingChildren);
                 _logger.Here().Warning(
                     $"Skipping metadata preview for '{attribute.Name}': {e.Message}");
-                preview = null;
+                diagnostics.Add(MetaDataDiagnosticFactory.Create(
+                    attribute,
+                    owner,
+                    "SuperView.Diagnostics.PreviewUnavailable"));
+                return new(true, null, diagnostics);
             }
-
-            return true;
         }
 
         private void TryAddPreview(
             ICollection<IMetaDataInstance> output,
-            string tagName,
+            ICollection<MetaDataBuildDiagnostic> diagnostics,
+            MetaDataDocumentOwner owner,
+            ParsedMetadataAttribute source,
+            SceneNode root,
             Func<IMetaDataInstance?> create)
         {
+            var existingChildren = root.Children.ToHashSet();
             try
             {
                 var instance = create();
@@ -463,74 +648,26 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             }
             catch (Exception e)
             {
+                RemoveNewChildren(root, existingChildren);
                 _logger.Here().Warning(
-                    $"Skipping metadata preview for '{tagName}': {e.Message}");
+                    $"Skipping metadata preview for '{source.Name}': {e.Message}");
+                diagnostics.Add(MetaDataDiagnosticFactory.Create(
+                    source,
+                    owner,
+                    "SuperView.Diagnostics.PreviewUnavailable"));
             }
         }
 
-        private void TryAddRule(string tagName, Action create)
+        private static void RemoveNewChildren(
+            SceneNode root,
+            ISet<ISceneNode> existingChildren)
         {
-            try
+            foreach (var child in root.Children
+                .Where(child => !existingChildren.Contains(child))
+                .ToList())
             {
-                create();
+                root.RemoveObject(child);
             }
-            catch (Exception e)
-            {
-                _logger.Here().Warning(
-                    $"Skipping metadata preview rule for '{tagName}': {e.Message}");
-            }
-        }
-
-        private void CreateTransform(Transform_v10 transform, AnimationPlayer rootPlayer)
-        {
-            var rule = new TransformBoneRule(transform);
-            rootPlayer.AnimationRules.Add(rule);
-        }
-
-        private void CreateEquipmentDock(DockEquipment metaData, IAnimationBinGenericFormat? fragment, ISkeletonProvider skeleton, AnimationPlayer rootPlayer)
-        {
-            if (fragment == null)
-            {
-                _logger.Here().Error($"Unable to create docking, as animation is missing - select an animation");
-                return;
-            }
-
-            var animPath = fragment.Entries.FirstOrDefault(x => x.SlotName == metaData.AnimationSlotName)?.AnimationFile ??
-                           fragment.Entries.FirstOrDefault(x => x.SlotName == metaData.AnimationSlotName + "_2")?.AnimationFile;
-            if (animPath == null)
-            {
-                _logger.Here().Error($"Unable to create docking, as {metaData.AnimationSlotName} animation is missing");
-                return;
-            }
-
-            var finalBoneIndex = -1;
-            foreach (var potentialBoneName in metaData.SkeletonNameAlternatives)
-            {
-                finalBoneIndex = skeleton.Skeleton.GetBoneIndexByName(potentialBoneName);
-                if (finalBoneIndex != -1)
-                    break;
-            }
-
-            if (finalBoneIndex == -1)
-            {
-                var boneNames = string.Join(", ", metaData.SkeletonNameAlternatives);
-                _logger.Here().Error($"Unable to create docking, as {boneNames} bone is missing");
-                return;
-            }
-
-            var pf = _packFileService.FindFile(animPath);
-            if (pf == null)
-            {
-                _logger.Here().Warning(
-                    $"Skipping docking preview because animation '{animPath}' was not found.");
-                return;
-            }
-
-            var animFile = AnimationFile.Create(pf);
-            var clip = new AnimationClip(animFile, skeleton.Skeleton);
-
-            var rule = new DockEquipmentRule(finalBoneIndex, metaData.PropBoneId, clip, skeleton, metaData.StartTime, metaData.EndTime);
-            rootPlayer.AnimationRules.Add(rule);
         }
 
         private IMetaDataInstance? CreateAnimatedProp(
@@ -538,7 +675,9 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             SceneNode root,
             ISkeletonProvider rootSkeleton,
             ParsedMetadataAttribute? selectedMetaDataAttribute,
-            AnimationPlayer rootPlayer)
+            AnimationPlayer rootPlayer,
+            MetaDataDocumentOwner owner,
+            ICollection<MetaDataBuildDiagnostic> diagnostics)
         {
             var source = (ParsedMetadataAttribute)animatedPropMeta;
             var data = new PropPreviewData(
@@ -557,7 +696,9 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                 rootSkeleton,
                 selectedMetaDataAttribute,
                 rootPlayer,
-                true);
+                true,
+                owner,
+                diagnostics);
         }
 
         private IMetaDataInstance? CreateOrdinaryProp(
@@ -565,14 +706,18 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             SceneNode root,
             ISkeletonProvider rootSkeleton,
             ParsedMetadataAttribute? selectedMetaDataAttribute,
-            AnimationPlayer rootPlayer) =>
+            AnimationPlayer rootPlayer,
+            MetaDataDocumentOwner owner,
+            ICollection<MetaDataBuildDiagnostic> diagnostics) =>
             CreatePropPreview(
                 data,
                 root,
                 rootSkeleton,
                 selectedMetaDataAttribute,
                 rootPlayer,
-                false);
+                false,
+                owner,
+                diagnostics);
 
         private IMetaDataInstance? CreatePropPreview(
             PropPreviewData data,
@@ -580,7 +725,9 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             ISkeletonProvider rootSkeleton,
             ParsedMetadataAttribute? selectedMetaDataAttribute,
             AnimationPlayer rootPlayer,
-            bool attachThroughAnimation)
+            bool attachThroughAnimation,
+            MetaDataDocumentOwner owner,
+            ICollection<MetaDataBuildDiagnostic> diagnostics)
         {
             if (!SpatialMetaDataCatalog.TryCreate(
                     data.Source,
@@ -595,7 +742,11 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             var color = selectedMetaDataAttribute == data.Source
                 ? s_selectedColor
                 : s_color;
-            var meshPath = _packFileService.FindFile(data.ModelName);
+            var meshPath = _resourceResolver.FindModel(
+                data.Source,
+                owner,
+                data.ModelName,
+                diagnostics);
             if (meshPath == null)
             {
                 _logger.Here().Warning(
@@ -614,7 +765,11 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             {
                 var animationPath = string.IsNullOrWhiteSpace(data.AnimationName)
                     ? null
-                    : _packFileService.FindFile(data.AnimationName);
+                    : _resourceResolver.FindAnimation(
+                        data.Source,
+                        owner,
+                        data.AnimationName,
+                        diagnostics);
                 propPlayer = _animationsContainerComponent.RegisterAnimationPlayer(
                     new AnimationPlayer(),
                     propName + Guid.NewGuid());
@@ -741,6 +896,10 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
 
                 _logger.Here().Warning(
                     $"Skipping prop preview: {e.Message}");
+                diagnostics.Add(MetaDataDiagnosticFactory.Create(
+                    data.Source,
+                    owner,
+                    "SuperView.Diagnostics.PreviewUnavailable"));
                 return CreateSpatialMarker(
                     spatialBinding,
                     root,
@@ -1188,9 +1347,20 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             };
         }
 
-        private IMetaDataInstance CreateEffect(IEffectMeta effect, SceneNode root, ISkeletonProvider skeleton, ParsedMetadataAttribute? selectedAttribute)
+        private IMetaDataInstance CreateEffect(
+            IEffectMeta effect,
+            SceneNode root,
+            ISkeletonProvider skeleton,
+            ParsedMetadataAttribute? selectedAttribute,
+            MetaDataDocumentOwner owner,
+            ICollection<MetaDataBuildDiagnostic> diagnostics)
         {
             var source = (ParsedMetadataAttribute)effect;
+            _resourceResolver.CheckEffect(
+                source,
+                owner,
+                effect.VfxName,
+                diagnostics);
             var node = new SimpleDrawableNode("Effect:" + effect.VfxName);
             var instance = new DrawableMetaInstance(
                 GetActiveTimeRange(source),
@@ -1205,7 +1375,22 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                 () => new Quaternion(effect.Orientation));
             root.AddObject(node);
             if (effect.Tracking)
-                instance.FollowBone(skeleton, effect.NodeIndex);
+            {
+                if (skeleton?.Skeleton != null &&
+                    effect.NodeIndex >= 0 &&
+                    effect.NodeIndex < skeleton.Skeleton.BoneCount)
+                {
+                    instance.FollowBone(skeleton, effect.NodeIndex);
+                }
+                else
+                {
+                    diagnostics.Add(MetaDataDiagnosticFactory.Create(
+                        source,
+                        owner,
+                        "SuperView.Diagnostics.MissingBone",
+                        boneName: effect.NodeIndex.ToString()));
+                }
+            }
             return instance;
         }
 

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataDiagnosticFactory.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataDiagnosticFactory.cs
@@ -1,0 +1,56 @@
+using Microsoft.Xna.Framework;
+using Shared.GameFormats.AnimationMeta.Parsing;
+
+namespace Editors.AnimationMeta.SuperView.Visualisation
+{
+    internal static class MetaDataDiagnosticFactory
+    {
+        public static MetaDataBuildDiagnostic Create(
+            ParsedMetadataAttribute source,
+            MetaDataDocumentOwner owner,
+            string reasonKey,
+            string? resourcePath = null,
+            string? boneName = null)
+        {
+            var timeRange = TryGetTimeRange(source);
+            var position = TryGetPosition(source);
+            return new(
+                source,
+                owner,
+                MetaDataDiagnosticSeverity.Warning,
+                reasonKey,
+                timeRange,
+                position,
+                resourcePath,
+                boneName);
+        }
+
+        private static MetaDataTimeRange? TryGetTimeRange(ParsedMetadataAttribute source)
+        {
+            try
+            {
+                return MetaDataTimeRange.TryCreate(source, out var range)
+                    ? range
+                    : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static Vector3? TryGetPosition(ParsedMetadataAttribute source)
+        {
+            try
+            {
+                return SpatialMetaDataCatalog.TryCreate(source, out var binding)
+                    ? binding.Position
+                    : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataResourceResolver.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataResourceResolver.cs
@@ -1,0 +1,93 @@
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+using Serilog;
+using Shared.Core.ErrorHandling;
+using Shared.GameFormats.AnimationMeta.Parsing;
+
+namespace Editors.AnimationMeta.SuperView.Visualisation
+{
+    internal sealed class MetaDataResourceResolver
+    {
+        private readonly ILogger _logger =
+            Logging.Create<MetaDataResourceResolver>();
+        private readonly IPackFileService _packFileService;
+
+        public MetaDataResourceResolver(IPackFileService packFileService)
+        {
+            _packFileService = packFileService;
+        }
+
+        public PackFile? FindModel(
+            ParsedMetadataAttribute source,
+            MetaDataDocumentOwner owner,
+            string path,
+            ICollection<MetaDataBuildDiagnostic> diagnostics) =>
+            FindRequired(
+                source,
+                owner,
+                path,
+                "SuperView.Diagnostics.MissingModel",
+                diagnostics);
+
+        public PackFile? FindAnimation(
+            ParsedMetadataAttribute source,
+            MetaDataDocumentOwner owner,
+            string path,
+            ICollection<MetaDataBuildDiagnostic> diagnostics) =>
+            FindRequired(
+                source,
+                owner,
+                path,
+                "SuperView.Diagnostics.MissingAnimation",
+                diagnostics);
+
+        public void CheckEffect(
+            ParsedMetadataAttribute source,
+            MetaDataDocumentOwner owner,
+            string effectName,
+            ICollection<MetaDataBuildDiagnostic> diagnostics)
+        {
+            var path = string.IsNullOrWhiteSpace(effectName)
+                ? ""
+                : $@"vfx\{effectName}.xml";
+            FindRequired(
+                source,
+                owner,
+                path,
+                "SuperView.Diagnostics.MissingEffect",
+                diagnostics);
+        }
+
+        private PackFile? FindRequired(
+            ParsedMetadataAttribute source,
+            MetaDataDocumentOwner owner,
+            string path,
+            string reasonKey,
+            ICollection<MetaDataBuildDiagnostic> diagnostics)
+        {
+            PackFile? resource = null;
+            try
+            {
+                resource = string.IsNullOrWhiteSpace(path)
+                    ? null
+                    : _packFileService.FindFile(path);
+            }
+            catch
+            {
+                // Resource lookup failures are isolated to the current META.
+            }
+            if (resource == null)
+            {
+                _logger.Here().Warning(
+                    $"Metadata preview resource was not found: '{path}'.");
+                diagnostics.Add(MetaDataDiagnosticFactory.Create(
+                    source,
+                    owner,
+                    reasonKey,
+                    path));
+            }
+
+            return resource;
+        }
+    }
+}

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataRuleBuilder.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataRuleBuilder.cs
@@ -1,0 +1,199 @@
+using Editors.AnimationMeta.SuperView.Visualisation.Rules;
+using GameWorld.Core.Animation;
+using GameWorld.Core.Animation.AnimationChange;
+using GameWorld.Core.SceneNodes;
+using Serilog;
+using Shared.Core.ErrorHandling;
+using Shared.GameFormats.Animation;
+using Shared.GameFormats.AnimationMeta.Definitions;
+using Shared.GameFormats.AnimationMeta.Parsing;
+using Shared.GameFormats.AnimationPack;
+
+namespace Editors.AnimationMeta.SuperView.Visualisation
+{
+    internal sealed class MetaDataRuleBuilder
+    {
+        private readonly ILogger _logger = Logging.Create<MetaDataRuleBuilder>();
+        private readonly MetaDataResourceResolver _resourceResolver;
+
+        public MetaDataRuleBuilder(
+            MetaDataResourceResolver resourceResolver)
+        {
+            _resourceResolver = resourceResolver;
+        }
+
+        public void AppendRules(
+            ParsedMetadataFile? file,
+            MetaDataDocumentOwner owner,
+            IAnimationBinGenericFormat? fragment,
+            ISkeletonProvider skeleton,
+            ICollection<IAnimationChangeRule> rules,
+            ICollection<MetaDataBuildDiagnostic> diagnostics)
+        {
+            if (file == null)
+                return;
+
+            foreach (var item in file.GetItemsOfType<DockEquipment>())
+            {
+                try
+                {
+                    TryAddDockRule(
+                        item,
+                        owner,
+                        fragment,
+                        skeleton,
+                        rules,
+                        diagnostics);
+                }
+                catch (Exception exception)
+                {
+                    _logger.Here().Warning(
+                        $"Skipping metadata preview rule for '{item.Name}': {exception.Message}");
+                    AddDiagnostic(
+                        item,
+                        owner,
+                        "SuperView.Diagnostics.RuleUnavailable",
+                        diagnostics);
+                }
+            }
+
+            foreach (var item in file.GetItemsOfType<Transform_v10>())
+            {
+                TryAddRule(
+                    item,
+                    owner,
+                    () => new TransformBoneRule(item),
+                    rules,
+                    diagnostics);
+            }
+        }
+
+        private void TryAddDockRule(
+            DockEquipment source,
+            MetaDataDocumentOwner owner,
+            IAnimationBinGenericFormat? fragment,
+            ISkeletonProvider skeleton,
+            ICollection<IAnimationChangeRule> rules,
+            ICollection<MetaDataBuildDiagnostic> diagnostics)
+        {
+            if (fragment == null)
+            {
+                AddDiagnostic(
+                    source,
+                    owner,
+                    "SuperView.Diagnostics.MissingAnimation",
+                    diagnostics,
+                    source.AnimationSlotName);
+                return;
+            }
+
+            var animationPath = fragment.Entries.FirstOrDefault(entry =>
+                    entry.SlotName == source.AnimationSlotName)?.AnimationFile ??
+                fragment.Entries.FirstOrDefault(entry =>
+                    entry.SlotName == source.AnimationSlotName + "_2")?.AnimationFile;
+            if (string.IsNullOrWhiteSpace(animationPath))
+            {
+                AddDiagnostic(
+                    source,
+                    owner,
+                    "SuperView.Diagnostics.MissingAnimation",
+                    diagnostics,
+                    source.AnimationSlotName);
+                return;
+            }
+
+            var boneIndex = FindBoneIndex(source, skeleton);
+            if (boneIndex < 0)
+            {
+                AddDiagnostic(
+                    source,
+                    owner,
+                    "SuperView.Diagnostics.MissingBone",
+                    diagnostics,
+                    boneName: string.Join(", ", source.SkeletonNameAlternatives));
+                return;
+            }
+
+            var animationFile = _resourceResolver.FindAnimation(
+                source,
+                owner,
+                animationPath,
+                diagnostics);
+            if (animationFile == null)
+                return;
+
+            TryAddRule(
+                source,
+                owner,
+                () =>
+                {
+                    var clip = new AnimationClip(
+                        AnimationFile.Create(animationFile),
+                        skeleton.Skeleton);
+                    return new DockEquipmentRule(
+                        boneIndex,
+                        source.PropBoneId,
+                        clip,
+                        skeleton,
+                        source.StartTime,
+                        source.EndTime);
+                },
+                rules,
+                diagnostics);
+        }
+
+        private static int FindBoneIndex(
+            DockEquipment source,
+            ISkeletonProvider skeleton)
+        {
+            if (skeleton?.Skeleton == null)
+                return -1;
+
+            foreach (var boneName in source.SkeletonNameAlternatives)
+            {
+                var boneIndex = skeleton.Skeleton.GetBoneIndexByName(boneName);
+                if (boneIndex >= 0)
+                    return boneIndex;
+            }
+
+            return -1;
+        }
+
+        private void TryAddRule(
+            ParsedMetadataAttribute source,
+            MetaDataDocumentOwner owner,
+            Func<IAnimationChangeRule> create,
+            ICollection<IAnimationChangeRule> rules,
+            ICollection<MetaDataBuildDiagnostic> diagnostics)
+        {
+            try
+            {
+                rules.Add(create());
+            }
+            catch (Exception exception)
+            {
+                _logger.Here().Warning(
+                    $"Skipping metadata preview rule for '{source.Name}': {exception.Message}");
+                AddDiagnostic(
+                    source,
+                    owner,
+                    "SuperView.Diagnostics.RuleUnavailable",
+                    diagnostics);
+            }
+        }
+
+        private static void AddDiagnostic(
+            ParsedMetadataAttribute source,
+            MetaDataDocumentOwner owner,
+            string reasonKey,
+            ICollection<MetaDataBuildDiagnostic> diagnostics,
+            string? resourcePath = null,
+            string? boneName = null) =>
+            diagnostics.Add(MetaDataDiagnosticFactory.Create(
+                source,
+                owner,
+                reasonKey,
+                resourcePath,
+                boneName));
+    }
+}

--- a/docs/superview.md
+++ b/docs/superview.md
@@ -79,7 +79,10 @@
 | `SceneObjectViewModel` | 单个参考资产的 UI 状态 | 模型路径、动画选择、阵营/相机等共享预览状态 |
 | `SceneObjectEditor` | 加载模型、骨架、动画和 meta，并发布更新事件 | 当前运行时 `SceneObject` |
 | `SceneObject` | 场景根、主播放器、metadata instances | 每帧调用实例 `Update` |
-| `MetaDataBuilder` | 把两份已解析元数据建立为预览实例与动画规则 | 一次构建结果，不持有文档 dirty |
+| `MetaDataBuilder` | 组合预览实例、动画规则和结构化诊断 | 一次构建结果，不持有文档 dirty |
+| `MetaDataPreviewBuilder` | 分派并建立已支持的预览实例族 | 单条预览的失败隔离与 marker fallback |
+| `MetaDataRuleBuilder` | 建立 Dock Equipment 和 Transform 动画规则 | 规则列表，不直接写主播放器 |
+| `MetaDataResourceResolver` | 查找模型、动画和 Effect XML | 统一资源缺失诊断，不伪造资源 |
 | `CombatMetaDataEditSession` | 空间元数据预览事务、撤销/重做、每文档历史 | 以文档 owner 区分的编辑历史 |
 | `CombatMetaDataGizmoComponent` | 3D 手势与 Gizmo/鼠标生命周期 | 当前空间目标和活动 gesture |
 | `SpatialMetaDataCatalog` | 已验证空间标签到可写字段的适配 | 类型能力定义，不持有运行时选择 |
@@ -137,8 +140,8 @@
 2. 各自加载 persistent 与 animation metadata 编辑器；
 3. 清理旧的预览实例和动画规则；
 4. 清除已不属于当前源对象的用户预览覆盖设置；
-5. 调用 `MetaDataBuilder.Create(...)`；
-6. 把结果放入 `SceneObject.MetaDataItems`；
+5. 调用 `MetaDataBuilder.Build(...)`，一次取得实例、规则和诊断；
+6. 把实例放入 `SceneObject.MetaDataItems`，把规则安装到主播放器，并替换当前诊断快照；
 7. 刷新播放器和选择状态，并保持所有参考模型节点不可选择。
 
 构建参数包含两份解析文档、当前选中属性、场景根、骨架、主播放器和 Fragment 上下文。任何缓存都必须以这些实际输入为准，不能只按 tag 名复用。
@@ -153,17 +156,19 @@
 
 ### 7.1 合并顺序
 
-`MetaDataBuilder.Create` 先应用 persistent metadata，再应用当前 animation metadata。若 animation metadata 包含格式定义中的 `DisablePersistant_v10`，则跳过 persistent 部分。保留代码中的格式拼写，不要为了文字正确而重命名二进制定义。
+`MetaDataBuilder.Build` 先应用 persistent metadata，再应用当前 animation metadata。若 animation metadata 包含格式定义中的 `DisablePersistant_v10`，则跳过 persistent 部分。保留代码中的格式拼写，不要为了文字正确而重命名二进制定义。
 
 两层来源的预览仍保留各自 `ParsedMetadataAttribute` 引用。后续选中、增量替换、批量显隐和保存都依赖对象身份，不应按字段值或 tag 文本猜来源。
 
 ### 7.2 支持的输出
 
-构建器可产生三类运行时结果：
+`MetaDataBuildResult` 一次返回三类运行时结果：
 
 1. 场景实例：普通 Prop、Animated Prop、Effect、战斗定位器和通用空间标记；
-2. 动画规则：Dock Equipment、Transform Bone、根变换复制等；
-3. 预览描述：来源、分类、世界变换、参考变换、焦点位置、时间范围、选中和显隐。
+2. 根播放器动画规则：Dock Equipment 和 Transform Bone；Animated Prop 的根变换复制仍由其附属播放器持有并随实例清理；
+3. 结构化诊断：原始 `ParsedMetadataAttribute` 引用、`Persistent`/`Animation` owner、严重程度、本地化原因键，以及可用的时间范围、空间位置、资源路径或骨骼上下文。
+
+构建器不直接把根规则写入 `AnimationPlayer`。调用者只消费完整结果，不参与 META 类型分派。`MetaDataBuildDiagnostic.ReasonKey` 必须对应中文本地化资源；诊断只描述预览问题，不改变字段校验、dirty 或保存门禁。
 
 战斗预览分类为 `Impact`、`Target`、`Fire`、`Splash`。每个实例都有独立显隐，不应通过隐藏整个模型实现分类筛选。
 
@@ -177,11 +182,11 @@
 - 未知或不支持的 tag 保留在解析文档中，不因无法预览而删除或改写；
 - 不能凭空生成一个“看起来合理”的资源或坐标掩盖数据缺失。
 
-资源失败策略的目标是保留可编辑文档与其余预览，而不是把整个构建标记为成功无误。UI/日志仍应让用户知道缺失项。
+资源失败策略的目标是保留可编辑文档与其余预览，而不是把整个构建标记为成功无误。资源查找失败、资源服务异常和单项建立异常都只追加该源对象的诊断；若失败发生在节点挂载之后，必须移除该项产生的半成品节点。诊断快照由 `SuperViewViewModel.MetaDataDiagnostics` 提供给后续检查索引和问题列表。
 
 ### 7.4 增量刷新
 
-字段编辑后，超级视图优先尝试只重建受影响的一个预览：
+字段编辑后，超级视图优先通过 `BuildPreview` 只重建受影响的一个预览：
 
 - 构建器能为该源创建替代实例时，保留其他实例和它们的 UI 状态；
 - 不支持增量创建、结构变更或影响动画规则时，回退到完整重建；
@@ -324,7 +329,7 @@ Edit Session 以 owner 的引用身份隔离历史。Persistent 与 Animation �
 - `DockEquipmentRule`：在活动时间内，把装备槽骨骼对齐到目标骨骼；
 - `TransformBoneRule`：在活动时间内对指定骨骼应用 authored 位置/方向增量。
 
-这些规则改变预览 pose，不直接改写原始动画文件。规则创建失败应只隔离单条规则；旧规则在 rebuild 时必须从播放器移除，不能累计执行。
+这些规则改变预览 pose，不直接改写原始动画文件。完整构建只返回根规则，由 `SuperViewViewModel` 在清除旧规则后统一安装。规则创建失败应只产生该源对象的诊断并隔离单条规则；旧规则在 rebuild 时必须从播放器移除，不能累计执行。
 
 修改规则时同时检查：局部/世界空间接口、时间单位、骨骼索引、父子层级、循环/暂停刷新和错误后的停用行为。不能把预览规则的结果烘焙回模型或动画资源，除非另有明确功能授权。
 
@@ -389,7 +394,7 @@ Edit Session 以 owner 的引用身份隔离历史。Persistent 与 Animation �
 | 时间显示不对 | `MetaDataTimeRange` | 秒/微秒换算、零范围策略、播放器 seek |
 | Gizmo 移动方向/保存坐标错误 | `CombatMetaDataEditSession` | `ReferenceWorldTransform`、局部/世界转换、骨骼 frame |
 | Undo/dirty 串到另一页签 | owner 历史映射 | 子编辑器 dirty、saved state、引用身份 |
-| 修改后全部预览闪烁/重建 | 增量 `TryCreateMetaDataPreview` | 结构/规则 fallback、旧实例清理 |
+| 修改后全部预览闪烁/重建 | 增量 `BuildPreview` | 结构/规则 fallback、旧实例和该源诊断清理 |
 | 缺失 Prop 导致整个视图失败 | 构建器资源隔离 | 通用 marker fallback、日志、其他实例保留 |
 | 超级视图按钮出现在直接 Meta Editor | `MetaDataAttributeView.xaml` 祖先绑定 | Visibility 条件、控件测试 |
 | 模型能被点选或编辑 | 场景节点 `IsSelectable` | 是否误插入共享/Kitbash 选择组件 |
@@ -401,7 +406,7 @@ Edit Session 以 owner 的引用身份隔离历史。Persistent 与 Animation �
 | --- | --- | --- |
 | 双文档、保存、dirty | `MetaDataEditorViewModelTests`、`MetaDataEditorMultiSelectTests` | 两页签修改、部分缺失、保存/重开 |
 | 空间 Gizmo | `CombatMetaDataEditSessionTests`、`SpatialMetaDataCatalogTests` | 根/骨骼附着、平移/旋转、取消/撤销/重做 |
-| 预览构建/资源失败 | `MetaDataBuilderMissingResourceTests` | 真实 Fragment、模型、动画和日志表现 |
+| 预览构建/资源失败 | `MetaDataBuildResultTests`、`MetaDataBuilderMissingResourceTests` | 真实 Fragment、模型、动画、Effect 和诊断表现 |
 | 时间与同步 | `MetaDataPreviewTimeTests` | 播放/暂停/seek/循环、瞬时 tag 与整段 tag |
 | 字段 UI/批量控制 | `MetaDataAttributeControlTests` | 两页签、直接 Meta Editor、中文 UI 和焦点 |
 | 格式解析 | `MetaDataFileParserTests` 及格式项目测试 | 真实文件 round trip、未知 payload |


### PR DESCRIPTION
## 概要

- 将 SuperView 构建结果收敛为预览实例、动画规则和结构化诊断
- 分离预览、规则与资源查找职责，单项失败不再中断其余预览
- 保持 Persistent/Animation、选择高亮、单项刷新、保存与撤销边界不变
- 补充诊断、资源失败和完整重建生命周期测试，并更新稳定契约文档

## 验证

- `dotnet restore AssetEditor.CN.sln`
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore`
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity minimal`：3111 通过，6 跳过，0 失败
- 双轨代码审查：规范 0 项，规格 0 项
- 真实 `Data\Throt.pack` / `ATTACK_5` Fragment/META：模型、动画、播放、时间拖动和选择高亮正常
- 真实缺失 `vfx\wh2_dlc16_entity_weapon_sparks_360.xml`：诊断日志可观察，其余预览继续可用

Closes #91