### PR TITLE
feat(superview): 交付 3D META 标记选取

### DIFF
--- a/Editors/AnimationMeta/Test.AnimationMeta/MetaDataBuilderMissingResourceTests.cs
+++ b/Editors/AnimationMeta/Test.AnimationMeta/MetaDataBuilderMissingResourceTests.cs
@@ -612,6 +612,7 @@ namespace Test.AnimationMeta
                     null).Instances
                 .Single();
             var preview = (ICombatMetaDataPreview)instance;
+            var markerPreview = (IMetaDataMarkerPreview)instance;
             var node = root.Children.Single();
 
             instance.Update(0);
@@ -620,6 +621,19 @@ namespace Test.AnimationMeta
                 Assert.That(
                     preview.FocusPosition,
                     Is.EqualTo(new Vector3(1, 2, 5)));
+                Assert.That(
+                    markerPreview.HitTargets,
+                    Is.EqualTo(new[]
+                    {
+                        new MetaDataMarkerHitTarget(
+                            splash.StartPosition,
+                            MetaDataMarkerPoint.SplashStart,
+                            0.5f),
+                        new MetaDataMarkerHitTarget(
+                            splash.EndPosition,
+                            MetaDataMarkerPoint.SplashEnd,
+                            0.5f),
+                    }));
                 Assert.That(node.ModelMatrix, Is.EqualTo(Matrix.Identity));
             });
 
@@ -632,7 +646,39 @@ namespace Test.AnimationMeta
                 Assert.That(
                     preview.FocusPosition,
                     Is.EqualTo(new Vector3(4, 5, 8)));
+                Assert.That(
+                    markerPreview.HitTargets.Select(target => target.Position),
+                    Is.EqualTo(new[]
+                    {
+                        splash.StartPosition,
+                        splash.EndPosition,
+                    }));
                 Assert.That(node.ModelMatrix, Is.EqualTo(Matrix.Identity));
+            });
+        }
+
+        [Test]
+        public void SplashAttackMarker_UsesOnlyEndpointRingsAndPlanarArrow()
+        {
+            var marker = MetaDataPreviewBuilder.CreateSplashAttackMarker(
+                Vector3.Zero,
+                new Vector3(0, 0, 4),
+                endpointRadius: 0.15f,
+                color: Color.Red,
+                edgeWidth: 1);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(marker.Triangles, Is.Empty);
+                Assert.That(marker.Edges, Has.Length.EqualTo(51));
+                Assert.That(marker.Edges[^3].P0, Is.EqualTo(Vector3.Zero));
+                Assert.That(
+                    marker.Edges[^3].P1,
+                    Is.EqualTo(new Vector3(0, 0, 4)));
+                Assert.That(
+                    marker.Edges.TakeLast(3)
+                        .SelectMany(edge => new[] { edge.P0.Y, edge.P1.Y }),
+                    Has.All.EqualTo(0));
             });
         }
 

--- a/Editors/AnimationMeta/Test.AnimationMeta/MetaDataEditorViewModelTests.cs
+++ b/Editors/AnimationMeta/Test.AnimationMeta/MetaDataEditorViewModelTests.cs
@@ -1677,6 +1677,99 @@ namespace Test.AnimationMeta
         }
 
         [Test]
+        public void SuperView_MarkerSelection_UsesCurrentIndexOwnerWithoutSeeking()
+        {
+            const string animationPath =
+                @"animations\battle\codex\marker_animation.anm.meta";
+            const string persistentPath =
+                @"animations\battle\codex\marker_persistent.anm.meta";
+            var runner = new AssetEditorTestRunner();
+            runner.CreateOutputPack();
+            var editorCreator =
+                runner.ServiceProvider.GetRequiredService<IEditorCreator>();
+            var superView = (SuperViewViewModel)editorCreator.Create(
+                EditorEnums.SuperView_Editor);
+
+            try
+            {
+                var parser = runner.GetRequiredServiceInCurrentEditorScope<
+                    MetaDataFileParser>();
+                var fileSaveService =
+                    runner.GetRequiredServiceInCurrentEditorScope<
+                        IFileSaveService>();
+                var sceneObjectEditor =
+                    runner.GetRequiredServiceInCurrentEditorScope<
+                        SceneObjectEditor>();
+                var animationFile = SaveTimedMetaFile(
+                    fileSaveService,
+                    parser,
+                    animationPath);
+                var persistentFile = SaveTimedMetaFile(
+                    fileSaveService,
+                    parser,
+                    persistentPath);
+                var sceneObject = superView.SceneObjects.Single();
+                sceneObject.FragAndSlotSelection.MetaDataName = animationPath;
+                sceneObject.FragAndSlotSelection.MetaDataPersistName =
+                    persistentPath;
+                sceneObjectEditor.SetMetaFile(
+                    sceneObject.Data,
+                    animationFile,
+                    persistentFile);
+                superView.Player.SelectedAnimationMaxTime.Value = 5;
+                superView.SelectedTabControllerIndex = 1;
+                foreach (var preview in sceneObject.Data.MetaDataItems)
+                    preview.Update(1);
+                var persistentItem = superView.MetaDataInspectionIndex.Items
+                    .Single(item => item.Owner ==
+                        MetaDataDocumentOwner.Persistent);
+
+                superView.SelectMetaDataMarker(persistentItem);
+
+                var selectedTimelineMarker = superView.MetaDataTimeline.Markers
+                    .Single(marker => ReferenceEquals(
+                        marker.Item.Source,
+                        persistentItem.Source));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(superView.SelectedTabControllerIndex, Is.Zero);
+                    Assert.That(
+                        superView.PersistentMetaEditor.SelectedAttribute,
+                        Is.SameAs(persistentItem.Source));
+                    Assert.That(
+                        sceneObject.Data.Player.GetTimeUs(),
+                        Is.Zero);
+                    Assert.That(selectedTimelineMarker.IsSelected, Is.True);
+                    Assert.That(superView.CanEditSelectedMetaData3D, Is.True);
+                    Assert.That(
+                        superView.GetMetaDataMarkerCandidates(),
+                        Has.Count.EqualTo(2));
+                    Assert.That(superView.HasUnsavedChanges, Is.False);
+                });
+
+                superView.ClearMetaDataMarkerSelection();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(
+                        superView.PersistentMetaEditor.SelectedAttribute,
+                        Is.Null);
+                    Assert.That(
+                        superView.MetaDataTimeline.Markers,
+                        Has.None.Property("IsSelected").True);
+                    Assert.That(
+                        superView.CanEditSelectedMetaData3D,
+                        Is.False);
+                    Assert.That(superView.HasUnsavedChanges, Is.False);
+                });
+            }
+            finally
+            {
+                superView.Close();
+            }
+        }
+
+        [Test]
         public void SuperView_InvalidField_RefreshesIndexWithoutRebuildingPreview()
         {
             const string metaPath =

--- a/Editors/AnimationMeta/Test.AnimationMeta/MetaDataMarkerPickingTests.cs
+++ b/Editors/AnimationMeta/Test.AnimationMeta/MetaDataMarkerPickingTests.cs
@@ -1,0 +1,415 @@
+using Editors.AnimationMeta.SuperView.Inspection;
+using Editors.AnimationMeta.SuperView.Visualisation;
+using Editors.AnimationMeta.SuperView.Visualisation.Instances;
+using GameWorld.Core.SceneNodes;
+using Microsoft.Xna.Framework;
+using Shared.GameFormats.AnimationMeta.Definitions;
+using Shared.GameFormats.AnimationMeta.Parsing;
+
+namespace Test.AnimationMeta;
+
+[TestFixture]
+public sealed class MetaDataMarkerPickingTests
+{
+    [Test]
+    public void Pick_PrefersDistanceFromRayThenStableIndexOrder()
+    {
+        var fartherFromRay = CreateCandidate(
+            new Vector3(0.1f, 0, 3),
+            stableOrder: 0);
+        var nearerToRay = CreateCandidate(
+            new Vector3(0.05f, 0, 8),
+            stableOrder: 1);
+        var ray = new Ray(Vector3.Zero, Vector3.UnitZ);
+
+        var nearest = MetaDataMarkerHitTester.Pick(
+            ray,
+            [fartherFromRay, nearerToRay],
+            useAngularTolerance: false);
+
+        Assert.That(nearest?.Candidate, Is.SameAs(nearerToRay));
+
+        var firstInIndex = CreateCandidate(
+            new Vector3(0, 0, 5),
+            stableOrder: 2);
+        var secondInIndex = CreateCandidate(
+            new Vector3(0, 0, 5),
+            stableOrder: 3);
+
+        var tied = MetaDataMarkerHitTester.Pick(
+            ray,
+            [secondInIndex, firstInIndex],
+            useAngularTolerance: false);
+
+        Assert.That(tied?.Candidate, Is.SameAs(firstInIndex));
+    }
+
+    [Test]
+    public void Pick_IgnoresHiddenOrRemovedMarkersAndKeepsFarMarkersUsable()
+    {
+        var hidden = CreateCandidate(
+            new Vector3(0, 0, 2),
+            stableOrder: 0,
+            isVisible: false);
+        var removed = CreateCandidate(
+            new Vector3(0, 0, 3),
+            stableOrder: 1);
+        var current = CreateCandidate(
+            new Vector3(0.5f, 0, 100),
+            stableOrder: 2);
+        var ray = new Ray(Vector3.Zero, Vector3.UnitZ);
+
+        var hit = MetaDataMarkerHitTester.Pick(
+            ray,
+            [hidden, current],
+            useAngularTolerance: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(hit?.Candidate, Is.SameAs(current));
+            Assert.That(hit?.Candidate, Is.Not.SameAs(removed));
+        });
+    }
+
+    [Test]
+    public void Pick_SplashEndpoint_ReturnsTheSpecificEditPoint()
+    {
+        var candidate = CreateCandidate(
+            new Vector3(1, 0, 3),
+            stableOrder: 0,
+            hitTargets:
+            [
+                new MetaDataMarkerHitTarget(
+                    new Vector3(0, 0, 3),
+                    MetaDataMarkerPoint.SplashStart),
+                new MetaDataMarkerHitTarget(
+                    new Vector3(2, 0, 3),
+                    MetaDataMarkerPoint.SplashEnd),
+            ]);
+
+        var hit = MetaDataMarkerHitTester.Pick(
+            new Ray(Vector3.Zero, Vector3.UnitZ),
+            [candidate],
+            useAngularTolerance: false);
+
+        Assert.That(
+            hit?.Target.Point,
+            Is.EqualTo(MetaDataMarkerPoint.SplashStart));
+    }
+
+    [Test]
+    public void PointerInteraction_SingleThenDoubleClick_SelectsOnceAndFocusesOnce()
+    {
+        var candidate = CreateCandidate(
+            new Vector3(0, 0, 3),
+            stableOrder: 0);
+        var interaction = new MetaDataMarkerPointerInteraction();
+
+        Assert.That(
+            interaction.Update(
+                TimeSpan.Zero,
+                new Vector2(10, 10),
+                isPressed: true,
+                isReleased: false,
+                isBlocked: false,
+                CreateHit(candidate)).Kind,
+            Is.EqualTo(MetaDataMarkerPointerActionKind.None));
+        var firstClick = interaction.Update(
+            TimeSpan.FromMilliseconds(20),
+            new Vector2(10, 10),
+            isPressed: false,
+            isReleased: true,
+            isBlocked: false,
+            CreateHit(candidate));
+
+        interaction.Update(
+            TimeSpan.FromMilliseconds(100),
+            new Vector2(10, 10),
+            isPressed: true,
+            isReleased: false,
+            isBlocked: false,
+            CreateHit(candidate));
+        var secondClick = interaction.Update(
+            TimeSpan.FromMilliseconds(120),
+            new Vector2(10, 10),
+            isPressed: false,
+            isReleased: true,
+            isBlocked: false,
+            CreateHit(candidate));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                firstClick.Kind,
+                Is.EqualTo(MetaDataMarkerPointerActionKind.Select));
+            Assert.That(firstClick.Hit?.Candidate, Is.SameAs(candidate));
+            Assert.That(
+                secondClick.Kind,
+                Is.EqualTo(MetaDataMarkerPointerActionKind.Focus));
+            Assert.That(secondClick.Hit?.Candidate, Is.SameAs(candidate));
+        });
+    }
+
+    [Test]
+    public void PointerInteraction_ClickWithoutMarker_ClearsSelection()
+    {
+        var interaction = new MetaDataMarkerPointerInteraction();
+
+        interaction.Update(
+            TimeSpan.Zero,
+            Vector2.Zero,
+            isPressed: true,
+            isReleased: false,
+            isBlocked: false,
+            hit: null);
+        var action = interaction.Update(
+            TimeSpan.FromMilliseconds(20),
+            Vector2.Zero,
+            isPressed: false,
+            isReleased: true,
+            isBlocked: false,
+            hit: null);
+
+        Assert.That(
+            action.Kind,
+            Is.EqualTo(MetaDataMarkerPointerActionKind.ClearSelection));
+    }
+
+    [Test]
+    public void PointerInteraction_DifferentSplashEndpoints_DoNotDoubleClick()
+    {
+        var candidate = CreateCandidate(
+            new Vector3(0, 0, 3),
+            stableOrder: 0);
+        var interaction = new MetaDataMarkerPointerInteraction();
+        var startHit = CreateHit(
+            candidate,
+            MetaDataMarkerPoint.SplashStart);
+        var endHit = CreateHit(
+            candidate,
+            MetaDataMarkerPoint.SplashEnd);
+
+        interaction.Update(
+            TimeSpan.Zero,
+            Vector2.Zero,
+            isPressed: true,
+            isReleased: false,
+            isBlocked: false,
+            startHit);
+        interaction.Update(
+            TimeSpan.FromMilliseconds(20),
+            Vector2.Zero,
+            isPressed: false,
+            isReleased: true,
+            isBlocked: false,
+            startHit);
+        interaction.Update(
+            TimeSpan.FromMilliseconds(100),
+            Vector2.Zero,
+            isPressed: true,
+            isReleased: false,
+            isBlocked: false,
+            endHit);
+        var secondClick = interaction.Update(
+            TimeSpan.FromMilliseconds(120),
+            Vector2.Zero,
+            isPressed: false,
+            isReleased: true,
+            isBlocked: false,
+            endHit);
+
+        Assert.That(
+            secondClick.Kind,
+            Is.EqualTo(MetaDataMarkerPointerActionKind.Select));
+    }
+
+    [Test]
+    public void PointerInteraction_GizmoOrCameraOwnershipCancelsPendingClick()
+    {
+        var candidate = CreateCandidate(
+            new Vector3(0, 0, 3),
+            stableOrder: 0);
+        var interaction = new MetaDataMarkerPointerInteraction();
+
+        interaction.Update(
+            TimeSpan.Zero,
+            Vector2.Zero,
+            isPressed: true,
+            isReleased: false,
+            isBlocked: false,
+            CreateHit(candidate));
+        var blocked = interaction.Update(
+            TimeSpan.FromMilliseconds(10),
+            Vector2.Zero,
+            isPressed: false,
+            isReleased: false,
+            isBlocked: true,
+            CreateHit(candidate));
+        var released = interaction.Update(
+            TimeSpan.FromMilliseconds(20),
+            Vector2.Zero,
+            isPressed: false,
+            isReleased: true,
+            isBlocked: false,
+            CreateHit(candidate));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                blocked.Kind,
+                Is.EqualTo(MetaDataMarkerPointerActionKind.None));
+            Assert.That(
+                released.Kind,
+                Is.EqualTo(MetaDataMarkerPointerActionKind.None));
+        });
+    }
+
+    [Test]
+    public void MarkerPreview_HoverUsesExistingOutlineAndVisibilityControlsHitTest()
+    {
+        var source = new ImpactPosition_v10
+        {
+            Name = "IMPACT_POS",
+            Version = 10,
+        };
+        var root = new GroupNode("root");
+        var node = new SimpleDrawableNode("marker");
+        root.AddObject(node);
+        var visualStates = new List<bool>();
+        var preview = new DrawableMetaInstance(
+            null,
+            node,
+            source,
+            false,
+            visualStates.Add,
+            () => Vector3.Zero,
+            () => Quaternion.Identity);
+
+        preview.IsHovered = true;
+        preview.IsHovered = false;
+        preview.IsEnabled = false;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(visualStates, Is.EqualTo(new[]
+            {
+                false,
+                true,
+                false,
+            }));
+            Assert.That(preview.IsHitTestVisible, Is.False);
+        });
+
+        preview.CleanUp();
+        preview.IsEnabled = true;
+        Assert.That(preview.IsHitTestVisible, Is.False);
+    }
+
+    [Test]
+    public void MarkerContract_ExcludesPropAndSharedSelectionTypes()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                typeof(IMetaDataMarkerPreview).IsAssignableFrom(
+                    typeof(DrawableMetaInstance)),
+                Is.True);
+            Assert.That(
+                typeof(IMetaDataMarkerPreview).IsAssignableFrom(
+                    typeof(CombatMetaDataInstance)),
+                Is.True);
+            Assert.That(
+                typeof(IMetaDataMarkerPreview).IsAssignableFrom(
+                    typeof(PropInstance)),
+                Is.False);
+            Assert.That(
+                typeof(IMetaDataMarkerPreview).IsAssignableFrom(
+                    typeof(AnimatedPropInstance)),
+                Is.False);
+            Assert.That(
+                typeof(MetaDataMarkerPickerComponent)
+                    .GetConstructors()
+                    .SelectMany(constructor => constructor.GetParameters())
+                    .Select(parameter => parameter.ParameterType.FullName)
+                    .Where(name => name != null),
+                Has.None.Contains("SelectionManager"));
+        });
+    }
+
+    private static MetaDataMarkerPickCandidate CreateCandidate(
+        Vector3 position,
+        int stableOrder,
+        bool isVisible = true,
+        IReadOnlyList<MetaDataMarkerHitTarget>? hitTargets = null)
+    {
+        var source = new ImpactPosition_v10
+        {
+            Name = "IMPACT_POS",
+            Version = 10,
+            Position = position,
+        };
+        var item = new MetaDataInspectionItem(
+            source,
+            MetaDataDocumentOwner.Animation,
+            true,
+            null,
+            MetaDataAuthoredTimeStatus.NotApplicable,
+            null,
+            MetaDataPreviewCapability.Available,
+            CombatMetaDataPreviewCategory.Impact,
+            position,
+            []);
+        return new MetaDataMarkerPickCandidate(
+            item,
+            new TestMarkerPreview(
+                source,
+                position,
+                isVisible,
+                hitTargets),
+            stableOrder);
+    }
+
+    private static MetaDataMarkerHit CreateHit(
+        MetaDataMarkerPickCandidate candidate,
+        MetaDataMarkerPoint point = MetaDataMarkerPoint.Default) =>
+        new(
+            candidate,
+            new MetaDataMarkerHitTarget(
+                candidate.Preview.FocusPosition,
+                point));
+
+    private sealed class TestMarkerPreview : IMetaDataMarkerPreview
+    {
+        private readonly Vector3 _position;
+
+        public ParsedMetadataAttribute Source { get; }
+        public bool IsEnabled { get; set; } = true;
+        public bool IsSelected { get; set; }
+        public bool ShowForEntireAnimation { get; set; }
+        public Vector3 FocusPosition => _position;
+        public Matrix ReferenceWorldTransform => Matrix.Identity;
+        public Matrix WorldTransform => Matrix.CreateTranslation(_position);
+        public int? HighlightedBoneIndex => null;
+        public bool IsHitTestVisible { get; }
+        public bool IsHovered { get; set; }
+        public float HitTestRadius => 0.3f;
+        public IReadOnlyList<MetaDataMarkerHitTarget> HitTargets { get; }
+
+        public TestMarkerPreview(
+            ParsedMetadataAttribute source,
+            Vector3 position,
+            bool isVisible,
+            IReadOnlyList<MetaDataMarkerHitTarget>? hitTargets)
+        {
+            Source = source;
+            _position = position;
+            IsHitTestVisible = isVisible;
+            HitTargets = hitTargets ??
+            [
+                new MetaDataMarkerHitTarget(
+                    position,
+                    MetaDataMarkerPoint.Default),
+            ];
+        }
+    }
+}

--- a/Editors/MetaDataEditor/AnimationMeta/Assembly.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/Assembly.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Test.AnimationMeta")]

--- a/Editors/MetaDataEditor/AnimationMeta/DependencyInjectionContainer.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/DependencyInjectionContainer.cs
@@ -4,6 +4,7 @@ using Editors.AnimationMeta.Presentation;
 using Editors.AnimationMeta.Presentation.View;
 using Editors.AnimationMeta.SuperView;
 using Editors.AnimationMeta.SuperView.Editing;
+using Editors.AnimationMeta.SuperView.Inspection;
 using Editors.AnimationMeta.SuperView.Visualisation;
 using Editors.Shared.Core.Common.BaseControl;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,6 +25,7 @@ namespace Editors.AnimationMeta
             serviceCollection.AddScoped<SuperViewViewModel>();
             serviceCollection.AddScoped<CombatMetaDataEditSession>();
             serviceCollection.AddScoped<CombatMetaDataGizmoComponent>();
+            serviceCollection.AddScoped<MetaDataMarkerPickerComponent>();
 
             serviceCollection.AddScoped<IMetaDataBuilder, MetaDataBuilder>(); // Needs heavy refactorying!
 

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Editing/CombatMetaDataGizmoComponent.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Editing/CombatMetaDataGizmoComponent.cs
@@ -23,6 +23,8 @@ public sealed class CombatMetaDataGizmoComponent : BaseComponent, IDisposable
     private bool _isEnabled;
     private CombatMetaDataTransformMode _transformMode;
 
+    public bool IsGestureActive => _dragActive;
+
     public bool IsEnabled
     {
         get => _isEnabled;

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Inspection/MetaDataMarkerPickerComponent.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Inspection/MetaDataMarkerPickerComponent.cs
@@ -1,0 +1,355 @@
+using Editors.AnimationMeta.SuperView.Editing;
+using Editors.AnimationMeta.SuperView.Visualisation;
+using GameWorld.Core.Components;
+using GameWorld.Core.Components.Input;
+using GameWorld.Core.Components.Rendering;
+using Microsoft.Xna.Framework;
+using Shared.GameFormats.AnimationMeta.Parsing;
+
+namespace Editors.AnimationMeta.SuperView.Inspection;
+
+public sealed record MetaDataMarkerPickCandidate(
+    MetaDataInspectionItem Item,
+    IMetaDataMarkerPreview Preview,
+    int StableOrder);
+
+public sealed record MetaDataMarkerHit(
+    MetaDataMarkerPickCandidate Candidate,
+    MetaDataMarkerHitTarget Target);
+
+public static class MetaDataMarkerHitTester
+{
+    private const float MinimumAngularRadius = 0.008f;
+
+    public static MetaDataMarkerHit? Pick(
+        Ray ray,
+        IEnumerable<MetaDataMarkerPickCandidate> candidates,
+        bool useAngularTolerance)
+    {
+        MetaDataMarkerHit? bestHit = null;
+        var bestDistanceToRaySquared = float.MaxValue;
+        var bestDistanceAlongRay = float.MaxValue;
+        var bestStableOrder = int.MaxValue;
+        var bestTargetOrder = int.MaxValue;
+
+        foreach (var candidate in candidates)
+        {
+            if (!candidate.Preview.IsHitTestVisible)
+                continue;
+
+            IReadOnlyList<MetaDataMarkerHitTarget> hitTargets;
+            try
+            {
+                hitTargets = candidate.Preview.HitTargets;
+            }
+            catch (NullReferenceException)
+            {
+                continue;
+            }
+
+            for (var targetOrder = 0;
+                targetOrder < hitTargets.Count;
+                targetOrder++)
+            {
+                var target = hitTargets[targetOrder];
+                var position = target.Position;
+                if (!IsFinite(position))
+                    continue;
+
+                var toMarker = position - ray.Position;
+                var distanceAlongRay = Vector3.Dot(
+                    toMarker,
+                    ray.Direction);
+                if (distanceAlongRay < 0)
+                    continue;
+
+                var closestPoint = ray.Position +
+                    ray.Direction * distanceAlongRay;
+                var distanceToRaySquared = Vector3.DistanceSquared(
+                    position,
+                    closestPoint);
+                var radius = target.HitTestRadius ??
+                    candidate.Preview.HitTestRadius;
+                if (useAngularTolerance)
+                {
+                    radius = Math.Max(
+                        radius,
+                        distanceAlongRay * MinimumAngularRadius);
+                }
+
+                if (distanceToRaySquared > radius * radius ||
+                    !IsBetter(
+                        distanceToRaySquared,
+                        distanceAlongRay,
+                        candidate.StableOrder,
+                        targetOrder,
+                        bestDistanceToRaySquared,
+                        bestDistanceAlongRay,
+                        bestStableOrder,
+                        bestTargetOrder))
+                {
+                    continue;
+                }
+
+                bestHit = new MetaDataMarkerHit(candidate, target);
+                bestDistanceToRaySquared = distanceToRaySquared;
+                bestDistanceAlongRay = distanceAlongRay;
+                bestStableOrder = candidate.StableOrder;
+                bestTargetOrder = targetOrder;
+            }
+        }
+
+        return bestHit;
+    }
+
+    private static bool IsFinite(Vector3 value) =>
+        float.IsFinite(value.X) &&
+        float.IsFinite(value.Y) &&
+        float.IsFinite(value.Z);
+
+    private static bool IsBetter(
+        float distanceToRaySquared,
+        float distanceAlongRay,
+        int stableOrder,
+        int targetOrder,
+        float bestDistanceToRaySquared,
+        float bestDistanceAlongRay,
+        int bestStableOrder,
+        int bestTargetOrder)
+    {
+        var distanceComparison = distanceToRaySquared.CompareTo(
+            bestDistanceToRaySquared);
+        if (distanceComparison != 0)
+            return distanceComparison < 0;
+
+        var depthComparison = distanceAlongRay.CompareTo(
+            bestDistanceAlongRay);
+        if (depthComparison != 0)
+            return depthComparison < 0;
+
+        var stableOrderComparison = stableOrder.CompareTo(bestStableOrder);
+        if (stableOrderComparison != 0)
+            return stableOrderComparison < 0;
+
+        return targetOrder < bestTargetOrder;
+    }
+}
+
+public enum MetaDataMarkerPointerActionKind
+{
+    None,
+    ClearSelection,
+    Select,
+    Focus,
+}
+
+public readonly record struct MetaDataMarkerPointerAction(
+    MetaDataMarkerPointerActionKind Kind,
+    MetaDataMarkerHit? Hit)
+{
+    public static MetaDataMarkerPointerAction None => new(
+        MetaDataMarkerPointerActionKind.None,
+        null);
+}
+
+public sealed class MetaDataMarkerPointerInteraction
+{
+    private const float MaximumClickMovementSquared = 16;
+    private static readonly TimeSpan s_doubleClickInterval =
+        TimeSpan.FromMilliseconds(500);
+
+    private bool _pressActive;
+    private Vector2 _pressPosition;
+    private TimeSpan _lastClickTime;
+    private ParsedMetadataAttribute? _lastClickSource;
+    private MetaDataMarkerPoint _lastClickPoint;
+
+    public MetaDataMarkerPointerAction Update(
+        TimeSpan currentTime,
+        Vector2 pointerPosition,
+        bool isPressed,
+        bool isReleased,
+        bool isBlocked,
+        MetaDataMarkerHit? hit)
+    {
+        if (isBlocked)
+        {
+            Reset();
+            return MetaDataMarkerPointerAction.None;
+        }
+
+        if (isPressed)
+        {
+            _pressActive = true;
+            _pressPosition = pointerPosition;
+        }
+
+        if (!isReleased || !_pressActive)
+            return MetaDataMarkerPointerAction.None;
+
+        _pressActive = false;
+        if (Vector2.DistanceSquared(_pressPosition, pointerPosition) >
+            MaximumClickMovementSquared)
+        {
+            _lastClickSource = null;
+            return MetaDataMarkerPointerAction.None;
+        }
+
+        if (hit == null)
+        {
+            _lastClickSource = null;
+            return new MetaDataMarkerPointerAction(
+                MetaDataMarkerPointerActionKind.ClearSelection,
+                null);
+        }
+
+        var elapsed = currentTime - _lastClickTime;
+        if (ReferenceEquals(
+                _lastClickSource,
+                hit.Candidate.Item.Source) &&
+            _lastClickPoint == hit.Target.Point &&
+            elapsed >= TimeSpan.Zero &&
+            elapsed <= s_doubleClickInterval)
+        {
+            _lastClickSource = null;
+            return new MetaDataMarkerPointerAction(
+                MetaDataMarkerPointerActionKind.Focus,
+                hit);
+        }
+
+        _lastClickSource = hit.Candidate.Item.Source;
+        _lastClickPoint = hit.Target.Point;
+        _lastClickTime = currentTime;
+        return new MetaDataMarkerPointerAction(
+            MetaDataMarkerPointerActionKind.Select,
+            hit);
+    }
+
+    public void Reset()
+    {
+        _pressActive = false;
+        _lastClickSource = null;
+    }
+}
+
+public sealed class MetaDataMarkerPickerComponent : BaseComponent, IDisposable
+{
+    private readonly ArcBallCamera _camera;
+    private readonly IMouseComponent _mouse;
+    private readonly CombatMetaDataGizmoComponent _gizmo;
+    private readonly MetaDataMarkerPointerInteraction _interaction = new();
+
+    private Func<IReadOnlyList<MetaDataMarkerPickCandidate>>?
+        _candidateProvider;
+    private Action<MetaDataInspectionItem, MetaDataMarkerPoint>? _select;
+    private Action<MetaDataInspectionItem>? _focus;
+    private Action? _clearSelection;
+    private IMetaDataMarkerPreview? _hoveredPreview;
+
+    public MetaDataMarkerPickerComponent(
+        ArcBallCamera camera,
+        IMouseComponent mouse,
+        CombatMetaDataGizmoComponent gizmo)
+    {
+        _camera = camera;
+        _mouse = mouse;
+        _gizmo = gizmo;
+        UpdateOrder = (int)ComponentUpdateOrderEnum.SelectionComponent;
+    }
+
+    public void Connect(
+        Func<IReadOnlyList<MetaDataMarkerPickCandidate>> candidateProvider,
+        Action<MetaDataInspectionItem, MetaDataMarkerPoint> select,
+        Action<MetaDataInspectionItem> focus,
+        Action clearSelection)
+    {
+        _candidateProvider = candidateProvider;
+        _select = select;
+        _focus = focus;
+        _clearSelection = clearSelection;
+    }
+
+    public override void Update(GameTime gameTime)
+    {
+        if (_candidateProvider == null)
+            return;
+
+        try
+        {
+            var isBlocked = _gizmo.IsGestureActive ||
+                !_mouse.IsMouseOwner(this);
+            MetaDataMarkerHit? hit = null;
+            if (!isBlocked)
+            {
+                hit = MetaDataMarkerHitTester.Pick(
+                    _camera.CreateCameraRay(_mouse.Position()),
+                    _candidateProvider(),
+                    _camera.CurrentProjectionType ==
+                        ProjectionType.Perspective);
+            }
+
+            SetHovered(isBlocked ? null : hit?.Candidate.Preview);
+            var action = _interaction.Update(
+                gameTime.TotalGameTime,
+                _mouse.Position(),
+                _mouse.IsMouseButtonPressed(MouseButton.Left),
+                _mouse.IsMouseButtonReleased(MouseButton.Left),
+                isBlocked,
+                hit);
+            if (action.Kind ==
+                MetaDataMarkerPointerActionKind.ClearSelection)
+            {
+                _clearSelection?.Invoke();
+                return;
+            }
+
+            if (action.Hit == null)
+                return;
+
+            if (action.Kind == MetaDataMarkerPointerActionKind.Select)
+            {
+                _select?.Invoke(
+                    action.Hit.Candidate.Item,
+                    action.Hit.Target.Point);
+            }
+            else if (action.Kind == MetaDataMarkerPointerActionKind.Focus)
+                _focus?.Invoke(action.Hit.Candidate.Item);
+        }
+        catch
+        {
+            ClearInteractionState();
+            throw;
+        }
+    }
+
+    public void ClearInteractionState()
+    {
+        ClearHover();
+        _interaction.Reset();
+    }
+
+    public void ClearHover() => SetHovered(null);
+
+    public void Disconnect()
+    {
+        ClearInteractionState();
+        _candidateProvider = null;
+        _select = null;
+        _focus = null;
+        _clearSelection = null;
+    }
+
+    private void SetHovered(IMetaDataMarkerPreview? preview)
+    {
+        if (ReferenceEquals(_hoveredPreview, preview))
+            return;
+
+        if (_hoveredPreview != null)
+            _hoveredPreview.IsHovered = false;
+        _hoveredPreview = preview;
+        if (_hoveredPreview != null)
+            _hoveredPreview.IsHovered = true;
+    }
+
+    public void Dispose() => Disconnect();
+}

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Inspection/MetaDataTimelinePanel.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Inspection/MetaDataTimelinePanel.cs
@@ -6,57 +6,135 @@ namespace Editors.AnimationMeta.SuperView.Inspection
     public sealed class MetaDataTimelinePanel : Panel
     {
         private const double MinimumHitWidth = 12;
+        private const double MinimumHeight = 18;
+        private const double LaneHeight = 10;
+        private const double LaneGap = 2;
+        private const double VerticalPadding = 1;
 
         protected override Size MeasureOverride(Size availableSize)
         {
-            var height = double.IsFinite(availableSize.Height)
-                ? availableSize.Height
-                : 18;
-            foreach (UIElement child in InternalChildren)
-                child.Measure(new Size(double.PositiveInfinity, height));
-
             var width = double.IsFinite(availableSize.Width)
                 ? availableSize.Width
                 : 0;
+            var layout = CreateLayout(width);
+            foreach (var item in layout.Items)
+                item.Child.Measure(new Size(item.Width, LaneHeight));
+
+            var height = Math.Max(
+                MinimumHeight,
+                layout.LaneCount * LaneHeight + VerticalPadding * 2);
             return new Size(width, height);
         }
 
         protected override Size ArrangeOverride(Size finalSize)
         {
-            foreach (UIElement child in InternalChildren)
+            var layout = CreateLayout(finalSize.Width);
+            var top = Math.Max(
+                VerticalPadding,
+                (finalSize.Height - layout.LaneCount * LaneHeight) / 2);
+            foreach (var item in layout.Items)
             {
-                if (child is not FrameworkElement element ||
-                    element.DataContext is not
-                        MetaDataTimelineMarkerViewModel marker)
-                {
-                    child.Arrange(new Rect(finalSize));
-                    continue;
-                }
-
-                var isInstant = marker.Item.TimelineMarkerKind ==
-                    MetaDataTimelineMarkerKind.Instant;
-                var left = marker.StartFraction * finalSize.Width;
-                var width = isInstant
-                    ? MinimumHitWidth
-                    : Math.Max(
-                        MinimumHitWidth,
-                        (marker.EndFraction - marker.StartFraction) *
-                            finalSize.Width);
-                if (isInstant)
-                    left -= width / 2;
-                left = Math.Clamp(left, 0, Math.Max(0, finalSize.Width - width));
-                width = Math.Min(width, finalSize.Width);
-                var markerLayer = marker.Item.TimelineMarkerKind switch
+                var markerLayer = item.Marker.Item.TimelineMarkerKind switch
                 {
                     MetaDataTimelineMarkerKind.Instant => 20,
                     MetaDataTimelineMarkerKind.Range => 10,
                     _ => 0,
                 };
-                SetZIndex(child, markerLayer + (marker.IsSelected ? 1 : 0));
-                child.Arrange(new Rect(left, 0, width, finalSize.Height));
+                SetZIndex(
+                    item.Child,
+                    markerLayer + (item.Marker.IsSelected ? 1 : 0));
+                item.Child.Arrange(new Rect(
+                    item.Left,
+                    top + item.Lane * LaneHeight,
+                    item.Width,
+                    LaneHeight));
             }
 
             return finalSize;
+        }
+
+        private TimelineLayout CreateLayout(double width)
+        {
+            var items = InternalChildren
+                .OfType<FrameworkElement>()
+                .Select((child, index) => CreateLayoutItem(
+                    child,
+                    index,
+                    width))
+                .Where(item => item.HasValue)
+                .Select(item => item!.Value)
+                .OrderBy(item => item.Left)
+                .ThenBy(item => item.Right)
+                .ThenBy(item => item.Index)
+                .ToArray();
+            var laneEnds = new List<double>();
+            for (var itemIndex = 0; itemIndex < items.Length; itemIndex++)
+            {
+                var item = items[itemIndex];
+                var lane = laneEnds.FindIndex(end =>
+                    end + LaneGap <= item.Left);
+                if (lane < 0)
+                {
+                    lane = laneEnds.Count;
+                    laneEnds.Add(item.Right);
+                }
+                else
+                {
+                    laneEnds[lane] = item.Right;
+                }
+
+                items[itemIndex] = item with { Lane = lane };
+            }
+
+            return new TimelineLayout(items, Math.Max(1, laneEnds.Count));
+        }
+
+        private static TimelineLayoutItem? CreateLayoutItem(
+            FrameworkElement child,
+            int index,
+            double availableWidth)
+        {
+            if (child.DataContext is not MetaDataTimelineMarkerViewModel marker)
+                return null;
+
+            var isInstant = marker.Item.TimelineMarkerKind ==
+                MetaDataTimelineMarkerKind.Instant;
+            var left = marker.StartFraction * availableWidth;
+            var width = isInstant
+                ? MinimumHitWidth
+                : Math.Max(
+                    MinimumHitWidth,
+                    (marker.EndFraction - marker.StartFraction) *
+                        availableWidth);
+            if (isInstant)
+                left -= width / 2;
+            left = Math.Clamp(
+                left,
+                0,
+                Math.Max(0, availableWidth - width));
+            width = Math.Min(width, availableWidth);
+            return new TimelineLayoutItem(
+                child,
+                marker,
+                index,
+                left,
+                width,
+                0);
+        }
+
+        private readonly record struct TimelineLayout(
+            IReadOnlyList<TimelineLayoutItem> Items,
+            int LaneCount);
+
+        private readonly record struct TimelineLayoutItem(
+            FrameworkElement Child,
+            MetaDataTimelineMarkerViewModel Marker,
+            int Index,
+            double Left,
+            double Width,
+            int Lane)
+        {
+            public double Right => Left + Width;
         }
     }
 }

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Inspection/MetaDataTimelineView.xaml
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Inspection/MetaDataTimelineView.xaml
@@ -13,8 +13,8 @@
                TargetType="Button"
                BasedOn="{StaticResource AeButton.Base}">
             <Setter Property="MinWidth" Value="0" />
-            <Setter Property="MinHeight" Value="18" />
-            <Setter Property="Height" Value="18" />
+            <Setter Property="MinHeight" Value="10" />
+            <Setter Property="Height" Value="10" />
             <Setter Property="Padding" Value="0" />
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderBrush" Value="Transparent" />
@@ -58,7 +58,7 @@
                 <DataTrigger Binding="{Binding Item.TimelineMarkerKind}"
                              Value="{x:Static inspection:MetaDataTimelineMarkerKind.Instant}">
                     <Setter Property="Width" Value="4" />
-                    <Setter Property="Height" Value="14" />
+                    <Setter Property="Height" Value="10" />
                     <Setter Property="HorizontalAlignment" Value="Center" />
                 </DataTrigger>
                 <DataTrigger Binding="{Binding Item.TimelineMarkerKind}"
@@ -83,7 +83,7 @@
                                    Value="True" />
                     </MultiDataTrigger.Conditions>
                     <Setter Property="Width" Value="6" />
-                    <Setter Property="Height" Value="16" />
+                    <Setter Property="Height" Value="10" />
                 </MultiDataTrigger>
                 <DataTrigger Binding="{Binding IsSelected}" Value="True">
                     <Setter Property="Height" Value="9" />
@@ -97,14 +97,14 @@
                         <Condition Binding="{Binding IsSelected}" Value="True" />
                     </MultiDataTrigger.Conditions>
                     <Setter Property="Width" Value="6" />
-                    <Setter Property="Height" Value="16" />
+                    <Setter Property="Height" Value="10" />
                 </MultiDataTrigger>
             </Style.Triggers>
         </Style>
     </UserControl.Resources>
 
     <Grid>
-        <Border Height="18"
+        <Border MinHeight="18"
                 Background="{DynamicResource AeBrush.Surface1}"
                 BorderBrush="{DynamicResource AeBrush.Border}"
                 BorderThickness="1"

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/SuperViewViewModel.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/SuperViewViewModel.cs
@@ -33,6 +33,7 @@ namespace Editors.AnimationMeta.SuperView
         private readonly IUiCommandFactory _uiCommandFactory;
         private readonly CombatMetaDataEditSession _combatEditSession;
         private readonly CombatMetaDataGizmoComponent _combatGizmo;
+        private readonly MetaDataMarkerPickerComponent _markerPicker;
         private CombatMetaDataPoint _selectedSplashPoint =
             CombatMetaDataPoint.SplashStart;
         private CombatMetaDataTransformMode _selectedTransformMode =
@@ -382,7 +383,8 @@ namespace Editors.AnimationMeta.SuperView
             MetaDataFileParser metaDataFileParser,
             IMetaDataBuilder metaDataFactory,
             CombatMetaDataEditSession combatEditSession,
-            CombatMetaDataGizmoComponent combatGizmo)
+            CombatMetaDataGizmoComponent combatGizmo,
+            MetaDataMarkerPickerComponent markerPicker)
             : base(editorHostParameters)
         {
             EditorContentVerticalScrollBarVisibility =
@@ -396,12 +398,19 @@ namespace Editors.AnimationMeta.SuperView
             _metaDataFactory = metaDataFactory;
             _combatEditSession = combatEditSession;
             _combatGizmo = combatGizmo;
+            _markerPicker = markerPicker;
             MetaDataTimeline = new MetaDataTimelineViewModel(
                 SelectMetaDataInspectionItem);
             Player.TimelineAnnotationContent = MetaDataTimeline;
             Player.SelectedAnimationMaxTime.PropertyChanged +=
                 OnSelectedAnimationMaxTimeChanged;
             GameWorld!.AddComponent(combatGizmo);
+            markerPicker.Connect(
+                GetMetaDataMarkerCandidates,
+                SelectMetaDataMarker,
+                FocusMetaDataMarker,
+                ClearMetaDataMarkerSelection);
+            GameWorld.AddComponent(markerPicker);
             _combatEditSession.ValueChanged += OnCombatMetaDataValueChanged;
             _combatEditSession.HistoryChanged += OnCombatHistoryChanged;
             Initialize();
@@ -421,6 +430,7 @@ namespace Editors.AnimationMeta.SuperView
         }
         partial void OnSelectedTabControllerIndexChanged(int value)
         {
+            _markerPicker.ClearHover();
             Set3DTransformMode(CombatMetaDataTransformMode.Translate);
             ApplySelectedMetaDataPreview();
             UpdateCombatEditTarget();
@@ -529,6 +539,7 @@ namespace Editors.AnimationMeta.SuperView
 
         void RecreateMetaDataInformation()
         {
+            _markerPicker.ClearInteractionState();
             foreach (var item in SceneObjects)
             {
                 foreach (var t in item.Data.MetaDataItems)
@@ -603,6 +614,7 @@ namespace Editors.AnimationMeta.SuperView
         private bool RefreshMetaDataPreview(
             ParsedMetadataAttribute attribute)
         {
+            _markerPicker.ClearInteractionState();
             if (!TryGetDocumentOwner(attribute, out var owner))
                 return false;
 
@@ -702,19 +714,90 @@ namespace Editors.AnimationMeta.SuperView
                 return;
             }
 
+            if (!SelectMetaDataItem(item))
+                return;
+
+            Player.PlaybackPositionSeconds = timeRange.StartTime;
+            NotifySelectedMetaDataContextChanged();
+        }
+
+        private bool SelectMetaDataItem(MetaDataInspectionItem item)
+        {
             var editor = item.Owner == MetaDataDocumentOwner.Persistent
                 ? PersistentMetaEditor
                 : MetaEditor;
             var tag = editor.Tags.FirstOrDefault(candidate =>
                 ReferenceEquals(candidate._input, item.Source));
             if (tag == null)
-                return;
+                return false;
 
             SelectedTabControllerIndex = item.Owner ==
                 MetaDataDocumentOwner.Persistent ? 0 : 1;
             editor.SelectedTag = tag;
-            Player.PlaybackPositionSeconds = timeRange.StartTime;
+            return true;
+        }
+
+        internal void SelectMetaDataMarker(
+            MetaDataInspectionItem item,
+            MetaDataMarkerPoint point = MetaDataMarkerPoint.Default)
+        {
+            if (!SelectMetaDataItem(item))
+                return;
+
+            if (point == MetaDataMarkerPoint.SplashStart)
+                SetSplashPoint(CombatMetaDataPoint.SplashStart);
+            else if (point == MetaDataMarkerPoint.SplashEnd)
+                SetSplashPoint(CombatMetaDataPoint.SplashEnd);
+
             NotifySelectedMetaDataContextChanged();
+        }
+
+        internal void ClearMetaDataMarkerSelection()
+        {
+            var editor = SelectedTabControllerIndex == 0
+                ? PersistentMetaEditor
+                : MetaEditor;
+            editor.SelectedTag = null;
+        }
+
+        private void FocusMetaDataMarker(MetaDataInspectionItem item)
+        {
+            if (!ReferenceEquals(SelectedPreviewAttribute, item.Source) ||
+                item.FocusPosition == null)
+            {
+                return;
+            }
+
+            FocusSelectedMetaDataAction();
+        }
+
+        internal IReadOnlyList<MetaDataMarkerPickCandidate>
+            GetMetaDataMarkerCandidates()
+        {
+            if (_asset == null)
+                return [];
+
+            var previews = _asset.Data.MetaDataItems
+                .OfType<IMetaDataMarkerPreview>()
+                .ToArray();
+            var candidates = new List<MetaDataMarkerPickCandidate>();
+            for (var index = 0;
+                index < _metaDataInspectionIndex.Items.Count;
+                index++)
+            {
+                var item = _metaDataInspectionIndex.Items[index];
+                var preview = previews.FirstOrDefault(candidate =>
+                    ReferenceEquals(candidate.Source, item.Source));
+                if (preview?.IsHitTestVisible == true)
+                {
+                    candidates.Add(new MetaDataMarkerPickCandidate(
+                        item,
+                        preview,
+                        index));
+                }
+            }
+
+            return candidates;
         }
 
         private void UpdateMetaDataTimelineSelection()
@@ -1110,6 +1193,7 @@ namespace Editors.AnimationMeta.SuperView
 
         public override void Close()
         {
+            _markerPicker.Disconnect();
             _asset.FragAndSlotSelection.PropertyChanged -=
                 OnFragmentSelectionPropertyChanged;
             _asset.Data.Player.OnFrameChanged -= OnAnimationFrameChanged;

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/CombatMetaDataPreview.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/CombatMetaDataPreview.cs
@@ -11,6 +11,18 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
         Splash
     }
 
+    public enum MetaDataMarkerPoint
+    {
+        Default,
+        SplashStart,
+        SplashEnd
+    }
+
+    public readonly record struct MetaDataMarkerHitTarget(
+        Vector3 Position,
+        MetaDataMarkerPoint Point,
+        float? HitTestRadius = null);
+
     public interface IMetaDataPreview
     {
         ParsedMetadataAttribute Source { get; }
@@ -34,5 +46,13 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
         Matrix ReferenceWorldTransform { get; }
         Matrix WorldTransform { get; }
         int? HighlightedBoneIndex { get; }
+    }
+
+    public interface IMetaDataMarkerPreview : ISpatialMetaDataPreview
+    {
+        bool IsHitTestVisible { get; }
+        bool IsHovered { get; set; }
+        float HitTestRadius { get; }
+        IReadOnlyList<MetaDataMarkerHitTarget> HitTargets { get; }
     }
 }

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/Instances/CombatMetaDataInstance.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/Instances/CombatMetaDataInstance.cs
@@ -8,17 +8,22 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
 {
     public sealed class CombatMetaDataInstance :
         IMetaDataInstance,
-        ICombatMetaDataPreview
+        ICombatMetaDataPreview,
+        IMetaDataMarkerPreview
     {
         private readonly SceneNode _node;
         private readonly Action<bool> _selectionChanged;
         private readonly MetaDataTimeRange? _activeTimeRange;
         private readonly Func<Vector3> _localFocusPositionProvider;
+        private readonly Func<IReadOnlyList<MetaDataMarkerHitTarget>>
+            _localHitTargetsProvider;
         private readonly Func<Matrix> _referenceLocalTransform;
         private readonly Func<Matrix> _nodeLocalTransformProvider;
         private readonly Action? _refreshVisual;
         private readonly int? _highlightedBoneIndex;
         private bool _isEnabled = true;
+        private bool _isCleaned;
+        private bool _isHovered;
         private bool _isSelected;
         private bool _showForEntireAnimation;
         private float _currentTimeSeconds;
@@ -48,8 +53,38 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
             set
             {
                 _isSelected = value;
-                _selectionChanged(value);
+                _selectionChanged(_isSelected || _isHovered);
                 ApplyVisibility();
+            }
+        }
+        public bool IsHitTestVisible =>
+            !_isCleaned && _node.IsVisible;
+        public bool IsHovered
+        {
+            get => _isHovered;
+            set
+            {
+                if (_isHovered == value)
+                    return;
+
+                _isHovered = value;
+                _selectionChanged(_isSelected || _isHovered);
+            }
+        }
+        public float HitTestRadius => 0.3f;
+        public IReadOnlyList<MetaDataMarkerHitTarget> HitTargets
+        {
+            get
+            {
+                var referenceWorldTransform = ReferenceWorldTransform;
+                return _localHitTargetsProvider()
+                    .Select(target => new MetaDataMarkerHitTarget(
+                        Vector3.Transform(
+                            target.Position,
+                            referenceWorldTransform),
+                        target.Point,
+                        target.HitTestRadius))
+                    .ToArray();
             }
         }
         public bool ShowForEntireAnimation
@@ -74,7 +109,9 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
             Func<Matrix>? referenceLocalTransform = null,
             int? highlightedBoneIndex = null,
             Func<Matrix>? nodeLocalTransformProvider = null,
-            Action? refreshVisual = null)
+            Action? refreshVisual = null,
+            Func<IReadOnlyList<MetaDataMarkerHitTarget>>?
+                localHitTargetsProvider = null)
             : this(
                 source,
                 category,
@@ -87,7 +124,8 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
                 referenceLocalTransform,
                 highlightedBoneIndex,
                 nodeLocalTransformProvider,
-                refreshVisual)
+                refreshVisual,
+                localHitTargetsProvider)
         {
         }
 
@@ -103,11 +141,20 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
             Func<Matrix>? referenceLocalTransform = null,
             int? highlightedBoneIndex = null,
             Func<Matrix>? nodeLocalTransformProvider = null,
-            Action? refreshVisual = null)
+            Action? refreshVisual = null,
+            Func<IReadOnlyList<MetaDataMarkerHitTarget>>?
+                localHitTargetsProvider = null)
         {
             Source = source;
             Category = category;
             _localFocusPositionProvider = focusPositionProvider;
+            _localHitTargetsProvider = localHitTargetsProvider ??
+                (() =>
+                [
+                    new MetaDataMarkerHitTarget(
+                        _localFocusPositionProvider(),
+                        MetaDataMarkerPoint.Default),
+                ]);
             _node = node;
             _selectionChanged = selectionChanged;
             Player = player;
@@ -135,6 +182,8 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
 
         public void CleanUp()
         {
+            _isCleaned = true;
+            _isHovered = false;
             if (_node.Parent != null)
                 _node.Parent.RemoveObject(_node);
         }

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/Instances/DrawableMetaInstance.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/Instances/DrawableMetaInstance.cs
@@ -11,15 +11,18 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
 {
     public class DrawableMetaInstance :
         IMetaDataInstance,
-        ISpatialMetaDataPreview
+        IMetaDataMarkerPreview
     {
         private readonly ILogger _logger = Logging.Create<MetaDataBuilder>();
         private bool _hasError = false;
+        private bool _isCleaned;
 
         private readonly SceneNode _node;
         private readonly MetaDataTimeRange? _activeTimeRange;
         private readonly Action<bool>? _selectionChanged;
         private bool _isEnabled = true;
+        private readonly bool _isHitTestEnabled;
+        private bool _isHovered;
         private bool _isSelected;
         private bool _showForEntireAnimation;
         private float _currentTimeSeconds;
@@ -46,9 +49,28 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
                     return;
 
                 _isSelected = value;
-                _selectionChanged?.Invoke(value);
+                RefreshSelectionVisual();
             }
         }
+        public bool IsHitTestVisible =>
+            !_isCleaned && _isHitTestEnabled && _node.IsVisible;
+        public bool IsHovered
+        {
+            get => _isHovered;
+            set
+            {
+                if (_isHovered == value)
+                    return;
+
+                _isHovered = value;
+                RefreshSelectionVisual();
+            }
+        }
+        public float HitTestRadius => 0.3f;
+        public IReadOnlyList<MetaDataMarkerHitTarget> HitTargets =>
+        [
+            new(FocusPosition, MetaDataMarkerPoint.Default),
+        ];
         public bool ShowForEntireAnimation
         {
             get => _showForEntireAnimation;
@@ -74,9 +96,12 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
 
         private SkeletonBoneAnimationResolver? _animationResolver;
 
-        public DrawableMetaInstance(SceneNode node)
+        public DrawableMetaInstance(
+            SceneNode node,
+            bool isHitTestEnabled = true)
         {
             _node = node;
+            _isHitTestEnabled = isHitTestEnabled;
         }
 
         public DrawableMetaInstance(float startTime, float endTime, SceneNode node)
@@ -112,8 +137,9 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
             bool isSelected,
             Action<bool> selectionChanged,
             Func<Vector3> positionProvider,
-            Func<Quaternion> orientationProvider)
-            : this(node)
+            Func<Quaternion> orientationProvider,
+            bool isHitTestEnabled = true)
+            : this(node, isHitTestEnabled)
         {
             _activeTimeRange = activeTimeRange;
             Source = source;
@@ -162,8 +188,14 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
 
         public void CleanUp()
         {
-            _node.Parent.RemoveObject(_node);
+            _isCleaned = true;
+            _isHovered = false;
+            if (_node.Parent != null)
+                _node.Parent.RemoveObject(_node);
         }
+
+        private void RefreshSelectionVisual() =>
+            _selectionChanged?.Invoke(_isSelected || _isHovered);
 
         private Matrix GetLocalTransform()
         {

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataBuilder.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataBuilder.cs
@@ -1245,7 +1245,9 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                 player,
                 GetActiveTimeRange(splashAttack.Source),
                 nodeLocalTransformProvider: () => Matrix.Identity,
-                refreshVisual: RefreshVisual);
+                refreshVisual: RefreshVisual,
+                localHitTargetsProvider: () =>
+                    CreateSplashHitTargets(currentSplashAttack));
             root.AddObject(node);
             return instance;
         }
@@ -1261,6 +1263,26 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                 _ => throw new InvalidOperationException(
                     $"Unsupported splash attack type {source.GetType().Name}")
             };
+
+        private static IReadOnlyList<MetaDataMarkerHitTarget>
+            CreateSplashHitTargets(SplashPreviewData splashAttack)
+        {
+            var hitRadius = splashAttack.AoeShape == 1 &&
+                splashAttack.WidthForCorridor > 0
+                    ? splashAttack.WidthForCorridor / 2
+                    : 0.3f;
+            return
+            [
+                new MetaDataMarkerHitTarget(
+                    splashAttack.StartPosition,
+                    MetaDataMarkerPoint.SplashStart,
+                    hitRadius),
+                new MetaDataMarkerHitTarget(
+                    splashAttack.EndPosition,
+                    MetaDataMarkerPoint.SplashEnd,
+                    hitRadius),
+            ];
+        }
 
         private static MetaDataTimeRange? GetActiveTimeRange(
             ParsedMetadataAttribute attribute) =>
@@ -1286,11 +1308,9 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
             var textPos = (splashAttack.EndPosition + splashAttack.StartPosition) / 2;
 
             node.AddItem(new WorldTextRenderItem(_resourceLibrary, "StartPos", splashAttack.StartPosition, edgeColor));
-            node.AddItem(LineHelper.AddLocator(splashAttack.StartPosition, scale, edgeColor));
             node.AddItem(new WorldTextRenderItem(_resourceLibrary, "EndPos", splashAttack.EndPosition, edgeColor));
-            node.AddItem(LineHelper.AddLocator(splashAttack.EndPosition, scale, edgeColor));
             node.AddItem(new WorldTextRenderItem(_resourceLibrary, displayName, textPos, edgeColor));
-
+            PreviewShape? filledArea = null;
             if (splashAttack.AoeShape == 0)
             {
                 if (MathUtil.CompareEqualFloats(
@@ -1301,15 +1321,15 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                         $"{displayName}: the half-angle {splashAttack.AngleForCone / 2} of the cone is close to 0");
                 }
 
-                node.AddItem(PreviewShapeGeometry.CreateSplashCone(
+                filledArea = PreviewShapeGeometry.CreateSplashCone(
                     splashAttack.StartPosition,
                     splashAttack.EndPosition,
                     splashAttack.AngleForCone,
                     fillColor,
                     edgeColor,
-                    edgeWidth));
+                    edgeWidth);
             }
-            if (splashAttack.AoeShape == 1)
+            else if (splashAttack.AoeShape == 1)
             {
                 if (MathUtil.CompareEqualFloats(
                     splashAttack.WidthForCorridor,
@@ -1319,15 +1339,85 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                         $"{displayName}: the WidthForCorridor {splashAttack.WidthForCorridor} of the corridor is close to 0");
                 }
 
-                node.AddItem(PreviewShapeGeometry.CreateSplashCorridor(
+                filledArea = PreviewShapeGeometry.CreateSplashCorridor(
                     splashAttack.StartPosition,
                     splashAttack.EndPosition,
                     splashAttack.WidthForCorridor / 2,
                     fillColor,
                     edgeColor,
-                    edgeWidth));
+                    edgeWidth);
             }
 
+            var endpointRadius = splashAttack.AoeShape == 1
+                ? splashAttack.WidthForCorridor / 2
+                : scale / 2;
+            var marker = CreateSplashAttackMarker(
+                splashAttack.StartPosition,
+                splashAttack.EndPosition,
+                endpointRadius,
+                edgeColor,
+                edgeWidth,
+                PreviewShapeGeometry.SmoothSegments);
+            node.AddItem(filledArea == null
+                ? marker
+                : new PreviewShape(filledArea.Triangles, marker.Edges));
+        }
+
+        internal static PreviewShape CreateSplashAttackMarker(
+            Vector3 start,
+            Vector3 end,
+            float endpointRadius,
+            Color color,
+            float edgeWidth,
+            int segments = 24)
+        {
+            var direction = Vector3.Normalize(end - start);
+            var side = Vector3.Cross(direction, Vector3.Up);
+            if (side.LengthSquared() < 0.000001f)
+                side = Vector3.Cross(direction, Vector3.Forward);
+            side.Normalize();
+            var up = Vector3.Normalize(Vector3.Cross(side, direction));
+            var edges = new List<EdgeData>(segments * 2 + 3);
+
+            AddRing(start);
+            AddRing(end);
+            AddEdge(start, end);
+
+            var distance = Vector3.Distance(start, end);
+            var arrowLength = MathF.Min(distance * 0.18f, 0.35f);
+            var arrowHalfWidth = arrowLength * 0.45f;
+            var arrowBase = end - direction * arrowLength;
+            AddEdge(end, arrowBase + side * arrowHalfWidth);
+            AddEdge(end, arrowBase - side * arrowHalfWidth);
+
+            return new PreviewShape([], edges.ToArray());
+
+            void AddRing(Vector3 center)
+            {
+                for (var index = 0; index < segments; index++)
+                {
+                    var angle = MathHelper.TwoPi * index / segments;
+                    var nextAngle = MathHelper.TwoPi *
+                        ((index + 1) % segments) / segments;
+                    AddEdge(
+                        center + side * (MathF.Cos(angle) * endpointRadius) +
+                            up * (MathF.Sin(angle) * endpointRadius),
+                        center + side * (MathF.Cos(nextAngle) * endpointRadius) +
+                            up * (MathF.Sin(nextAngle) * endpointRadius));
+                }
+            }
+
+            void AddEdge(Vector3 edgeStart, Vector3 edgeEnd)
+            {
+                edges.Add(new EdgeData
+                {
+                    P0 = edgeStart,
+                    P1 = edgeEnd,
+                    C0 = color.ToVector3(),
+                    C1 = color.ToVector3(),
+                    Width = edgeWidth,
+                });
+            }
         }
 
         private static Color GetCombatPreviewColor(
@@ -1444,7 +1534,8 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                 ReferenceEquals(source, selectedAttribute),
                 _ => PopulateBoneOnlyMarkerNode(node),
                 () => Vector3.Zero,
-                () => Quaternion.Identity);
+                () => Quaternion.Identity,
+                isHitTestEnabled: false);
             root.AddObject(node);
             instance.FollowBone(skeleton, boneIndex);
             preview = instance;

--- a/Testing/AssetEditorTests/UiAnimationMetadataFamilyGallery.cs
+++ b/Testing/AssetEditorTests/UiAnimationMetadataFamilyGallery.cs
@@ -1015,6 +1015,20 @@ public class UiAnimationMetadataFamilyGallery
                 Visual = FindVisualDescendants<Border>(button)
                     .Single(border => border.Name == "Marker"),
             }).ToArray();
+            var markerBounds = markers.Select(marker =>
+            {
+                var origin = marker.Button.TransformToAncestor(timeline)
+                    .Transform(new Point());
+                return new
+                {
+                    marker.ViewModel,
+                    Bounds = new Rect(
+                        origin,
+                        new Size(
+                            marker.Button.ActualWidth,
+                            marker.Button.ActualHeight)),
+                };
+            }).ToArray();
             var genericTypeColors = markers
                 .Where(marker => marker.ViewModel.Item.PreviewCategory == null)
                 .Select(marker => new
@@ -1124,6 +1138,33 @@ public class UiAnimationMetadataFamilyGallery
                     markerButtons.All(button => button.Style.Triggers.Count == 0),
                     Is.True);
             });
+
+            for (var firstIndex = 0;
+                 firstIndex < markerBounds.Length;
+                 firstIndex++)
+            {
+                for (var secondIndex = firstIndex + 1;
+                     secondIndex < markerBounds.Length;
+                     secondIndex++)
+                {
+                    var first = markerBounds[firstIndex];
+                    var second = markerBounds[secondIndex];
+                    var horizontalOverlap =
+                        first.ViewModel.StartFraction <=
+                            second.ViewModel.EndFraction &&
+                        second.ViewModel.StartFraction <=
+                            first.ViewModel.EndFraction;
+                    if (!horizontalOverlap)
+                        continue;
+
+                    NUnitAssert.That(
+                        second.Bounds.Top,
+                        Is.Not.EqualTo(first.Bounds.Top).Within(0.5),
+                        $"Overlapping timeline markers share a lane: " +
+                        $"{first.ViewModel.Item.Source.Name} and " +
+                        second.ViewModel.Item.Source.Name);
+                }
+            }
 
             var instantButton = markers.Single(marker =>
                 marker.ViewModel.Item.TimelineMarkerKind ==

--- a/Testing/AssetEditorTests/View3DComponentIsolationTests.cs
+++ b/Testing/AssetEditorTests/View3DComponentIsolationTests.cs
@@ -1,6 +1,8 @@
 using System.Runtime.CompilerServices;
 using System.Windows;
 using AssetEditor.Services;
+using Editors.AnimationMeta.SuperView.Editing;
+using Editors.AnimationMeta.SuperView.Inspection;
 using Editors.KitbasherEditor.Components;
 using GameWorld.Core.Components;
 using GameWorld.Core.Components.Input;
@@ -98,6 +100,30 @@ public class View3DComponentIsolationTests
         {
             (provider as IDisposable)?.Dispose();
         }
+    }
+
+    [TestMethod]
+    public void SuperViewMarkerPicker_DoesNotDependOnSharedModelSelection()
+    {
+        var dependencies = typeof(MetaDataMarkerPickerComponent)
+            .GetConstructors()
+            .Single()
+            .GetParameters()
+            .Select(parameter => parameter.ParameterType)
+            .ToArray();
+
+        CollectionAssert.AreEquivalent(
+            new[]
+            {
+                typeof(ArcBallCamera),
+                typeof(IMouseComponent),
+                typeof(CombatMetaDataGizmoComponent),
+            },
+            dependencies);
+        Assert.IsFalse(dependencies.Contains(typeof(SelectionManager)));
+        Assert.IsFalse(dependencies.Any(type =>
+            type.Namespace?.Contains("Kitbasher", StringComparison.Ordinal) ==
+                true));
     }
 
     private static View3DCoreComponentSet CreateCoreComponentSet()

--- a/docs/superview.md
+++ b/docs/superview.md
@@ -65,9 +65,9 @@
 
 ### 3.3 View3D 组成
 
-`SuperViewViewModel` 继承 `EditorHostBase`。基类建立共享 `IWpfGame`、核心 View3D 组件、参考模型 VM、动画播放器和场景对象集合；超级视图构造时再显式加入 scoped 的 `CombatMetaDataGizmoComponent`。
+`SuperViewViewModel` 继承 `EditorHostBase`。基类建立共享 `IWpfGame`、核心 View3D 组件、参考模型 VM、动画播放器和场景对象集合；超级视图构造时再显式加入 scoped 的 `CombatMetaDataGizmoComponent` 与 `MetaDataMarkerPickerComponent`。
 
-超级视图不插入 `KitbashSceneComponentSet`。其专属 Gizmo 使用共享 `Gizmo` 原语，但编辑目标是 `ParsedMetadataAttribute`，不是 `SelectionManager` 中的模型选择。
+超级视图不插入 `KitbashSceneComponentSet`。其专属 Gizmo 使用共享 `Gizmo` 原语，但编辑目标是 `ParsedMetadataAttribute`，不是 `SelectionManager` 中的模型选择。专属 marker picker 只消费当前 `MetaDataInspectionIndex` 与当前可见 marker 预览，同样不进入共享模型选择。
 
 ## 4. 对象与状态所有权
 
@@ -87,6 +87,7 @@
 | `MetaDataTimelineViewModel` | 把索引中的有效时间范围投影成播放器标记并执行导航 | 只属于 SuperView，不解释或修改 META 字段 |
 | `CombatMetaDataEditSession` | 空间元数据预览事务、撤销/重做、每文档历史 | 以文档 owner 区分的编辑历史 |
 | `CombatMetaDataGizmoComponent` | 3D 手势与 Gizmo/鼠标生命周期 | 当前空间目标和活动 gesture |
+| `MetaDataMarkerPickerComponent` | 当前 marker 的射线命中、悬停、单击选择和双击聚焦 | 只持有瞬时指针状态，不缓存文档或模型选择 |
 | `SpatialMetaDataCatalog` | 已验证空间标签到可写字段的适配 | 类型能力定义，不持有运行时选择 |
 
 必须区分：
@@ -241,7 +242,7 @@
 
 时间轴紧邻共享播放滑块，只投影三种只读标记：普通同一时刻为瞬时刻线，合法 start/end 为区间条，明确 allowlist 的 `(0,0)` 为全程条。Impact、Target、Fire、Splash 沿用三维预览分类颜色；其他类型使用主题语义色。所选项还必须通过轮廓、厚度或形状变化表达，不能只换颜色；tooltip 和 `AutomationProperties.Name` 需用中文说明类型、owner 和时间。
 
-点击标记只做导航：切换到对应 owner 页签，按引用身份选择同一个源对象，并把共享播放器 seek 到 authored start。它不提供拖动、时间编辑、缩放、裁剪或区间调整。共享 `AnimationPlayerView` 只暴露通用的可选注释内容槽；所有 META 索引、标记、颜色和点击语义仍留在 `AnimationMeta/SuperView`，不得向共享播放器加入 `IsSuperView`、META 类型判断或业务分发。
+点击标记只做导航：切换到对应 owner 页签，按引用身份选择同一个源对象，并把共享播放器 seek 到 authored start。它不提供拖动、时间编辑、缩放、裁剪或区间调整。时间范围横向相交的标记分配到不同的紧凑轨道，不相交的标记复用轨道；轨道数量增加时注释区域按需增高，不能把多个标记完全覆盖成一条。共享 `AnimationPlayerView` 只暴露通用的可选注释内容槽；所有 META 索引、标记、颜色、轨道布局和点击语义仍留在 `AnimationMeta/SuperView`，不得向共享播放器加入 `IsSuperView`、META 类型判断或业务分发。
 
 ## 10. 空间元数据能力目录
 
@@ -309,6 +310,12 @@ Edit Session 以 owner 的引用身份隔离历史。Persistent 与 Animation �
 
 参考模型节点和 Prop 节点保持 `IsSelectable=false`。选中预览可使用专用 preview outline，但不得写入共享 `SelectionManager` 或触发 Kitbash 整体选择语义。
 
+3D marker 选取只注册实现 `IMetaDataMarkerPreview`、仍属于当前检查索引且当前实际可见的预览。普通/Animated Prop、参考模型、网格、面、边、顶点、骨骼和无可视几何的骨骼占位预览不实现该命中契约。命中按到相机射线的距离、沿射线深度和检查索引顺序依次稳定排序；透视视图保留小角度容差，使远处可见 marker 仍可点选。Splash 保留半透明攻击范围面，线框只显示首尾端面圆环和位于同一平面的方向箭头；走廊端面圆环的显示与命中半径都必须使用 `WidthForCorridor / 2`，不能替换成固定尺寸的小定位环。首尾圆环分别作为 start/end 命中点，不能退化为只命中中心点。
+
+单击 marker 通过检查索引中的 owner 与源对象引用切换页签并选择原始 `ParsedMetadataAttribute`，不跳播放时间、不改字段；点击未命中 marker 的空白位置清除当前 META 选择，但不能转而选中参考模型或 Prop。Splash 的首尾命中还必须同步切换对应 Gizmo 控制点。双击同一 marker 同一控制点的第二次点击只调用现有 META 聚焦，不重复选择；连续点击 Splash 的不同控制点仍是两次单击选择。没有有效焦点位置时保留单击选择且不移动相机。活动 Gizmo gesture 或相机等其他组件持有鼠标时 picker 必须清空本次点击并让路；它不得抢占鼠标所有权。
+
+悬停复用 marker 已有的选中轮廓/加粗反馈，不新增共享 View3D 覆盖层。owner 切换立即清除旧悬停；预览替换、完整重建、Fragment/Slot 切换和关闭还必须清除待完成点击与双击状态。清理后的实例即使仍有旧对象引用也不得再次命中。
+
 批量显示覆盖只应用于当前 animation metadata 来源的对应分类，不应修改 persistent metadata 的预览。用户覆盖按源对象身份跟踪；完整重建后应剔除已不存在的源，保留仍存在源的设置。
 
 ## 13. 保存与文件所有权
@@ -354,6 +361,7 @@ Edit Session 以 owner 的引用身份隔离历史。Persistent 与 Animation �
 - `CombatMetaDataEditSession` 事件；
 - EventHub 注册；
 - 当前 Gizmo gesture 与鼠标所有权；
+- marker picker 的悬停、待完成点击、双击序列和宿主回调；
 - 所有 metadata instances、附属 players、场景节点和动画规则。
 
 重新构建预览是高频生命周期，不等于关闭编辑器。每次 rebuild 都必须先有序清理旧结果，同时保留真正属于文档或用户覆盖的状态。不要依赖 GC 清理场景节点、GPU 资源或事件订阅。
@@ -423,7 +431,7 @@ Edit Session 以 owner 的引用身份隔离历史。Persistent 与 Animation �
 | 检查索引/时间轴 | `MetaDataInspectionIndexTests`、`MetaDataEditorViewModelTests`、`UiAnimationMetadataFamilyGallery` | 双文档同值项、无效范围、点击导航、四主题/高对比度、空状态和缩放 |
 | 字段 UI/批量控制 | `MetaDataAttributeControlTests` | 两页签、直接 Meta Editor、中文 UI 和焦点 |
 | 格式解析 | `MetaDataFileParserTests` 及格式项目测试 | 真实文件 round trip、未知 payload |
-| View3D 隔离 | `View3DComponentIsolationTests` | 确认模型不可选择、无 Kitbash 编辑工具泄漏 |
+| View3D 隔离与 marker 选取 | `MetaDataMarkerPickingTests`、`View3DComponentIsolationTests` | 单/双击、重叠/远距、播放可见性、Gizmo/相机让路，并确认模型、Prop、骨骼不可选择且无 Kitbash 编辑工具泄漏 |
 | XAML/视觉 | 受影响项目构建和布局/本地化测试 | 实际 WPF 主题、缩放、marker、Gizmo 和遮挡 |
 
 若修改共享动画播放器、SceneObject、Gizmo、RenderEngine 或格式层，必须补跑所有受影响调用者的测试。自动测试不能替代本地 WPF/GPU 视觉检查。


### PR DESCRIPTION
## 改动内容

- 为 SuperView 增加专属 3D META marker 单击选择、双击聚焦和稳定重叠命中。
- 保持 Gizmo、镜头、模型、Prop、骨骼与 Kitbash 选择边界互不干扰。
- 完善 Splash Attack 首尾端点选取、端面圆环、半透明范围面和平面方向箭头。
- 将时间相交的 META 时间条分配到紧凑独立轨道，避免完全重叠。
- 补充生命周期清理、自动测试和 SuperView 长期契约文档。

## 用户影响

用户可以直接在 3D 场景中准确选择 META，Splash Attack 起点和终点可分别操作；密集时间标记也能逐条识别和点击。

## 验证

- 真实 SuperView/GPU 场景四轮人工验收通过，包含远距、密集标记、播放、Gizmo、镜头、Splash 端点和深浅主题。
- Release 全解决方案构建通过：0 错误。
- 全解决方案测试通过：2748 通过，6 跳过，0 失败。
- 最终差异审查无阻断问题。

关联 #96