### PR TITLE
Fix audio editor filters and loading dialog timing

### DIFF
--- a/Editors/Audio/AudioEditor/Core/AudioEditorFileService.cs
+++ b/Editors/Audio/AudioEditor/Core/AudioEditorFileService.cs
@@ -40,7 +40,8 @@ namespace Editors.Audio.AudioEditor.Core
             CancellationToken cancellationToken = default);
         Task<bool> LoadFromDialogAsync(
             IProgress<AudioLoadProgress> progress = null,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            System.Action loadStarted = null);
     }
 
     public class AudioEditorFileService(
@@ -120,12 +121,14 @@ namespace Editors.Audio.AudioEditor.Core
 
         public async Task<bool> LoadFromDialogAsync(
             IProgress<AudioLoadProgress> progress = null,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            System.Action loadStarted = null)
         {
             var result = _audioProjectFileService.LoadFromDialog();
             if (result == null)
                 return false;
 
+            loadStarted?.Invoke();
             return await LoadAsync(
                 result.AudioProject,
                 result.FileName,

--- a/Editors/Audio/AudioEditor/Presentation/AudioEditorView.xaml
+++ b/Editors/Audio/AudioEditor/Presentation/AudioEditorView.xaml
@@ -120,7 +120,7 @@
                     CancelCommand="{Binding LoadAudioProjectCancelCommand}"
                     CancelText="{loc:Loc General.Cancel}"
                     CurrentDetailText="{Binding OperationDetail}"
-                    IsOperationActive="{Binding IsLoading}"
+                    IsOperationActive="{Binding IsLoadProgressWindowActive}"
                     IsProgressIndeterminate="{Binding OperationProgressIsIndeterminate}"
                     ProgressMaximum="{Binding OperationProgressMaximum}"
                     ProgressValue="{Binding OperationProgressValue}"

--- a/Editors/Audio/AudioEditor/Presentation/AudioEditorViewModel.cs
+++ b/Editors/Audio/AudioEditor/Presentation/AudioEditorViewModel.cs
@@ -43,6 +43,7 @@ namespace Editors.Audio.AudioEditor.Presentation
         [ObservableProperty] private bool _isSettingsBorderVisible = false;
         [ObservableProperty] private bool _isCompiling = false;
         [ObservableProperty] private bool _isLoading = false;
+        [ObservableProperty] private bool _isLoadProgressWindowActive = false;
         [ObservableProperty] private bool _isBusy = false;
         [ObservableProperty] private bool _isEditorIdle = true;
         [ObservableProperty] private bool _canEditAudioProject = false;
@@ -218,7 +219,10 @@ namespace Editors.Audio.AudioEditor.Presentation
             try
             {
                 var loaded = await _audioEditorFileService
-                    .LoadFromDialogAsync(progress, cancellationToken);
+                    .LoadFromDialogAsync(
+                        progress,
+                        cancellationToken,
+                        () => IsLoadProgressWindowActive = true);
                 if (loaded)
                 {
                     CompileStatus = LocalizationManager.Instance.Get(
@@ -250,6 +254,7 @@ namespace Editors.Audio.AudioEditor.Presentation
             }
             finally
             {
+                IsLoadProgressWindowActive = false;
                 IsLoading = false;
             }
         }

--- a/Editors/Audio/AudioEditor/Presentation/AudioProjectEditor/AudioProjectEditorViewModel.cs
+++ b/Editors/Audio/AudioEditor/Presentation/AudioProjectEditor/AudioProjectEditorViewModel.cs
@@ -319,6 +319,16 @@ namespace Editors.Audio.AudioEditor.Presentation.AudioProjectEditor
             IsAddRowButtonEnabled = false;
             _audioEditorStateService.StoreEditorRow(null);
 
+            if (PruneRemovedPendingEditedRows() && IsEditing)
+            {
+                ResetEditMode();
+                ResetTable();
+                LoadTable(
+                    _audioEditorStateService
+                        .SelectedAudioProjectExplorerNode.Type);
+                return;
+            }
+
             if (Table.Rows.Count == 0)
                 return;
 
@@ -345,6 +355,25 @@ namespace Editors.Audio.AudioEditor.Presentation.AudioProjectEditor
                 _audioEditorStateService.StoreEditorRow(Table.Rows[0]);
                 return;
             }
+        }
+
+        private bool PruneRemovedPendingEditedRows()
+        {
+            var pendingRows = _audioEditorStateService
+                .PendingEditedViewerRows;
+            if (pendingRows.Count == 0)
+                return false;
+
+            var availableRows = pendingRows
+                .Where(row => row.RowState is not DataRowState.Deleted
+                    and not DataRowState.Detached)
+                .ToList();
+            if (availableRows.Count == pendingRows.Count)
+                return false;
+
+            _audioEditorStateService.StorePendingEditedViewerRows(
+                availableRows);
+            return availableRows.Count == 0;
         }
 
         private bool AreAudioFilesSet()

--- a/Editors/Audio/AudioEditor/Presentation/AudioProjectExplorer/AudioProjectExplorerView.xaml
+++ b/Editors/Audio/AudioEditor/Presentation/AudioProjectExplorer/AudioProjectExplorerView.xaml
@@ -273,6 +273,24 @@
                 ScrollViewer.HorizontalScrollBarVisibility="Auto"
                 Padding="0, 5, 0, 5">
 
+                <TreeView.ItemContainerStyle>
+                    <Style
+                        TargetType="{x:Type TreeViewItem}"
+                        BasedOn="{StaticResource AeTree.Item}">
+                        <Setter
+                            Property="IsExpanded"
+                            Value="{Binding IsExpanded, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
+                        <Setter
+                            Property="Visibility">
+                            <Setter.Value>
+                                <Binding
+                                    Path="IsVisible"
+                                    Converter="{StaticResource BoolToVisibilityConverter}" />
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </TreeView.ItemContainerStyle>
+
                 <TreeView.Resources>
                     <HierarchicalDataTemplate 
                         DataType="{x:Type Models:AudioProjectTreeNode}" 
@@ -287,22 +305,6 @@
                             </TextBlock.Inlines>
                         </TextBlock>
                     </HierarchicalDataTemplate>
-
-                    <Style 
-                        TargetType="{x:Type TreeViewItem}" 
-                        BasedOn="{StaticResource {x:Type TreeViewItem}}">
-                        <Setter 
-                            Property="IsExpanded" 
-                            Value="{Binding IsExpanded, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" />
-                        <Setter 
-                            Property="Visibility">
-                            <Setter.Value>
-                                <Binding 
-                                    Path="IsVisible" 
-                                    Converter="{StaticResource BoolToVisibilityConverter}" />
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
                 </TreeView.Resources>
             </TreeView>
         </Grid>

--- a/Editors/Audio/AudioEditor/Presentation/AudioProjectExplorer/AudioProjectExplorerViewModel.cs
+++ b/Editors/Audio/AudioEditor/Presentation/AudioProjectExplorer/AudioProjectExplorerViewModel.cs
@@ -63,6 +63,7 @@ namespace Editors.Audio.AudioEditor.Presentation.AudioProjectExplorer
             ResetFilters();
 
             AudioProjectTree = _audioProjectTreeBuilder.BuildTree(_audioEditorStateService.AudioProject, ShowEditedItemsOnly);
+            InitialiseDialogueEventFilters();
 
             var audioProjectFileName = Path.GetFileNameWithoutExtension(_audioEditorStateService.AudioProjectFileName);
             AudioProjectExplorerLabel =
@@ -73,14 +74,8 @@ namespace Editors.Audio.AudioEditor.Presentation.AudioProjectExplorer
         {
             _audioEditorStateService
                 .StoreSelectedAudioProjectExplorerNode(value);
-            IsDialogueEventFilterEnabled = false;
             _eventHub.Publish(
                 new AudioProjectExplorerNodeSelectedEvent(value));
-            if (value == null)
-                return;
-
-            if (value.IsDialogueEvents())
-                InitialiseDialogueEventFilters();
         }
 
         private void FilterAudioProjectTree()
@@ -94,25 +89,28 @@ namespace Editors.Audio.AudioEditor.Presentation.AudioProjectExplorer
 
         partial void OnSelectedDialogueEventTypeChanged(Wh3DialogueEventType? value)
         {
-            if (SelectedNode == null)
-                return;
-
-            SelectedNode.DialogueEventTypeFilter = value ?? Wh3DialogueEventType.TypeShowAll;
-            SetDialogueEventFilterDisplayText();
+            foreach (var node in GetDialogueEventNodes())
+            {
+                node.DialogueEventTypeFilter = value ??
+                    Wh3DialogueEventType.TypeShowAll;
+                SetDialogueEventFilterDisplayText(node);
+            }
             FilterAudioProjectTree();
         }
 
         partial void OnSelectedDialogueEventProfileChanged(Wh3DialogueEventUnitProfile? value)
         {
-            if (SelectedNode == null)
-                return;
-
-            SelectedNode.DialogueEventProfileFilter = value ?? Wh3DialogueEventUnitProfile.ProfileShowAll;
-            SetDialogueEventFilterDisplayText();
+            foreach (var node in GetDialogueEventNodes())
+            {
+                node.DialogueEventProfileFilter = value ??
+                    Wh3DialogueEventUnitProfile.ProfileShowAll;
+                SetDialogueEventFilterDisplayText(node);
+            }
             FilterAudioProjectTree();
         }
 
-        private void SetDialogueEventFilterDisplayText()
+        private void SetDialogueEventFilterDisplayText(
+            AudioProjectTreeNode node)
         {
             var setTypeFilterText = SelectedDialogueEventType != null && SelectedDialogueEventType != Wh3DialogueEventType.TypeShowAll;
             var setProfileFilterText = SelectedDialogueEventProfile != null && SelectedDialogueEventProfile != Wh3DialogueEventUnitProfile.ProfileShowAll;
@@ -120,20 +118,20 @@ namespace Editors.Audio.AudioEditor.Presentation.AudioProjectExplorer
             {
                 var typeFilterText = $"Type: {Wh3DialogueEventInformation.GetDialogueEventTypeDisplayName(SelectedDialogueEventType)}";
                 var profileFilterText = $"Profile: {Wh3DialogueEventInformation.GetDialogueEventProfileDisplayName(SelectedDialogueEventProfile)}";
-                SelectedNode.DialogueEventFilterDisplayText = $"({typeFilterText}, {profileFilterText})";
+                node.DialogueEventFilterDisplayText = $"({typeFilterText}, {profileFilterText})";
             }
             else if (setTypeFilterText)
             {
                 var typeFilterText = $"Type: {Wh3DialogueEventInformation.GetDialogueEventTypeDisplayName(SelectedDialogueEventType)}";
-                SelectedNode.DialogueEventFilterDisplayText = $"({typeFilterText})";
+                node.DialogueEventFilterDisplayText = $"({typeFilterText})";
             }
             else if (setProfileFilterText)
             {
                 var profileFilterText = $"Profile: {Wh3DialogueEventInformation.GetDialogueEventProfileDisplayName(SelectedDialogueEventProfile)}";
-                SelectedNode.DialogueEventFilterDisplayText = $"({profileFilterText})";
+                node.DialogueEventFilterDisplayText = $"({profileFilterText})";
             }
             else
-                SelectedNode.DialogueEventFilterDisplayText = null;
+                node.DialogueEventFilterDisplayText = null;
         }
 
         partial void OnSearchQueryChanged(string value) => DebounceFilterAudioProjectTreeForSearchQuery();
@@ -198,33 +196,35 @@ namespace Editors.Audio.AudioEditor.Presentation.AudioProjectExplorer
 
         private void InitialiseDialogueEventFilters()
         {
-            var soundBankName = Wh3SoundBankInformation.GetName(SelectedNode.GameSoundBank);
-            var soundBank = Wh3SoundBankInformation.GetSoundBank(soundBankName);
+            var dialogueEventNodes = GetDialogueEventNodes();
+            var soundBanks = dialogueEventNodes
+                .Select(node => node.GameSoundBank)
+                .ToHashSet();
 
             DialogueEventTypes = new ObservableCollection<Wh3DialogueEventType>(Wh3DialogueEventInformation.Information
-                .Where(dialogueEventDefinition => dialogueEventDefinition.SoundBank == soundBank)
+                .Where(dialogueEventDefinition => soundBanks.Contains(
+                    dialogueEventDefinition.SoundBank))
                 .SelectMany(dialogueEventDefinition => dialogueEventDefinition.DialogueEventTypes)
                 .Distinct()
                 .OrderBy(type => (int)type)); //Order by enum order
 
             DialogueEventProfiles = new ObservableCollection<Wh3DialogueEventUnitProfile>(Wh3DialogueEventInformation.Information
-                .Where(dialogueEventDefinition => dialogueEventDefinition.SoundBank == soundBank)
+                .Where(dialogueEventDefinition => soundBanks.Contains(
+                    dialogueEventDefinition.SoundBank))
                 .SelectMany(dialogueEventDefinition => dialogueEventDefinition.UnitProfiles)
                 .Distinct()
                 .OrderBy(profile => (int)profile)); //Order by enum order
 
-            if (SelectedNode.DialogueEventTypeFilter != null && SelectedNode.DialogueEventTypeFilter != Wh3DialogueEventType.TypeShowAll)
-                SelectedDialogueEventType = SelectedNode.DialogueEventTypeFilter;
-            else
-                ResetDialogueEventTypeFilterComboBoxSelectedItem();
-
-            if (SelectedNode.DialogueEventProfileFilter != null && SelectedNode.DialogueEventProfileFilter != Wh3DialogueEventUnitProfile.ProfileShowAll)
-                SelectedDialogueEventProfile = SelectedNode.DialogueEventProfileFilter;
-            else
-                ResetDialogueEventProfileFilterComboBoxSelectedItem();
-
-            IsDialogueEventFilterEnabled = true;
+            ResetDialogueEventTypeFilterComboBoxSelectedItem();
+            ResetDialogueEventProfileFilterComboBoxSelectedItem();
+            IsDialogueEventFilterEnabled = dialogueEventNodes.Count > 0;
         }
+
+        private List<AudioProjectTreeNode> GetDialogueEventNodes() =>
+            FlattenAudioProjectTree(AudioProjectTree)
+                .Where(node => node.Type ==
+                    AudioProjectTreeNodeType.DialogueEvents)
+                .ToList();
 
         [RelayCommand] public void ResetFilters()
         {
@@ -242,6 +242,10 @@ namespace Editors.Audio.AudioEditor.Presentation.AudioProjectExplorer
                 dialogueEventNode.DialogueEventProfileFilter = Wh3DialogueEventUnitProfile.ProfileShowAll;
                 dialogueEventNode.DialogueEventFilterDisplayText = null;
             }
+
+            ResetDialogueEventTypeFilterComboBoxSelectedItem();
+            ResetDialogueEventProfileFilterComboBoxSelectedItem();
+            FilterAudioProjectTree();
         }
 
         private static IEnumerable<AudioProjectTreeNode> FlattenAudioProjectTree(IEnumerable<AudioProjectTreeNode> nodes)

--- a/Editors/Audio/AudioEditor/Presentation/AudioProjectExplorer/AudioProjectTreeSearchFilterService.cs
+++ b/Editors/Audio/AudioEditor/Presentation/AudioProjectExplorer/AudioProjectTreeSearchFilterService.cs
@@ -131,7 +131,9 @@ namespace Editors.Audio.AudioEditor.Presentation.AudioProjectExplorer
                 var dialogueEventProfile = node.DialogueEventProfileFilter.Value;
 
                 var allowedDialogueEvents = Wh3DialogueEventInformation.Information
-                    .Where(item => item.SoundBank == node.GameSoundBank && item.DialogueEventTypes.Contains(dialogueEventType) && item.UnitProfiles.Contains(dialogueEventProfile))
+                    .Where(item => item.SoundBank == node.GameSoundBank &&
+                        (!hasTypeFilter || item.DialogueEventTypes.Contains(dialogueEventType)) &&
+                        (!hasProfileFilter || item.UnitProfiles.Contains(dialogueEventProfile)))
                     .Select(item => item.Name)
                     .ToHashSet();
 

--- a/Editors/Audio/AudioExplorer/AudioExplorerView.xaml
+++ b/Editors/Audio/AudioExplorer/AudioExplorerView.xaml
@@ -204,7 +204,7 @@
                     CancelCommand="{Binding LoadAudioRepositoryForSelectedLanguagesCancelCommand}"
                     CancelText="{loc:Loc AudioExplorer.CancelLoading}"
                     CurrentDetailText="{Binding LoadProgressDetail}"
-                    IsOperationActive="{Binding IsLoading}"
+                    IsOperationActive="{Binding IsLoadProgressWindowActive}"
                     IsProgressIndeterminate="{Binding LoadProgressIsIndeterminate}"
                     ProgressMaximum="{Binding LoadProgressMaximum}"
                     ProgressValue="{Binding LoadProgressValue}"

--- a/Editors/Audio/AudioExplorer/AudioExplorerViewModel.cs
+++ b/Editors/Audio/AudioExplorer/AudioExplorerViewModel.cs
@@ -60,6 +60,7 @@ namespace Editors.Audio.AudioExplorer
         private readonly DispatcherTimer _playbackTimer;
         private readonly Serilog.ILogger _logger = Logging.Create<AudioExplorerViewModel>();
         private bool _isInitialized;
+        private bool _suppressAutomaticLoadProgressWindow;
         private bool _isUpdatingPlaybackPosition;
         private int _hiddenUnavailableReferenceCount;
         private int _playbackSelectionVersion;
@@ -95,6 +96,7 @@ namespace Editors.Audio.AudioExplorer
         [ObservableProperty] private double _playbackPositionSeconds = 0;
         [ObservableProperty] private double _totalPlaybackSeconds = 0;
         [ObservableProperty] private bool _isLoading = false;
+        [ObservableProperty] private bool _isLoadProgressWindowActive = false;
         [ObservableProperty] private int _loadProgress = 0;
         [ObservableProperty] private int _loadProgressValue = 0;
         [ObservableProperty] private int _loadProgressMaximum = 0;
@@ -462,7 +464,16 @@ namespace Editors.Audio.AudioExplorer
                 return;
 
             _isInitialized = true;
-            await LoadAudioRepositoryForSelectedLanguagesCommand.ExecuteAsync(null);
+            _suppressAutomaticLoadProgressWindow = true;
+            try
+            {
+                await LoadAudioRepositoryForSelectedLanguagesCommand
+                    .ExecuteAsync(null);
+            }
+            finally
+            {
+                _suppressAutomaticLoadProgressWindow = false;
+            }
         }
 
         [RelayCommand(IncludeCancelCommand = true)]
@@ -482,6 +493,8 @@ namespace Editors.Audio.AudioExplorer
             }
 
             IsLoading = true;
+            IsLoadProgressWindowActive =
+                !_suppressAutomaticLoadProgressWindow;
             LoadProgress = 0;
             LoadProgressValue = 0;
             LoadProgressMaximum = 0;
@@ -530,6 +543,7 @@ namespace Editors.Audio.AudioExplorer
             }
             finally
             {
+                IsLoadProgressWindowActive = false;
                 IsLoading = false;
             }
         }

--- a/Editors/Audio/AudioProjectConverter/AudioProjectConverterWindow.xaml
+++ b/Editors/Audio/AudioProjectConverter/AudioProjectConverterWindow.xaml
@@ -273,7 +273,7 @@
             Margin="10,0,10,8">
             <progress:OperationProgressWindowHost
                 CurrentDetailText="{Binding ProgressDetail}"
-                IsOperationActive="{Binding IsBusy}"
+                IsOperationActive="{Binding IsProcessing}"
                 IsProgressIndeterminate="{Binding ProgressIsIndeterminate}"
                 ProgressMaximum="{Binding ProgressMaximum}"
                 ProgressValue="{Binding ProgressValue}"
@@ -286,7 +286,7 @@
                 <TextBlock.Style>
                     <Style TargetType="TextBlock">
                         <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsBusy}" Value="True">
+                            <DataTrigger Binding="{Binding IsProcessing}" Value="True">
                                 <Setter Property="Visibility" Value="Collapsed" />
                             </DataTrigger>
                         </Style.Triggers>

--- a/Editors/Audio/AudioUiStyles.xaml
+++ b/Editors/Audio/AudioUiStyles.xaml
@@ -10,7 +10,13 @@
     <Style TargetType="{x:Type TreeViewItem}" BasedOn="{StaticResource AeTree.Item}" />
     <Style TargetType="{x:Type ListBox}" BasedOn="{StaticResource AeList.View}" />
     <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource AeList.Item}" />
-    <Style TargetType="{x:Type ListView}" BasedOn="{StaticResource AeList.View}" />
+    <Style TargetType="{x:Type ListView}" BasedOn="{StaticResource {x:Type ListView}}">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{DynamicResource AeBrush.Border}" />
+        <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextSecondary}" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    </Style>
     <Style TargetType="{x:Type DataGrid}" BasedOn="{StaticResource AeTable.Grid}" />
     <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource AeTable.Row}" />
     <Style TargetType="{x:Type DataGridCell}" BasedOn="{StaticResource AeTable.Cell}" />

--- a/Editors/Audio/DialogueEventMerger/DialogueEventMergerWindow.xaml
+++ b/Editors/Audio/DialogueEventMerger/DialogueEventMergerWindow.xaml
@@ -130,7 +130,7 @@
             Margin="10,0,10,8">
             <progress:OperationProgressWindowHost
                 CurrentDetailText="{Binding ProgressDetail}"
-                IsOperationActive="{Binding IsBusy}"
+                IsOperationActive="{Binding IsGenerating}"
                 IsProgressIndeterminate="{Binding ProgressIsIndeterminate}"
                 ProgressMaximum="{Binding ProgressMaximum}"
                 ProgressValue="{Binding ProgressValue}"
@@ -143,7 +143,7 @@
                 <TextBlock.Style>
                     <Style TargetType="TextBlock">
                         <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsBusy}" Value="True">
+                            <DataTrigger Binding="{Binding IsGenerating}" Value="True">
                                 <Setter Property="Visibility" Value="Collapsed" />
                             </DataTrigger>
                         </Style.Triggers>

--- a/Testing/AssetEditorTests/AudioEditorViewModelTests.cs
+++ b/Testing/AssetEditorTests/AudioEditorViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Text.Json;
 using Editors.Audio.AudioEditor.Commands.AudioProjectEditor;
 using Editors.Audio.AudioEditor.Core;
 using Editors.Audio.AudioEditor.Events;
@@ -11,6 +12,7 @@ using Editors.Audio.AudioEditor.Events.Settings.Shortcuts;
 using Editors.Audio.AudioEditor.Presentation;
 using Editors.Audio.AudioEditor.Presentation.AudioProjectEditor;
 using Editors.Audio.AudioEditor.Presentation.AudioProjectEditor.Table;
+using Editors.Audio.AudioEditor.Presentation.AudioProjectExplorer;
 using Editors.Audio.AudioEditor.Presentation.AudioProjectViewer.Table;
 using Editors.Audio.AudioEditor.Presentation.Settings;
 using Editors.Audio.AudioEditor.Presentation.Shared.Models;
@@ -124,6 +126,137 @@ namespace AssetEditorTests
 
             Assert.IsFalse(viewModel.IsAddRowButtonEnabled);
             Assert.IsNull(state.EditorRow);
+        }
+
+        [TestMethod]
+        public void RemovedEditedViewerRow_EndsEditModeWithoutReadingDetachedData()
+        {
+            var originalTable = new DataTable();
+            originalTable.Columns.Add(TableInformation.ActionEventColumnName);
+            var originalRow = originalTable.Rows.Add("Play_original");
+            originalTable.Rows.Remove(originalRow);
+
+            var eventHub = new TestEventHub();
+            var state = new AudioEditorStateService
+            {
+                AudioProject = new AudioProjectFile(),
+                SelectedAudioProjectExplorerNode = AudioProjectTreeNode.CreateNode(
+                    Wh3ActionEventInformation.GetName(
+                        Wh3ActionEventType.BattleAbilities),
+                    AudioProjectTreeNodeType.ActionEventType),
+                AudioFiles =
+                [
+                    new AudioFile(
+                        Guid.NewGuid(),
+                        1,
+                        "test.wav",
+                        "audio\\test.wav")
+                ],
+                PendingEditedViewerRows = [originalRow]
+            };
+            var tableService = Mock.Of<IEditorTableService>();
+            var tableServiceFactory = new Mock<IEditorTableServiceFactory>();
+            tableServiceFactory
+                .Setup(x => x.GetService(
+                    AudioProjectTreeNodeType.ActionEventType))
+                .Returns(tableService);
+            var viewModel = new AudioProjectEditorViewModel(
+                Mock.Of<IUiCommandFactory>(),
+                eventHub,
+                state,
+                tableServiceFactory.Object,
+                Mock.Of<IAudioRepository>())
+            {
+                IsEditing = true
+            };
+            viewModel.Table.Columns.Add(
+                TableInformation.ActionEventColumnName);
+            viewModel.Table.Rows.Add("Play_replacement");
+
+            viewModel.OnEditorAddRowButtonEnablementUpdateRequested(
+                new EditorAddRowButtonEnablementUpdateRequestedEvent());
+
+            Assert.IsFalse(viewModel.IsEditing);
+            Assert.AreEqual(0, state.PendingEditedViewerRows.Count);
+            Assert.IsFalse(viewModel.IsAddRowButtonEnabled);
+        }
+
+        [TestMethod]
+        public void EditedItemsFilter_ShowsSavedActionEventTypesAfterProjectReload()
+        {
+            var eventHub = new TestEventHub();
+            var soundBank = new SoundBank(
+                "battle_individual_magic_test",
+                Wh3SoundBank.BattleIndividualMagic,
+                "sfx");
+            soundBank.ActionEvents.Add(new ActionEvent(
+                1,
+                "ability_event",
+                [
+                    Editors.Audio.Shared.AudioProject.Models.Action.CreatePlay(
+                        11,
+                        Shared.GameFormats.Wwise.Enums.AkBkHircType.Sound,
+                        101,
+                        201)
+                ],
+                Wh3ActionEventType.BattleAbilities));
+            soundBank.ActionEvents.Add(new ActionEvent(
+                2,
+                "magic_event",
+                [
+                    Editors.Audio.Shared.AudioProject.Models.Action.CreatePlay(
+                        12,
+                        Shared.GameFormats.Wwise.Enums.AkBkHircType.Sound,
+                        102,
+                        202)
+                ],
+                Wh3ActionEventType.BattleMagic));
+            var audioProject = new AudioProjectFile
+            {
+                Language = Wh3LanguageInformation.GetLanguageAsString(
+                    Wh3Language.EnglishUK),
+                SoundBanks = [soundBank]
+            };
+            var reopenedAudioProject =
+                JsonSerializer.Deserialize<AudioProjectFile>(
+                    JsonSerializer.Serialize(audioProject.Clean()));
+            Assert.IsNotNull(reopenedAudioProject);
+            var state = new AudioEditorStateService
+            {
+                AudioProject = reopenedAudioProject,
+                AudioProjectFileName = "test.aproj"
+            };
+            var treeBuilder = new AudioProjectTreeBuilderService(state);
+            var filter = new AudioProjectTreeFilterService(state);
+            var viewModel = new AudioProjectExplorerViewModel(
+                eventHub,
+                state,
+                treeBuilder,
+                filter);
+
+            eventHub.Publish(new AudioProjectLoadedEvent());
+            var actionEventTypes = viewModel.AudioProjectTree
+                .SelectMany(root => root.Children)
+                .SelectMany(soundBankNode => soundBankNode.Children)
+                .Single(node =>
+                    node.Type == AudioProjectTreeNodeType.ActionEvents)
+                .Children;
+            viewModel.ShowEditedItemsOnly = true;
+
+            var visibleTypeNames = actionEventTypes
+                .Where(node => node.IsVisible)
+                .Select(node => node.Name)
+                .ToArray();
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    Wh3ActionEventInformation.GetName(
+                        Wh3ActionEventType.BattleAbilities),
+                    Wh3ActionEventInformation.GetName(
+                        Wh3ActionEventType.BattleMagic)
+                },
+                visibleTypeNames);
+            viewModel.Dispose();
         }
 
         [TestMethod]
@@ -500,11 +633,14 @@ namespace AssetEditorTests
             fileService
                 .Setup(x => x.LoadFromDialogAsync(
                     It.IsAny<IProgress<AudioLoadProgress>>(),
-                    It.IsAny<CancellationToken>()))
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<System.Action>()))
                 .Returns(async (
                     IProgress<AudioLoadProgress> _,
-                    CancellationToken cancellationToken) =>
+                    CancellationToken cancellationToken,
+                    System.Action loadStarted) =>
                 {
+                    loadStarted();
                     await loadCanFinish.Task.WaitAsync(cancellationToken);
                     eventHub.Publish(new AudioProjectLoadedEvent());
                     return true;
@@ -545,6 +681,49 @@ namespace AssetEditorTests
         }
 
         [TestMethod]
+        public async Task LoadAudioProject_KeepsProgressPopupClosedWhileChoosingProject()
+        {
+            AudioEditorViewModel viewModel = null!;
+            bool? popupActiveWhenDialogOpened = null;
+            var fileService = new Mock<IAudioEditorFileService>();
+            fileService
+                .Setup(x => x.LoadFromDialogAsync(
+                    It.IsAny<IProgress<AudioLoadProgress>>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<System.Action>()))
+                .Returns((
+                    IProgress<AudioLoadProgress> _,
+                    CancellationToken _,
+                    System.Action loadStarted) =>
+                {
+                    popupActiveWhenDialogOpened =
+                        viewModel.IsLoadProgressWindowActive;
+                    loadStarted();
+                    return Task.FromResult(false);
+                });
+            viewModel = new AudioEditorViewModel(
+                Mock.Of<IUiCommandFactory>(),
+                new TestEventHub(),
+                new AudioEditorStateService(),
+                fileService.Object,
+                Mock.Of<IAudioProjectCompilerService>(),
+                Mock.Of<IAudioEditorIntegrityService>(),
+                Mock.Of<IShortcutService>(),
+                Mock.Of<IStandardDialogs>(),
+                new ApplicationSettingsService(GameTypeEnum.Warhammer3),
+                null!,
+                null!,
+                null!,
+                null!,
+                null!,
+                null!);
+
+            await viewModel.LoadAudioProject(CancellationToken.None);
+
+            Assert.IsFalse(popupActiveWhenDialogOpened);
+        }
+
+        [TestMethod]
         public async Task LoadAudioProject_WhenAsyncLoadFails_PreservesEditorAndShowsError()
         {
             var eventHub = new TestEventHub();
@@ -552,7 +731,8 @@ namespace AssetEditorTests
             fileService
                 .Setup(x => x.LoadFromDialogAsync(
                     It.IsAny<IProgress<AudioLoadProgress>>(),
-                    It.IsAny<CancellationToken>()))
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<System.Action>()))
                 .ThrowsAsync(new InvalidOperationException("load failed"));
             var dialogs = new Mock<IStandardDialogs>();
             var viewModel = new AudioEditorViewModel(

--- a/Testing/AssetEditorTests/AudioExplorerTests.cs
+++ b/Testing/AssetEditorTests/AudioExplorerTests.cs
@@ -86,6 +86,33 @@ namespace AssetEditorTests
         }
 
         [TestMethod]
+        public async Task LoadingPopup_StaysClosedForInitializationAndOpensForManualLoad()
+        {
+            var popupStates = new List<bool>();
+            AudioExplorerViewModel viewModel = null!;
+            var repository = CreateRepositoryMock();
+            repository
+                .Setup(x => x.Load(
+                    It.IsAny<List<string>>(),
+                    It.IsAny<IProgress<AudioLoadProgress>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() =>
+                {
+                    popupStates.Add(
+                        viewModel.IsLoadProgressWindowActive);
+                });
+            viewModel = CreateViewModel(repository.Object);
+
+            await viewModel.InitializeAsync();
+            await viewModel.LoadAudioRepositoryForSelectedLanguagesAsync();
+
+            CollectionAssert.AreEqual(
+                new[] { false, true },
+                popupStates);
+            viewModel.Close();
+        }
+
+        [TestMethod]
         public async Task InitializeAsync_UnsupportedGameShowsMessageAndDoesNotLoad()
         {
             var repository = CreateRepositoryMock();

--- a/Testing/AssetEditorTests/AudioProjectExplorerInteractionTests.cs
+++ b/Testing/AssetEditorTests/AudioProjectExplorerInteractionTests.cs
@@ -1,0 +1,431 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Threading;
+using Editors.Audio.AudioEditor.Core;
+using Editors.Audio.AudioEditor.Events;
+using Editors.Audio.AudioEditor.Presentation.AudioProjectExplorer;
+using Editors.Audio.AudioEditor.Presentation.Shared.Models;
+using Editors.Audio.Shared.AudioProject.Models;
+using Editors.Audio.Shared.GameInformation.Warhammer3;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Shared.Core.Services;
+
+using Assert = NUnit.Framework.Assert;
+
+namespace AssetEditorTests;
+
+[NonParallelizable]
+public class AudioProjectExplorerInteractionTests
+{
+    [SetUp]
+    public void SetUp() => new LocalizationManager().LoadLanguage();
+
+    [Test]
+    public void GeneralFiltersAndButtons_UpdateTheRenderedTree()
+    {
+        using var services = new ServiceCollection()
+            .AddSingleton(LocalizationManager.Instance)
+            .BuildServiceProvider();
+        WpfTestApplicationHost.InvokeWithThemeResources(services, () =>
+        {
+            var (viewModel, view, window) = CreateView();
+            try
+            {
+                var actionEventType = Flatten(viewModel.AudioProjectTree)
+                    .First(node => node.Type ==
+                        AudioProjectTreeNodeType.ActionEventType);
+                var actionItem = FindTreeViewItem(view, actionEventType);
+                var showEdited = FindCheckBox(view, "ShowEditedItemsOnly");
+                var showAction = FindCheckBox(view, "ShowActionEvents");
+                var showDialogue = FindCheckBox(view, "ShowDialogueEvents");
+                var collapseOrExpand = FindButton(
+                    view,
+                    "CollapseOrExpandTreeCommand");
+                var reset = FindButton(view, "ResetFiltersCommand");
+
+                SetChecked(showAction, false);
+                FlushBindings(view);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(
+                        BindingOperations.GetBindingExpression(
+                            actionItem,
+                            UIElement.VisibilityProperty),
+                        Is.Not.Null);
+                    Assert.That(viewModel.ShowActionEvents, Is.False);
+                    Assert.That(actionEventType.IsVisible, Is.False);
+                    Assert.That(
+                        actionItem.Visibility,
+                        Is.EqualTo(Visibility.Collapsed));
+                });
+
+                SetChecked(showAction, true);
+                SetChecked(showDialogue, false);
+                Assert.That(viewModel.ShowDialogueEvents, Is.False);
+
+                SetChecked(showEdited, true);
+                Assert.That(viewModel.ShowEditedItemsOnly, Is.True);
+
+                Execute(collapseOrExpand);
+                Assert.That(
+                    Flatten(viewModel.AudioProjectTree)
+                        .Where(node => node.IsVisible)
+                        .All(node => !node.IsExpanded),
+                    Is.True);
+
+                Execute(collapseOrExpand);
+                Assert.That(
+                    Flatten(viewModel.AudioProjectTree)
+                        .Where(node => node.IsVisible)
+                        .All(node => node.IsExpanded),
+                    Is.True);
+
+                Execute(reset);
+                FlushBindings(view);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(viewModel.ShowEditedItemsOnly, Is.False);
+                    Assert.That(viewModel.ShowActionEvents, Is.True);
+                    Assert.That(viewModel.ShowDialogueEvents, Is.True);
+                    Assert.That(actionEventType.IsVisible, Is.True);
+                    Assert.That(
+                        actionItem.Visibility,
+                        Is.EqualTo(Visibility.Visible));
+                });
+            }
+            finally
+            {
+                viewModel.Dispose();
+                window.Close();
+            }
+        });
+    }
+
+    [Test]
+    public void DialogueFilters_UpdateTheRenderedTree()
+    {
+        using var services = new ServiceCollection()
+            .AddSingleton(LocalizationManager.Instance)
+            .BuildServiceProvider();
+        WpfTestApplicationHost.InvokeWithThemeResources(services, () =>
+        {
+            var (viewModel, view, window) = CreateView();
+            try
+            {
+                var dialogueEventBranches = Flatten(
+                        viewModel.AudioProjectTree)
+                    .Where(node => node.Type ==
+                        AudioProjectTreeNodeType.DialogueEvents)
+                    .ToList();
+                var dialogueEvents = dialogueEventBranches.Single(node =>
+                    node.GameSoundBank == Wh3SoundBank.CampaignVO);
+                viewModel.SelectedNode = Flatten(viewModel.AudioProjectTree)
+                    .Single(node => node.Type ==
+                        AudioProjectTreeNodeType.StateGroup);
+                view.UpdateLayout();
+
+                var typeComboBox = (ComboBox)view.FindName(
+                    "DialogueEventTypeFilterComboBox");
+                var profileComboBox = (ComboBox)view.FindName(
+                    "DialogueEventProfileFilterComboBox");
+                Assert.Multiple(() =>
+                {
+                    Assert.That(typeComboBox.IsEnabled, Is.True);
+                    Assert.That(typeComboBox.Items.Count, Is.GreaterThan(0));
+                    Assert.That(profileComboBox.IsEnabled, Is.True);
+                    Assert.That(profileComboBox.Items.Count, Is.GreaterThan(0));
+                });
+                var type = FindPartialType(dialogueEvents.GameSoundBank);
+                var profile = FindPartialProfile(dialogueEvents.GameSoundBank);
+
+                SetSelectedItem(typeComboBox, type);
+                foreach (var branch in dialogueEventBranches)
+                {
+                    AssertDialogueVisibility(
+                        view,
+                        branch,
+                        node => Wh3DialogueEventInformation.Information
+                            .Single(item => item.Name == node.Name)
+                            .DialogueEventTypes.Contains(type));
+                }
+
+                SetSelectedItem(
+                    typeComboBox,
+                    Wh3DialogueEventType.TypeShowAll);
+                SetSelectedItem(profileComboBox, profile);
+                foreach (var branch in dialogueEventBranches)
+                {
+                    AssertDialogueVisibility(
+                        view,
+                        branch,
+                        node => Wh3DialogueEventInformation.Information
+                            .Single(item => item.Name == node.Name)
+                            .UnitProfiles.Contains(profile));
+                }
+
+                Execute(FindButton(view, "ResetFiltersCommand"));
+                foreach (var branch in dialogueEventBranches)
+                    AssertDialogueVisibility(view, branch, _ => true);
+            }
+            finally
+            {
+                viewModel.Dispose();
+                window.Close();
+            }
+        });
+    }
+
+    private static (
+        AudioProjectExplorerViewModel ViewModel,
+        AudioProjectExplorerView View,
+        Window Window) CreateView()
+    {
+        var dialogueDefinitions = Wh3DialogueEventInformation.Information
+            .Where(item => item.SoundBank == Wh3SoundBank.CampaignVO)
+            .ToList();
+        var campaignDialogueSoundBank = new SoundBank(
+            "campaign_vo_test",
+            Wh3SoundBank.CampaignVO,
+            "english(uk)")
+        {
+            DialogueEvents = dialogueDefinitions
+                .Select(item => new DialogueEvent(item.Name))
+                .ToList(),
+        };
+        var battleDialogueSoundBank = new SoundBank(
+            "battle_vo_test",
+            Wh3SoundBank.BattleVO,
+            "english(uk)")
+        {
+            DialogueEvents = Wh3DialogueEventInformation.Information
+                .Where(item => item.SoundBank == Wh3SoundBank.BattleVO)
+                .Select(item => new DialogueEvent(item.Name))
+                .ToList(),
+        };
+        var actionSoundBank = new SoundBank(
+            "battle_individual_magic_test",
+            Wh3SoundBank.BattleIndividualMagic,
+            "sfx");
+        var audioProject = new AudioProjectFile
+        {
+            SoundBanks =
+            [
+                actionSoundBank,
+                campaignDialogueSoundBank,
+                battleDialogueSoundBank
+            ],
+            StateGroups =
+            [
+                StateGroup.CreateForAudioProjectFile("VO_Actor", [])
+            ],
+        };
+        var eventHub = new TestEventHub();
+        var state = new AudioEditorStateService
+        {
+            AudioProject = audioProject,
+            AudioProjectFileName = "audio_test.aproj",
+        };
+        var viewModel = new AudioProjectExplorerViewModel(
+            eventHub,
+            state,
+            new AudioProjectTreeBuilderService(state),
+            new AudioProjectTreeFilterService(state));
+        eventHub.Publish(new AudioProjectLoadedEvent());
+        SetExpanded(viewModel.AudioProjectTree, true);
+
+        var view = new AudioProjectExplorerView
+        {
+            DataContext = viewModel,
+            Width = 900,
+            Height = 700,
+        };
+        var window = new Window
+        {
+            Content = view,
+            Width = 920,
+            Height = 720,
+            ShowActivated = false,
+            ShowInTaskbar = false,
+            WindowStyle = WindowStyle.None,
+            Left = -10000,
+            Top = -10000,
+        };
+        window.Show();
+        window.UpdateLayout();
+        return (viewModel, view, window);
+    }
+
+    private static CheckBox FindCheckBox(
+        DependencyObject root,
+        string bindingPath) =>
+        FindVisualDescendants<CheckBox>(root).Single(checkBox =>
+            BindingOperations.GetBindingExpression(
+                    checkBox,
+                    ToggleButton.IsCheckedProperty)
+                ?.ParentBinding.Path.Path == bindingPath);
+
+    private static Button FindButton(
+        DependencyObject root,
+        string bindingPath) =>
+        FindVisualDescendants<Button>(root).Single(button =>
+            BindingOperations.GetBindingExpression(
+                    button,
+                    ButtonBase.CommandProperty)
+                ?.ParentBinding.Path.Path == bindingPath);
+
+    private static void SetChecked(CheckBox checkBox, bool value)
+    {
+        checkBox.IsChecked = value;
+        checkBox.GetBindingExpression(ToggleButton.IsCheckedProperty)
+            ?.UpdateSource();
+    }
+
+    private static void SetSelectedItem(
+        ComboBox comboBox,
+        object value)
+    {
+        comboBox.SelectedItem = value;
+        comboBox.GetBindingExpression(Selector.SelectedValueProperty)
+            ?.UpdateSource();
+        comboBox.GetBindingExpression(Selector.SelectedItemProperty)
+            ?.UpdateSource();
+    }
+
+    private static void Execute(Button button)
+    {
+        Assert.That(button.Command, Is.Not.Null);
+        button.Command.Execute(button.CommandParameter);
+    }
+
+    private static TreeViewItem FindTreeViewItem(
+        DependencyObject root,
+        AudioProjectTreeNode node)
+    {
+        var treeView = FindVisualDescendants<TreeView>(root).Single();
+        var item = FindTreeViewItem(treeView, node);
+        Assert.That(item, Is.Not.Null);
+        return item!;
+    }
+
+    private static TreeViewItem? FindTreeViewItem(
+        ItemsControl parent,
+        AudioProjectTreeNode target)
+    {
+        parent.ApplyTemplate();
+        parent.UpdateLayout();
+        foreach (var node in parent.Items.OfType<AudioProjectTreeNode>())
+        {
+            var item = parent.ItemContainerGenerator.ContainerFromItem(node)
+                as TreeViewItem;
+            if (item == null)
+                continue;
+            if (ReferenceEquals(node, target))
+                return item;
+
+            item.IsExpanded = true;
+            item.ApplyTemplate();
+            item.UpdateLayout();
+            var child = FindTreeViewItem(item, target);
+            if (child != null)
+                return child;
+        }
+
+        return null;
+    }
+
+    private static void AssertDialogueVisibility(
+        AudioProjectExplorerView view,
+        AudioProjectTreeNode dialogueEvents,
+        Func<AudioProjectTreeNode, bool> expectedVisibility)
+    {
+        FlushBindings(view);
+        foreach (var node in dialogueEvents.Children)
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(node.IsVisible, Is.EqualTo(expectedVisibility(node)));
+                Assert.That(
+                    FindTreeViewItem(view, node).Visibility,
+                    Is.EqualTo(expectedVisibility(node)
+                        ? Visibility.Visible
+                        : Visibility.Collapsed));
+            });
+        }
+    }
+
+    private static void FlushBindings(FrameworkElement view)
+    {
+        view.Dispatcher.Invoke(
+            () => { },
+            DispatcherPriority.DataBind);
+        view.UpdateLayout();
+    }
+
+    private static Wh3DialogueEventType FindPartialType(
+        Wh3SoundBank soundBank) =>
+        Enum.GetValues<Wh3DialogueEventType>()
+            .Where(type => type != Wh3DialogueEventType.TypeShowAll)
+            .First(type =>
+            {
+                var matches = Wh3DialogueEventInformation.Information
+                    .Count(item => item.SoundBank == soundBank &&
+                        item.DialogueEventTypes.Contains(type));
+                var total = Wh3DialogueEventInformation.Information
+                    .Count(item => item.SoundBank == soundBank);
+                return matches > 0 && matches < total;
+            });
+
+    private static Wh3DialogueEventUnitProfile FindPartialProfile(
+        Wh3SoundBank soundBank) =>
+        Enum.GetValues<Wh3DialogueEventUnitProfile>()
+            .Where(profile => profile !=
+                Wh3DialogueEventUnitProfile.ProfileShowAll)
+            .First(profile =>
+            {
+                var matches = Wh3DialogueEventInformation.Information
+                    .Count(item => item.SoundBank == soundBank &&
+                        item.UnitProfiles.Contains(profile));
+                var total = Wh3DialogueEventInformation.Information
+                    .Count(item => item.SoundBank == soundBank);
+                return matches > 0 && matches < total;
+            });
+
+    private static IEnumerable<AudioProjectTreeNode> Flatten(
+        IEnumerable<AudioProjectTreeNode> nodes)
+    {
+        foreach (var node in nodes)
+        {
+            yield return node;
+            foreach (var child in Flatten(node.Children))
+                yield return child;
+        }
+    }
+
+    private static void SetExpanded(
+        IEnumerable<AudioProjectTreeNode> nodes,
+        bool value)
+    {
+        foreach (var node in Flatten(nodes))
+            node.IsExpanded = value;
+    }
+
+    private static IEnumerable<T> FindVisualDescendants<T>(
+        DependencyObject root)
+        where T : DependencyObject
+    {
+        for (var index = 0;
+             index < VisualTreeHelper.GetChildrenCount(root);
+             index++)
+        {
+            var child = VisualTreeHelper.GetChild(root, index);
+            if (child is T match)
+                yield return match;
+            foreach (var descendant in FindVisualDescendants<T>(child))
+                yield return descendant;
+        }
+    }
+}

--- a/Testing/AssetEditorTests/OperationProgressViewTests.cs
+++ b/Testing/AssetEditorTests/OperationProgressViewTests.cs
@@ -1,5 +1,8 @@
 using NUnit.Framework;
 using Microsoft.Extensions.DependencyInjection;
+using Editors.Audio.AudioEditor.Core;
+using Editors.Audio.AudioEditor.Presentation.Settings;
+using Editors.Audio.Shared.Storage;
 using Shared.Core.Services;
 using Shared.Core.Settings;
 using Shared.Ui.Common.OperationProgress;
@@ -10,6 +13,9 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
+using Moq;
+
+using AudioFile = Editors.Audio.Shared.AudioProject.Models.AudioFile;
 
 using Assert = NUnit.Framework.Assert;
 
@@ -22,9 +28,12 @@ public class OperationProgressViewTests
     [
         (["AssetEditor", "Views", "FolderProjectHistory", "FolderProjectHistoryView.xaml"], 1),
         (["AssetEditor", "Views", "MainWindow.xaml"], 1),
+        (["Editors", "AnimationReTarget", "Editors.AnimatioReTarget", "Editor", "Saving", "SaveWindow.xaml"], 1),
         (["Editors", "Audio", "AudioEditor", "Presentation", "NewAudioProject", "NewAudioProjectWindow.xaml"], 1),
         (["Editors", "Audio", "AudioProjectConverter", "AudioProjectConverterWindow.xaml"], 1),
         (["Editors", "Audio", "DialogueEventMerger", "DialogueEventMergerWindow.xaml"], 1),
+        (["Editors", "ImportExportEditor", "Editors.ImportExport", "Exporting", "Presentation", "ExportWindow.xaml"], 1),
+        (["Editors", "ImportExportEditor", "Editors.ImportExport", "Importing", "Presentation", "ImportWindow.xaml"], 1),
         (["Shared", "SharedUI", "BaseDialogs", "PackFileTree", "PackFileBrowserView.xaml"], 1),
     ];
     private static readonly (string[] Path, int HostCount)[] AudioEditorProgressHostSurfaces =
@@ -204,6 +213,29 @@ public class OperationProgressViewTests
                 host.Close();
             }
         });
+    }
+
+    [Test]
+    public void AllOperationProgressWindowHosts_AreInventoried()
+    {
+        var solutionRoot = FindSolutionRoot();
+        var expectedPaths = IndependentProgressHostSurfaces
+            .Concat(AudioEditorProgressHostSurfaces)
+            .Select(item => string.Join(Path.DirectorySeparatorChar, item.Path))
+            .ToArray();
+        var actualPaths = new[] { "AssetEditor", "Editors", "Shared" }
+            .SelectMany(root => Directory.EnumerateFiles(
+                Path.Combine(solutionRoot, root),
+                "*.xaml",
+                SearchOption.AllDirectories))
+            .Where(path => !path.Split(Path.DirectorySeparatorChar)
+                .Any(part => part is "bin" or "obj"))
+            .Where(path => File.ReadAllText(path)
+                .Contains(nameof(OperationProgressWindowHost), StringComparison.Ordinal))
+            .Select(path => Path.GetRelativePath(solutionRoot, path))
+            .ToArray();
+
+        Assert.That(actualPaths, Is.EquivalentTo(expectedPaths));
     }
 
     [Test]
@@ -684,21 +716,124 @@ public class OperationProgressViewTests
     }
 
     [Test]
-    public void PopupLoadingWorkspaces_HideDuplicateInlineStatus()
+    public void AutomaticAudioPreloads_KeepPopupClosedUntilPrimaryActionStarts()
     {
         var solutionRoot = FindSolutionRoot();
+        var converter = File.ReadAllText(Path.Combine(
+            solutionRoot,
+            "Editors",
+            "Audio",
+            "AudioProjectConverter",
+            "AudioProjectConverterWindow.xaml"));
         var dialogueMerger = File.ReadAllText(Path.Combine(
             solutionRoot,
             "Editors",
             "Audio",
             "DialogueEventMerger",
             "DialogueEventMergerWindow.xaml"));
+        var audioEditor = File.ReadAllText(Path.Combine(
+            solutionRoot,
+            "Editors",
+            "Audio",
+            "AudioEditor",
+            "Presentation",
+            "AudioEditorView.xaml"));
+        var audioExplorer = File.ReadAllText(Path.Combine(
+            solutionRoot,
+            "Editors",
+            "Audio",
+            "AudioExplorer",
+            "AudioExplorerView.xaml"));
 
         Assert.Multiple(() =>
         {
             Assert.That(
+                converter,
+                Does.Contain(
+                    "IsOperationActive=\"{Binding IsProcessing}\""));
+            Assert.That(
+                converter,
+                Does.Contain(
+                    "Binding=\"{Binding IsProcessing}\" Value=\"True\""));
+            Assert.That(
                 dialogueMerger,
-                Does.Contain("Binding=\"{Binding IsBusy}\" Value=\"True\""));
+                Does.Contain(
+                    "IsOperationActive=\"{Binding IsGenerating}\""));
+            Assert.That(
+                dialogueMerger,
+                Does.Contain(
+                    "Binding=\"{Binding IsGenerating}\" Value=\"True\""));
+            Assert.That(
+                audioEditor,
+                Does.Contain(
+                    "IsOperationActive=\"{Binding IsLoadProgressWindowActive}\""));
+            Assert.That(
+                audioExplorer,
+                Does.Contain(
+                    "IsOperationActive=\"{Binding IsLoadProgressWindowActive}\""));
+        });
+    }
+
+    [Test]
+    public void AudioSettingsFileList_RendersFileNameAndPathColumns()
+    {
+        InvokeWithWpfApplication(() =>
+        {
+            var viewModel = new SettingsViewModel(
+                new TestEventHub(),
+                new AudioEditorStateService(),
+                Mock.Of<IAudioRepository>())
+            {
+                IsSettingsVisible = true,
+            };
+            viewModel.AudioFiles.Add(new AudioFile(
+                Guid.NewGuid(),
+                1,
+                "cathay_alchemist1_attack.wav",
+                @"audio\audio_wav\cathay_alchemist1_attack.wav"));
+            var view = new SettingsView
+            {
+                DataContext = viewModel,
+                Width = 900,
+                Height = 500,
+            };
+            var window = new Window
+            {
+                Content = view,
+                Width = 920,
+                Height = 520,
+                ShowActivated = false,
+                ShowInTaskbar = false,
+                WindowStyle = WindowStyle.None,
+                Left = -10000,
+                Top = -10000,
+            };
+            try
+            {
+                window.Show();
+                window.UpdateLayout();
+                var renderedText = FindVisualDescendants<TextBlock>(view)
+                    .Select(textBlock => textBlock.Text)
+                    .ToArray();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(
+                        renderedText,
+                        Does.Contain("cathay_alchemist1_attack.wav"));
+                    Assert.That(
+                        renderedText,
+                        Does.Contain(
+                            @"audio\audio_wav\cathay_alchemist1_attack.wav"));
+                    Assert.That(
+                        renderedText,
+                        Has.None.EqualTo(typeof(AudioFile).FullName));
+                });
+            }
+            finally
+            {
+                window.Close();
+            }
         });
     }
 
@@ -774,6 +909,26 @@ public class OperationProgressViewTests
         }
 
         return null;
+    }
+
+    private static IEnumerable<T> FindVisualDescendants<T>(
+        DependencyObject root)
+        where T : DependencyObject
+    {
+        for (var index = 0;
+             index < VisualTreeHelper.GetChildrenCount(root);
+             index++)
+        {
+            var child = VisualTreeHelper.GetChild(root, index);
+            if (child is T match)
+                yield return match;
+
+            foreach (var descendant in
+                     FindVisualDescendants<T>(child))
+            {
+                yield return descendant;
+            }
+        }
     }
 
     private static void PumpDispatcher(TimeSpan duration)


### PR DESCRIPTION
## Summary

- make audio loading progress dialogs appear only after the user confirms the initiating file or project selection
- prevent detached edited rows from being read after removal and restore the audio file name/path display
- make every audio-project filter and reset control affect the rendered tree
- preserve the original persisted meaning of “仅显示已编辑项”, so saved edits remain visible after reopening the project

## Root cause

The progress popups were bound to broad busy states that became active before modal selection dialogs completed. The audio-project tree also replaced its local container style with the shared `AeTree.Item` style, so `IsVisible` and `IsExpanded` changes never reached the rendered `TreeViewItem`. A removed `DataRow` could still be queried while edit mode was active.

## Validation

- user acceptance testing completed successfully
- `dotnet test Testing/AssetEditorTests/AssetEditorTests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~AudioEditorViewModelTests|FullyQualifiedName~AudioProjectExplorerInteractionTests" --verbosity minimal`
- result: 20 passed, 0 failed, 0 skipped
- `git diff --check` passed
