### PR TITLE
Refine UI surfaces and keyboard focus

### DIFF
--- a/AssetEditor/Themes/Controls.xaml
+++ b/AssetEditor/Themes/Controls.xaml
@@ -213,7 +213,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="3" />
         <Setter Property="AllowDrop" Value="true" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="WatermarkTemplate" Value="{StaticResource DefaultWatermarkTemplate}" />
@@ -481,7 +481,7 @@
                             <Setter Property="AllowDrop" Value="True" />
                             <Setter Property="MinWidth" Value="0" />
                             <Setter Property="MinHeight" Value="0" />
-                            <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
                             <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
                             <Setter Property="Template">
                                 <Setter.Value>
@@ -572,24 +572,7 @@
     </ControlTemplate>
 
     <Style x:Key="WatermarkComboBox" TargetType="{x:Type extendedwpftoolkit:WatermarkComboBox}">
-        <Setter Property="FocusVisualStyle">
-            <Setter.Value>
-                <Style>
-                    <Setter Property="Control.Template">
-                        <Setter.Value>
-                            <ControlTemplate>
-                                <Rectangle 
-                                    Margin="2"
-                                    SnapsToDevicePixels="True"
-                                    Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
-                                    StrokeThickness="1"
-                                    StrokeDashArray="1 2" />
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Background" Value="{DynamicResource TextBox.Static.Background}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextBox.Static.Border}" />
         <Setter Property="Foreground" Value="{DynamicResource ABrush.Foreground.Static}" />
@@ -731,7 +714,7 @@
 
     <Style x:Key="SpinnerButtonStyleKey"
        TargetType="RepeatButton">
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Padding" Value="2,2" />
         <Setter Property="Template">
@@ -1093,7 +1076,7 @@
     </ControlTemplate>
 
     <Style x:Key="NoBackgroundOnDisabledButton" TargetType="{x:Type Button}">
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Background" Value="{DynamicResource Button.Static.Background}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource Button.Static.Border}"/>
         <Setter Property="Foreground" Value="{DynamicResource Button.Static.Foreground}"/>
@@ -1158,7 +1141,7 @@
     </Style>
 
     <Style TargetType="{x:Type Button}">
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Background" Value="{DynamicResource Button.Static.Background}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource Button.Static.Border}"/>
         <Setter Property="Foreground" Value="{DynamicResource Button.Static.Foreground}"/>
@@ -1223,7 +1206,7 @@
     </Style>
 
     <Style TargetType="{x:Type ToggleButton}">
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Background" Value="{DynamicResource Button.Static.Background}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource Button.Static.Border}"/>
         <Setter Property="Foreground" Value="{DynamicResource Button.Static.Foreground}"/>
@@ -1420,9 +1403,6 @@
             <Trigger Property="IsSelectionRangeEnabled" Value="true">
                 <Setter Property="Visibility" TargetName="PART_SelectionRange" Value="Visible"/>
             </Trigger>
-            <Trigger Property="IsKeyboardFocused" Value="true">
-                <Setter Property="Foreground" TargetName="Thumb" Value="Blue"/>
-            </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
@@ -1471,9 +1451,6 @@
             </Trigger>
             <Trigger Property="IsSelectionRangeEnabled" Value="true">
                 <Setter Property="Visibility" TargetName="PART_SelectionRange" Value="Visible"/>
-            </Trigger>
-            <Trigger Property="IsKeyboardFocused" Value="true">
-                <Setter Property="Foreground" TargetName="Thumb" Value="Blue"/>
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
@@ -1581,9 +1558,6 @@
             <Trigger Property="IsSelectionRangeEnabled" Value="true">
                 <Setter Property="Visibility" TargetName="PART_SelectionRange" Value="Visible"/>
             </Trigger>
-            <Trigger Property="IsKeyboardFocused" Value="true">
-                <Setter Property="Foreground" TargetName="Thumb" Value="Blue"/>
-            </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
@@ -1592,6 +1566,7 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="Foreground" Value="{DynamicResource SliderThumb.Static.Foreground}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Template" Value="{StaticResource SliderHorizontal}"/>
         <Style.Triggers>
             <Trigger Property="Orientation" Value="Vertical">
@@ -1690,7 +1665,7 @@
     </Style>
 
     <Style x:Key="ScrollBarButton" TargetType="{x:Type RepeatButton}">
-        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Background" Value="{DynamicResource ScrollBarButton.Static.Background}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource ScrollBarButton.Static.Border}"/>
         <Setter Property="BorderThickness" Value="1"/>
@@ -2262,7 +2237,7 @@
     </Style>
 
     <Style TargetType="{x:Type CheckBox}">
-        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Background" Value="{DynamicResource OptionMark.Static.Background}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource OptionMark.Static.Border}"/>
         <Setter Property="Foreground" Value="{DynamicResource ABrush.Foreground.Static}"/>
@@ -2288,7 +2263,7 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="HasContent" Value="true">
-                            <Setter Property="FocusVisualStyle" Value="{StaticResource OptionMarkFocusVisual}"/>
+                            <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
                             <Setter Property="Padding" Value="4,-1,0,0"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
@@ -2324,7 +2299,7 @@
     </Style>
 
     <Style TargetType="{x:Type RadioButton}">
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Background" Value="{DynamicResource RadioButton.Static.Background}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource RadioButton.Static.Border}"/>
         <Setter Property="Foreground" Value="{DynamicResource ABrush.Foreground.Static}"/>
@@ -2443,7 +2418,7 @@
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="KeyboardNavigation.TabNavigation" Value="None"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="AllowDrop" Value="true"/>
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
         <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
@@ -2461,9 +2436,6 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
                             <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.MouseOver.Border}"/>
-                        </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="true">
-                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.Focus.Border}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2531,7 +2503,7 @@
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="KeyboardNavigation.TabNavigation" Value="None"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="AllowDrop" Value="true"/>
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
         <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
@@ -2547,9 +2519,6 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
                             <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.MouseOver.Border}"/>
-                        </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="true">
-                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.Focus.Border}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2576,7 +2545,7 @@
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="KeyboardNavigation.TabNavigation" Value="None"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="AllowDrop" Value="true"/>
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
         <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
@@ -2625,9 +2594,6 @@
                         <Trigger Property="IsMouseOver" Value="true">
                             <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.MouseOver.Border}"/>
                         </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="true">
-                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.Focus.Border}"/>
-                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -2651,7 +2617,7 @@
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="KeyboardNavigation.TabNavigation" Value="None"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="AllowDrop" Value="true"/>
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
         <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
@@ -2701,9 +2667,6 @@
                         <Trigger Property="IsMouseOver" Value="true">
                             <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.MouseOver.Border}"/>
                         </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="true">
-                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.Focus.Border}"/>
-                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -2727,7 +2690,7 @@
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="KeyboardNavigation.TabNavigation" Value="None"/>
         <Setter Property="HorizontalContentAlignment" Value="Left"/>
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="AllowDrop" Value="true"/>
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
         <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
@@ -2743,9 +2706,6 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
                             <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.MouseOver.Border}"/>
-                        </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="true">
-                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource TextBox.Focus.Border}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -2981,7 +2941,7 @@
                 <ControlTemplate TargetType="{x:Type Expander}">
                     <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="0" SnapsToDevicePixels="true">
                         <DockPanel >
-                            <ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FocusVisualStyle="{x:Null}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="0" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{StaticResource ExpanderDownHeaderWithBorderBackgroundStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                            <ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FocusVisualStyle="{StaticResource AeFocus.Keyboard}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="0" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{StaticResource ExpanderDownHeaderWithBorderBackgroundStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
                             <Border BorderBrush="{DynamicResource Button.Static.Border}" BorderThickness="1, 1, 1, 0" >
                                 <ContentPresenter x:Name="ExpandSite" DockPanel.Dock="Bottom" Focusable="false" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" Visibility="Collapsed" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                             </Border>
@@ -3012,7 +2972,7 @@
                 <ControlTemplate TargetType="{x:Type Expander}">
                     <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" CornerRadius="3" SnapsToDevicePixels="true">
                         <DockPanel>
-                            <ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FocusVisualStyle="{x:Null}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="1" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{StaticResource ExpanderDownHeaderStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                            <ToggleButton x:Name="HeaderSite" ContentTemplate="{TemplateBinding HeaderTemplate}" ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" Content="{TemplateBinding Header}" DockPanel.Dock="Top" Foreground="{TemplateBinding Foreground}" FontWeight="{TemplateBinding FontWeight}" FocusVisualStyle="{StaticResource AeFocus.Keyboard}" FontStyle="{TemplateBinding FontStyle}" FontStretch="{TemplateBinding FontStretch}" FontSize="{TemplateBinding FontSize}" FontFamily="{TemplateBinding FontFamily}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="1" MinWidth="0" MinHeight="0" Padding="{TemplateBinding Padding}" Style="{StaticResource ExpanderDownHeaderStyle}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
                             <ContentPresenter x:Name="ExpandSite" DockPanel.Dock="Bottom" Focusable="false" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" Visibility="Collapsed" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                         </DockPanel>
                     </Border>
@@ -3051,7 +3011,7 @@
         <Setter Property="AllowDrop" Value="true"/>
         <Setter Property="MinWidth" Value="0"/>
         <Setter Property="MinHeight" Value="0"/>
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
         <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
         <Setter Property="Template">
@@ -3231,9 +3191,6 @@
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Opacity" TargetName="border" Value="0.56"/>
             </Trigger>
-            <Trigger Property="IsKeyboardFocusWithin" Value="true">
-                <Setter Property="Foreground" Value="Orange"/>
-            </Trigger>
             <Trigger Property="HasDropShadow" SourceName="PART_Popup" Value="true">
                 <Setter Property="Margin" TargetName="shadow" Value="0,0,5,5"/>
                 <Setter Property="Color" TargetName="shadow" Value="#71000000"/>
@@ -3264,7 +3221,7 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ComboBoxItem}">
@@ -3275,24 +3232,14 @@
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="TextElement.Foreground" TargetName="Bd" Value="{DynamicResource ABrush.Foreground.Disabled}"/>
                         </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsSelected" Value="False"/>
-                                <Condition Property="IsMouseOver" Value="True"/>
-                                <Condition Property="IsKeyboardFocused" Value="False"/>
-                            </MultiTrigger.Conditions>
+                        <Trigger Property="IsMouseOver" Value="True">
                             <Setter Property="Background" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.Hover.Background}"/>
                             <Setter Property="BorderBrush" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.Hover.Border}"/>
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsSelected" Value="True"/>
-                                <Condition Property="IsMouseOver" Value="False"/>
-                                <Condition Property="IsKeyboardFocused" Value="True"/>
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Background" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.Selected.Background}"/>
-                            <Setter Property="BorderBrush" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.Selected.Border}"/>
-                        </MultiTrigger>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter Property="Background" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.SelectedNoFocus.Background}"/>
+                            <Setter Property="BorderBrush" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.SelectedNoFocus.Border}"/>
+                        </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="IsSelected" Value="True"/>
@@ -3301,32 +3248,6 @@
                             <Setter Property="Background" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.SelectedHover.Background}"/>
                             <Setter Property="BorderBrush" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.SelectedHover.Border}"/>
                         </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsSelected" Value="True"/>
-                                <Condition Property="IsMouseOver" Value="False"/>
-                                <Condition Property="IsKeyboardFocused" Value="False"/>
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Background" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.SelectedNoFocus.Background}"/>
-                            <Setter Property="BorderBrush" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.SelectedNoFocus.Border}"/>
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsSelected" Value="False"/>
-                                <Condition Property="IsMouseOver" Value="False"/>
-                                <Condition Property="IsKeyboardFocused" Value="True"/>
-                            </MultiTrigger.Conditions>
-                            <Setter Property="BorderBrush" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.Focus.Border}"/>
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsSelected" Value="False"/>
-                                <Condition Property="IsMouseOver" Value="True"/>
-                                <Condition Property="IsKeyboardFocused" Value="True"/>
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Background" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.HoverFocus.Background}"/>
-                            <Setter Property="BorderBrush" TargetName="Bd" Value="{DynamicResource ComboBoxItem.ItemView.HoverFocus.Border}"/>
-                        </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -3334,7 +3255,7 @@
     </Style>
 
     <Style TargetType="{x:Type ComboBox}">
-        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Background" Value="{DynamicResource ComboBox.Static.Background}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource ComboBox.Static.Border}"/>
         <Setter Property="Foreground" Value="{DynamicResource ComboBox.Static.Foreground}"/>
@@ -3471,7 +3392,7 @@
     </Style>
 
     <Style x:Key="{ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}" TargetType="{x:Type Button}">
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
@@ -3652,13 +3573,7 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="FocusVisualStyle">
-            <Setter.Value>
-                <Style TargetType="FrameworkElement">
-                    <Setter Property="Visibility" Value="Collapsed"/>
-                </Style>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
@@ -3765,7 +3680,7 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
@@ -3858,7 +3773,7 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListViewItem}">
@@ -3951,7 +3866,7 @@
         <Setter Property="MinWidth" Value="0"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
@@ -3983,9 +3898,6 @@
                         <Trigger Property="IsMouseOver" Value="true">
                             <Setter Property="Stroke" TargetName="Chevron" Value="{DynamicResource AeBrush.AccentHover}"/>
                         </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="true">
-                            <Setter Property="Stroke" TargetName="Chevron" Value="{DynamicResource AeBrush.AccentHover}"/>
-                        </Trigger>
                         <Trigger Property="IsChecked" Value="true">
                             <Setter Property="Stroke" TargetName="Chevron" Value="{DynamicResource AeBrush.Accent}"/>
                         </Trigger>
@@ -4004,7 +3916,7 @@
         <Setter Property="MinWidth" Value="0"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
@@ -4034,9 +3946,6 @@
                             </Trigger.ExitActions>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Stroke" TargetName="Chevron" Value="{DynamicResource AeBrush.AccentHover}"/>
-                        </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="true">
                             <Setter Property="Stroke" TargetName="Chevron" Value="{DynamicResource AeBrush.AccentHover}"/>
                         </Trigger>
                         <Trigger Property="IsChecked" Value="true">
@@ -4090,7 +3999,7 @@
     </Style>
 
     <Style x:Key="ToolBarButtonBaseStyle" TargetType="{x:Type ButtonBase}">
-        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Background" Value="{DynamicResource Button.Static.Background}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource Button.Static.Border}"/>
         <Setter Property="Foreground" Value="{DynamicResource Button.Static.Foreground}"/>
@@ -4148,7 +4057,7 @@
                 <ControlTemplate TargetType="{x:Type ToolBar}">
                     <Grid x:Name="Grid" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="true">
                         <Grid x:Name="OverflowGrid" HorizontalAlignment="Right">
-                            <ToggleButton x:Name="OverflowButton" ClickMode="Press" FocusVisualStyle="{x:Null}"
+                            <ToggleButton x:Name="OverflowButton" ClickMode="Press" FocusVisualStyle="{StaticResource AeFocus.Keyboard}"
                                           IsChecked="{Binding IsOverflowOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                           IsEnabled="{TemplateBinding HasOverflowItems}" Style="{StaticResource ToolBarHorizontalOverflowButtonStyle}"/>
                             <Popup x:Name="OverflowPopup" AllowsTransparency="true" Focusable="false"
@@ -4159,7 +4068,7 @@
                                     <Border x:Name="ToolBarSubMenuBorder" BorderBrush="{DynamicResource ToolBarMenuBorder}"
                                             BorderThickness="1" Background="{DynamicResource ToolBarSubMenuBackground}" RenderOptions.ClearTypeHint="Enabled">
                                         <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel" KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                              FocusVisualStyle="{x:Null}" Focusable="true" Margin="2"
+                                                              FocusVisualStyle="{StaticResource AeFocus.Keyboard}" Focusable="true" Margin="2"
                                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                               KeyboardNavigation.TabNavigation="Cycle" WrapWidth="200"/>
                                     </Border>
@@ -4220,7 +4129,7 @@
     </Style>
 
     <Style TargetType="{x:Type TabItem}">
-        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Foreground" Value="{DynamicResource ABrush.Foreground.Static}"/>
         <Setter Property="Background" Value="{DynamicResource TabItem.Static.Background}"/>
         <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=TabControl}, Path=BorderBrush}"/>
@@ -4370,7 +4279,7 @@
     </Style>
 
     <Style x:Key="NoOffsetTabItem" TargetType="{x:Type TabItem}">
-        <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Foreground" Value="{DynamicResource ABrush.Foreground.Static}"/>
         <Setter Property="Background" Value="{DynamicResource TabItem.Static.Background}"/>
         <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=TabControl}, Path=BorderBrush}"/>
@@ -5010,7 +4919,7 @@
         <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}, FallbackValue=Center}"/>
         <Setter Property="Padding" Value="1,0,0,0"/>
         <Setter Property="Foreground" Value="{DynamicResource ABrush.Foreground.Static}"/>
-        <Setter Property="FocusVisualStyle" Value="{StaticResource TreeViewItemFocusVisual}"/>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TreeViewItem}">

--- a/AssetEditor/Themes/DesignSystem/Controls/Buttons.xaml
+++ b/AssetEditor/Themes/DesignSystem/Controls/Buttons.xaml
@@ -2,20 +2,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:materialIcons="clr-namespace:Material.Icons.WPF;assembly=Material.Icons.WPF">
-    <Style x:Key="AeButton.KeyboardFocusVisual" TargetType="{x:Type Control}">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type Control}">
-                    <Border
-                        Margin="-2"
-                        BorderBrush="{DynamicResource AeBrush.Accent}"
-                        BorderThickness="2"
-                        CornerRadius="{StaticResource AeRadius.Surface}" />
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
     <Style x:Key="AeButton.Base" TargetType="{x:Type Button}">
         <Setter Property="MinWidth" Value="64" />
         <Setter Property="Height" Value="{StaticResource AeSize.ControlHeight}" />
@@ -29,7 +15,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
@@ -168,7 +154,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
@@ -212,12 +198,6 @@
                                 Property="Foreground"
                                 Value="{DynamicResource AeBrush.AccentHover}" />
                         </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter
-                                TargetName="Glyph"
-                                Property="Foreground"
-                                Value="{DynamicResource AeBrush.Accent}" />
-                        </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="Glyph" Property="Opacity" Value="0.45" />
                         </Trigger>
@@ -235,7 +215,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">

--- a/AssetEditor/Themes/DesignSystem/Controls/Collections.xaml
+++ b/AssetEditor/Themes/DesignSystem/Controls/Collections.xaml
@@ -8,7 +8,7 @@
         <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextSecondary}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">
@@ -26,13 +26,6 @@
                             VerticalAlignment="Bottom"
                             Background="{DynamicResource AeBrush.Accent}"
                             Visibility="Collapsed" />
-                        <Border
-                            x:Name="FocusRing"
-                            Margin="2"
-                            BorderBrush="{DynamicResource AeBrush.Accent}"
-                            BorderThickness="1"
-                            CornerRadius="{StaticResource AeRadius.Compact}"
-                            Visibility="Collapsed" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
@@ -43,9 +36,6 @@
                             <Setter Property="Background" Value="{DynamicResource AeBrush.Surface2}" />
                             <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextPrimary}" />
                             <Setter TargetName="SelectionLine" Property="Visibility" Value="Visible" />
-                        </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter TargetName="FocusRing" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.48" />
@@ -76,7 +66,7 @@
         <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextSecondary}" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TreeViewItem}">
@@ -174,9 +164,6 @@
                             <Setter TargetName="Row" Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
                             <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextPrimary}" />
                         </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter TargetName="Row" Property="BorderBrush" Value="{DynamicResource AeBrush.Accent}" />
-                        </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.48" />
                         </Trigger>
@@ -204,7 +191,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
@@ -227,9 +214,6 @@
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="Row" Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
                             <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextPrimary}" />
-                        </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter TargetName="Row" Property="BorderBrush" Value="{DynamicResource AeBrush.Accent}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.48" />
@@ -267,7 +251,7 @@
         <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextSecondary}" />
         <Setter Property="BorderBrush" Value="{DynamicResource AeBrush.Border}" />
         <Setter Property="BorderThickness" Value="0,0,0,1" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Background" Value="{DynamicResource AeBrush.SurfaceHover}" />
@@ -275,9 +259,6 @@
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
                 <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextPrimary}" />
-            </Trigger>
-            <Trigger Property="IsKeyboardFocusWithin" Value="True">
-                <Setter Property="BorderBrush" Value="{DynamicResource AeBrush.Accent}" />
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -287,13 +268,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-        <Style.Triggers>
-            <Trigger Property="IsKeyboardFocusWithin" Value="True">
-                <Setter Property="BorderBrush" Value="{DynamicResource AeBrush.Accent}" />
-                <Setter Property="BorderThickness" Value="1" />
-            </Trigger>
-        </Style.Triggers>
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
     </Style>
 
     <Style x:Key="AeTable.Grid" TargetType="{x:Type DataGrid}">

--- a/AssetEditor/Themes/DesignSystem/Controls/Inputs.xaml
+++ b/AssetEditor/Themes/DesignSystem/Controls/Inputs.xaml
@@ -40,7 +40,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CaretBrush" Value="{DynamicResource AeBrush.TextPrimary}" />
         <Setter Property="SelectionBrush" Value="{DynamicResource AeBrush.AccentSoft}" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 
@@ -56,7 +56,7 @@
         <Setter Property="Background" Value="{DynamicResource AeBrush.Surface2}" />
         <Setter Property="BorderBrush" Value="{DynamicResource AeBrush.BorderStrong}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="ItemContainerStyle">
             <Setter.Value>
@@ -107,7 +107,7 @@
                             Content="{TemplateBinding Header}"
                             ContentTemplate="{TemplateBinding HeaderTemplate}"
                             ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
-                            FocusVisualStyle="{x:Null}"
+                            FocusVisualStyle="{StaticResource AeFocus.Keyboard}"
                             HorizontalContentAlignment="Stretch"
                             IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
                             <ToggleButton.Template>
@@ -194,7 +194,7 @@
         <Setter Property="MinHeight" Value="24" />
         <Setter Property="HorizontalAlignment" Value="Left" />
         <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextSecondary}" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type CheckBox}">
@@ -239,10 +239,6 @@
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Box" Property="BorderBrush" Value="{DynamicResource AeBrush.AccentHover}" />
                         </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter TargetName="Box" Property="BorderThickness" Value="2" />
-                            <Setter TargetName="Box" Property="BorderBrush" Value="{DynamicResource AeBrush.Accent}" />
-                        </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.48" />
                         </Trigger>
@@ -255,7 +251,7 @@
     <Style x:Key="AeInput.RadioButton" TargetType="{x:Type RadioButton}">
         <Setter Property="MinHeight" Value="24" />
         <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextSecondary}" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RadioButton}">
@@ -305,9 +301,6 @@
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Ring" Property="BorderBrush" Value="{DynamicResource AeBrush.AccentHover}" />
                         </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter TargetName="Ring" Property="BorderThickness" Value="2" />
-                        </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.48" />
                         </Trigger>
@@ -323,7 +316,7 @@
         <Setter Property="Background" Value="{DynamicResource AeBrush.Surface3}" />
         <Setter Property="BorderBrush" Value="{DynamicResource AeBrush.BorderStrong}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">

--- a/AssetEditor/Themes/DesignSystem/Controls/MenusAndFeedback.xaml
+++ b/AssetEditor/Themes/DesignSystem/Controls/MenusAndFeedback.xaml
@@ -212,7 +212,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template" Value="{StaticResource AeMenu.SubmenuItemTemplate}" />
         <Style.Triggers>
             <Trigger Property="Role" Value="TopLevelHeader">
@@ -225,10 +225,6 @@
                 <Setter Property="StaysOpenOnClick" Value="True" />
             </Trigger>
             <Trigger Property="IsHighlighted" Value="True">
-                <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextPrimary}" />
-            </Trigger>
-            <Trigger Property="IsKeyboardFocused" Value="True">
-                <Setter Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
                 <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextPrimary}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">

--- a/AssetEditor/Themes/DesignSystem/Shell.xaml
+++ b/AssetEditor/Themes/DesignSystem/Shell.xaml
@@ -10,7 +10,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
@@ -27,14 +27,6 @@
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <Border
-                            x:Name="FocusRing"
-                            Margin="3"
-                            BorderBrush="{DynamicResource AeBrush.Accent}"
-                            BorderThickness="1"
-                            CornerRadius="{StaticResource AeRadius.Compact}"
-                            IsHitTestVisible="False"
-                            Visibility="Collapsed" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
@@ -45,9 +37,6 @@
                             <Setter Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
                             <Setter Property="Foreground" Value="{DynamicResource AeBrush.Accent}" />
                             <Setter TargetName="SelectionIndicator" Property="Visibility" Value="Visible" />
-                        </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter TargetName="FocusRing" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.42" />
@@ -227,15 +216,12 @@
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Cursor" Value="SizeWE" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="ResizeBehavior" Value="PreviousAndNext" />
         <Setter Property="ResizeDirection" Value="Columns" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
-            </Trigger>
-            <Trigger Property="IsKeyboardFocused" Value="True">
-                <Setter Property="Background" Value="{DynamicResource AeBrush.Accent}" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/AssetEditor/Themes/DesignSystem/SurfaceStyles.xaml
+++ b/AssetEditor/Themes/DesignSystem/SurfaceStyles.xaml
@@ -23,4 +23,18 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="{StaticResource AeRadius.Overlay}" />
     </Style>
+    <Style x:Key="AeFocus.Keyboard" TargetType="{x:Type Control}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Control}">
+                    <Border
+                        Margin="-1"
+                        BorderBrush="{DynamicResource AeBrush.Accent}"
+                        BorderThickness="1"
+                        CornerRadius="{StaticResource AeRadius.Control}"
+                        SnapsToDevicePixels="True" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/AssetEditor/Themes/DesignSystem/Workflows.xaml
+++ b/AssetEditor/Themes/DesignSystem/Workflows.xaml
@@ -11,7 +11,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabItem}">
@@ -35,14 +35,6 @@
                             VerticalAlignment="Center"
                             ContentSource="Header"
                             RecognizesAccessKey="True" />
-                        <Border
-                            x:Name="FocusRing"
-                            Margin="4,3"
-                            BorderBrush="{DynamicResource AeBrush.Accent}"
-                            BorderThickness="1"
-                            CornerRadius="{StaticResource AeRadius.Compact}"
-                            IsHitTestVisible="False"
-                            Visibility="Collapsed" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
@@ -66,9 +58,6 @@
                             <Setter Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
                             <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextPrimary}" />
                             <Setter TargetName="SelectionIndicator" Property="Visibility" Value="Visible" />
-                        </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter TargetName="FocusRing" Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.42" />

--- a/AssetEditor/Views/ExternalPack/ExternalPackOpenChoiceWindow.xaml
+++ b/AssetEditor/Views/ExternalPack/ExternalPackOpenChoiceWindow.xaml
@@ -19,31 +19,26 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Border
-            Margin="16,16,16,12"
-            Padding="16"
-            Style="{StaticResource AeSurface.Panel}">
-            <StackPanel>
-                <TextBlock
-                    Style="{StaticResource AeText.SectionTitle}"
-                    Text="{loc:Loc ExternalPack.Open.Heading}" />
-                <TextBlock
-                    Margin="0,8,0,16"
-                    Text="{loc:Loc ExternalPack.Open.Description}"
-                    TextWrapping="Wrap" />
-                <TextBlock
-                    Margin="0,0,0,8"
-                    Foreground="{DynamicResource AeBrush.TextSecondary}"
-                    Style="{StaticResource AeText.Caption}"
-                    Text="{loc:Loc ExternalPack.Open.PathLabel}" />
-                <TextBox
-                    x:Name="PackPathTextBox"
-                    Height="30"
-                    IsReadOnly="True"
-                    Style="{StaticResource AeInput.TextBox}"
-                    VerticalContentAlignment="Center" />
-            </StackPanel>
-        </Border>
+        <StackPanel Margin="32,32,32,16">
+            <TextBlock
+                Style="{StaticResource AeText.SectionTitle}"
+                Text="{loc:Loc ExternalPack.Open.Heading}" />
+            <TextBlock
+                Margin="0,8,0,16"
+                Text="{loc:Loc ExternalPack.Open.Description}"
+                TextWrapping="Wrap" />
+            <TextBlock
+                Margin="0,0,0,8"
+                Foreground="{DynamicResource AeBrush.TextSecondary}"
+                Style="{StaticResource AeText.Caption}"
+                Text="{loc:Loc ExternalPack.Open.PathLabel}" />
+            <TextBox
+                x:Name="PackPathTextBox"
+                Height="30"
+                IsReadOnly="True"
+                Style="{StaticResource AeInput.TextBox}"
+                VerticalContentAlignment="Center" />
+        </StackPanel>
 
         <Border
             Grid.Row="1"

--- a/AssetEditor/Views/FolderProject/FolderProjectSetupWindow.xaml
+++ b/AssetEditor/Views/FolderProject/FolderProjectSetupWindow.xaml
@@ -29,13 +29,6 @@
             <ColumnDefinition Width="120" />
         </Grid.ColumnDefinitions>
 
-        <Border
-            Grid.RowSpan="6"
-            Grid.ColumnSpan="3"
-            Margin="18,16,18,10"
-            Padding="16"
-            Style="{StaticResource AeSurface.Panel}" />
-
         <TextBlock
             x:Name="DescriptionTextBlock"
             Grid.ColumnSpan="3"

--- a/Editors/AnimationReTarget/Editors.AnimatioReTarget/Editor/Saving/SaveWindow.xaml
+++ b/Editors/AnimationReTarget/Editors.AnimatioReTarget/Editor/Saving/SaveWindow.xaml
@@ -81,8 +81,9 @@
 
             <Border
                 Margin="0,16,0,0"
-                Padding="12"
-                Style="{StaticResource AeSurface.Panel}">
+                Padding="0,12,0,0"
+                BorderBrush="{DynamicResource AeBrush.Border}"
+                BorderThickness="0,1,0,0">
                 <StackPanel>
                     <TextBlock
                         Style="{StaticResource AeText.SectionTitle}"

--- a/Editors/Kitbashing/KitbasherEditor/KitbashUiStyles.xaml
+++ b/Editors/Kitbashing/KitbasherEditor/KitbashUiStyles.xaml
@@ -29,7 +29,7 @@
         <Setter Property="Height" Value="{StaticResource AeSize.CompactRowHeight}" />
         <Setter Property="Margin" Value="0" />
         <Setter Property="Focusable" Value="True" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type basedialogs:OptionalRadioButton}">
@@ -303,9 +303,6 @@
                             <Setter TargetName="Row" Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
                             <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextPrimary}" />
                         </DataTrigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter TargetName="Row" Property="BorderBrush" Value="{DynamicResource AeBrush.BorderStrong}" />
-                        </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.48" />
                         </Trigger>
@@ -345,7 +342,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RadioButton}">

--- a/Shared/SharedUI/BaseDialogs/OptionalRadioButtonStyle.xaml
+++ b/Shared/SharedUI/BaseDialogs/OptionalRadioButtonStyle.xaml
@@ -11,7 +11,7 @@
         <Setter Property="MinHeight" Value="24" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type baseDialogs:OptionalRadioButton}">
@@ -78,10 +78,6 @@
                         <Trigger Property="IsChecked" Value="True">
                             <Setter TargetName="Ring" Property="Stroke" Value="{DynamicResource AeBrush.Accent}" />
                             <Setter TargetName="Dot" Property="Opacity" Value="1" />
-                        </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter TargetName="Ring" Property="Stroke" Value="{DynamicResource AeBrush.Accent}" />
-                            <Setter TargetName="Ring" Property="StrokeThickness" Value="2" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextMuted}" />

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/ErrorDialog/ErrorListWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/ErrorDialog/ErrorListWindow.xaml
@@ -18,9 +18,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <Border Margin="12" Style="{StaticResource AeSurface.Panel}">
-            <errorlistdialog:ErrorListView />
-        </Border>
+        <errorlistdialog:ErrorListView Margin="12" />
         <Border Grid.Row="1" Style="{StaticResource AeWorkflow.DialogFooter}">
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/ExceptionHandling/CustomExceptionWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/ExceptionHandling/CustomExceptionWindow.xaml
@@ -19,50 +19,46 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Border Margin="12" Style="{StaticResource AeSurface.Panel}">
-            <Grid Margin="14">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <TextBlock
-                    Text="{loc:Loc Shared.CustomException.ErrorMessageLabel}"
-                    Style="{StaticResource AeText.SectionTitle}" />
+        <Grid Margin="26,20,26,12">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <TextBlock
+                Text="{loc:Loc Shared.CustomException.ErrorMessageLabel}"
+                Style="{StaticResource AeText.SectionTitle}" />
+            <TextBox
+                x:Name="ErrorTextHandle"
+                Grid.Row="1"
+                Margin="0,8,0,0"
+                IsReadOnly="True"
+                TextWrapping="Wrap"
+                VerticalScrollBarVisibility="Auto"
+                Style="{StaticResource AeInput.TextBox}" />
+            <Expander
+                Grid.Row="2"
+                Margin="0,10,0,0"
+                Header="{loc:Loc Shared.CustomException.ExtraInfoHeader}"
+                IsExpanded="False">
                 <TextBox
-                    x:Name="ErrorTextHandle"
-                    Grid.Row="1"
+                    x:Name="ExtraInfoHandle"
+                    MinHeight="110"
                     Margin="0,8,0,0"
                     IsReadOnly="True"
-                    TextWrapping="Wrap"
+                    TextWrapping="NoWrap"
+                    HorizontalScrollBarVisibility="Auto"
                     VerticalScrollBarVisibility="Auto"
                     Style="{StaticResource AeInput.TextBox}" />
-                <Expander
-                    Grid.Row="2"
-                    Margin="0,10,0,0"
-                    Header="{loc:Loc Shared.CustomException.ExtraInfoHeader}"
-                    IsExpanded="False">
-                    <TextBox
-                        x:Name="ExtraInfoHandle"
-                        MinHeight="110"
-                        Margin="0,8,0,0"
-                        IsReadOnly="True"
-                        TextWrapping="NoWrap"
-                        HorizontalScrollBarVisibility="Auto"
-                        VerticalScrollBarVisibility="Auto"
-                        Style="{StaticResource AeInput.TextBox}" />
-                </Expander>
-            </Grid>
-        </Border>
+            </Expander>
+        </Grid>
 
         <Border
             Grid.Row="1"
-            Margin="12,0,12,12"
-            Padding="12"
-            Background="{DynamicResource AeBrush.Surface1}"
+            Margin="26,0,26,12"
+            Padding="0,10,0,0"
             BorderBrush="{DynamicResource AeBrush.Border}"
-            BorderThickness="1"
-            CornerRadius="{StaticResource AeRadius.Control}">
+            BorderThickness="0,1,0,0">
             <TextBlock
                 Text="{loc:Loc Shared.CustomException.InfoText}"
                 Style="{StaticResource AeText.Caption}"

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/PackFile/SavePackFileWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/PackFile/SavePackFileWindow.xaml
@@ -17,9 +17,9 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="auto"/>
         </Grid.RowDefinitions>
-        <Border Margin="12" Style="{StaticResource AeSurface.Panel}">
-            <packfiletree:PackFileBrowserView DataContext="{Binding ViewModel, Mode=OneTime}"/>
-        </Border>
+        <packfiletree:PackFileBrowserView
+            Margin="12"
+            DataContext="{Binding ViewModel, Mode=OneTime}"/>
 
         <Border Grid.Row="1" Style="{StaticResource AeWorkflow.DialogFooter}">
             <Grid>

--- a/Shared/SharedUI/Common/Styles/EditorWorkspaceStyles.xaml
+++ b/Shared/SharedUI/Common/Styles/EditorWorkspaceStyles.xaml
@@ -70,7 +70,7 @@
         <Setter Property="Background" Value="{DynamicResource AeBrush.Surface3}" />
         <Setter Property="BorderBrush" Value="{DynamicResource AeBrush.BorderStrong}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">

--- a/Shared/SharedUI/Common/Styles/GridSplitterStyles.xaml
+++ b/Shared/SharedUI/Common/Styles/GridSplitterStyles.xaml
@@ -6,6 +6,7 @@
         TargetType="{x:Type GridSplitter}">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Focusable" Value="True" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type GridSplitter}">
@@ -29,9 +30,6 @@
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Surface" Property="Background" Value="{DynamicResource AeBrush.SurfaceHover}" />
                         </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter TargetName="Surface" Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
-                        </Trigger>
                         <Trigger Property="IsDragging" Value="True">
                             <Setter TargetName="Surface" Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
                         </Trigger>
@@ -46,6 +44,7 @@
         TargetType="{x:Type GridSplitter}">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Focusable" Value="True" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource AeFocus.Keyboard}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type GridSplitter}">
@@ -68,9 +67,6 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Surface" Property="Background" Value="{DynamicResource AeBrush.SurfaceHover}" />
-                        </Trigger>
-                        <Trigger Property="IsKeyboardFocused" Value="True">
-                            <Setter TargetName="Surface" Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
                         </Trigger>
                         <Trigger Property="IsDragging" Value="True">
                             <Setter TargetName="Surface" Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />

--- a/Testing/AssetEditorTests/UiAnimationMetadataFamilyTests.cs
+++ b/Testing/AssetEditorTests/UiAnimationMetadataFamilyTests.cs
@@ -403,7 +403,7 @@ public class UiAnimationMetadataFamilyTests
             NUnitAssert.That(
                 styles,
                 Does.Contain(
-                    "<Setter Property=\"FocusVisualStyle\" Value=\"{x:Null}\" />"));
+                    "<Setter Property=\"FocusVisualStyle\" Value=\"{StaticResource AeFocus.Keyboard}\" />"));
             NUnitAssert.That(styles, Does.Not.Contain("To=\"1.015\""));
             NUnitAssert.That(styles, Does.Not.Contain("To=\"0.94\""));
             NUnitAssert.That(styles, Does.Not.Contain("ButtonBase.Click"));

--- a/Testing/AssetEditorTests/UiCommonControlGallery.cs
+++ b/Testing/AssetEditorTests/UiCommonControlGallery.cs
@@ -107,9 +107,9 @@ public class UiCommonControlGallery
         Grid.SetColumnSpan(heading, 5);
         layout.Children.Add(heading);
 
-        Add(layout, Card("操作与输入", CreateInputs()), 0);
-        Add(layout, Card("导航与集合", CreateCollections()), 2);
-        Add(layout, Card("菜单与反馈", CreateFeedback()), 4);
+        Add(layout, Section("操作与输入", CreateInputs()), 0);
+        Add(layout, Section("导航与集合", CreateCollections()), 2);
+        Add(layout, Section("菜单与反馈", CreateFeedback()), 4);
         root.Child = layout;
         return root;
     }
@@ -289,12 +289,11 @@ public class UiCommonControlGallery
         return stack;
     }
 
-    private static Border Card(string title, FrameworkElement content)
+    private static Border Section(string title, FrameworkElement content)
     {
         var border = new Border
         {
-            Padding = new Thickness(16),
-            Style = Style("AeSurface.Panel"),
+            Padding = new Thickness(8, 0, 8, 0),
         };
         var stack = VerticalStack();
         stack.Children.Add(Text(title, "AeText.SectionTitle", new Thickness(0, 0, 0, 12)));

--- a/Testing/AssetEditorTests/UiCommonControlResourceTests.cs
+++ b/Testing/AssetEditorTests/UiCommonControlResourceTests.cs
@@ -508,7 +508,8 @@ public class UiCommonControlResourceTests
                             style,
                             FrameworkElement.FocusVisualStyleProperty)
                             ?.Value,
-                        Is.Null);
+                        Is.SameAs(Application.Current.FindResource(
+                            "AeFocus.Keyboard")));
                     NUnitAssert.That(
                         pressedVisual.Setters
                             .OfType<Setter>()
@@ -728,7 +729,7 @@ public class UiCommonControlResourceTests
     }
 
     [Test]
-    public void Buttons_HighlightOnHoverAndAnimatePressWithoutFocusRings()
+    public void Buttons_HighlightOnHoverAndUseKeyboardOnlyFocusVisual()
     {
         WpfTestApplicationHost.InvokeWithThemeResources(
             WpfTestApplicationHost.EmptyServices,
@@ -769,7 +770,10 @@ public class UiCommonControlResourceTests
                                 item.Property ==
                                 Control.BackgroundProperty),
                         Is.True);
-                    NUnitAssert.That(focusVisual, Is.Null);
+                    NUnitAssert.That(
+                        focusVisual,
+                        Is.SameAs(Application.Current.FindResource(
+                            "AeFocus.Keyboard")));
                     NUnitAssert.That(persistentFocusRings, Is.Empty);
                     NUnitAssert.That(translucentStateOverlays, Is.Empty);
                 });
@@ -778,7 +782,7 @@ public class UiCommonControlResourceTests
     }
 
     [Test]
-    public void LegacyButtonBases_UsePressReleaseMotionWithoutFocusRings()
+    public void LegacyButtonBases_UsePressReleaseMotionWithKeyboardOnlyFocusVisual()
     {
         WpfTestApplicationHost.InvokeWithThemeResources(
             WpfTestApplicationHost.EmptyServices,
@@ -816,7 +820,10 @@ public class UiCommonControlResourceTests
                                 .Where(item => item.Name == "StateOverlay"),
                             Is.Empty);
                         NUnitAssert.That(focusVisualSetter, Is.Not.Null);
-                        NUnitAssert.That(focusVisualSetter!.Value, Is.Null);
+                        NUnitAssert.That(
+                            focusVisualSetter!.Value,
+                            Is.SameAs(Application.Current.FindResource(
+                                "AeFocus.Keyboard")));
                         NUnitAssert.That(
                             template.Triggers
                                 .OfType<Trigger>()
@@ -908,7 +915,7 @@ public class UiCommonControlResourceTests
     }
 
     [Test]
-    public void EditorToggleButtons_UsePressReleaseMotionWithoutFocusFrames()
+    public void EditorToggleButtons_UsePressReleaseMotionWithKeyboardOnlyFocusVisual()
     {
         WpfTestApplicationHost.InvokeWithThemeResources(
             WpfTestApplicationHost.EmptyServices,
@@ -946,7 +953,8 @@ public class UiCommonControlResourceTests
                                 style,
                                 FrameworkElement.FocusVisualStyleProperty)
                                 ?.Value,
-                            Is.Null);
+                            Is.SameAs(Application.Current.FindResource(
+                                "AeFocus.Keyboard")));
                         NUnitAssert.That(
                             FindDescendants<Border>(root)
                                 .Where(item => item.Name == "FocusRing"),
@@ -955,6 +963,45 @@ public class UiCommonControlResourceTests
                     AssertPressReleaseMotion(template, name);
                 }
             });
+    }
+
+    [Test]
+    public void ControlTemplates_DoNotDrawFocusFromInputAgnosticFocusProperties()
+    {
+        var root = FindSolutionRoot();
+        var paths = new[]
+        {
+            "AssetEditor/Themes/Controls.xaml",
+            "AssetEditor/Themes/DesignSystem/Controls/Buttons.xaml",
+            "AssetEditor/Themes/DesignSystem/Controls/Inputs.xaml",
+            "AssetEditor/Themes/DesignSystem/Controls/Collections.xaml",
+            "AssetEditor/Themes/DesignSystem/Controls/MenusAndFeedback.xaml",
+            "AssetEditor/Themes/DesignSystem/Shell.xaml",
+            "AssetEditor/Themes/DesignSystem/Workflows.xaml",
+            "Shared/SharedUI/Common/Styles/GridSplitterStyles.xaml",
+            "Shared/SharedUI/BaseDialogs/OptionalRadioButtonStyle.xaml",
+            "Editors/Kitbashing/KitbasherEditor/KitbashUiStyles.xaml",
+        };
+
+        foreach (var path in paths)
+        {
+            var source = File.ReadAllText(Path.Combine(
+                root,
+                path.Replace('/', Path.DirectorySeparatorChar)));
+            NUnitAssert.Multiple(() =>
+            {
+                NUnitAssert.That(
+                    source,
+                    Does.Not.Contain(
+                        "<Trigger Property=\"IsKeyboardFocused\""),
+                    path);
+                NUnitAssert.That(
+                    source,
+                    Does.Not.Contain(
+                        "<Trigger Property=\"IsKeyboardFocusWithin\""),
+                    path);
+            });
+        }
     }
 
     [Test]

--- a/Testing/AssetEditorTests/UiCommonWorkflowTests.cs
+++ b/Testing/AssetEditorTests/UiCommonWorkflowTests.cs
@@ -127,6 +127,57 @@ public class UiCommonWorkflowTests
     }
 
     [Test]
+    public void DialogContent_DoesNotUseDecorativePanelCards()
+    {
+        var root = FindSolutionRoot();
+        var paths = new[]
+        {
+            Path.Combine(
+                "AssetEditor",
+                "Views",
+                "FolderProject",
+                "FolderProjectSetupWindow.xaml"),
+            Path.Combine(
+                "AssetEditor",
+                "Views",
+                "ExternalPack",
+                "ExternalPackOpenChoiceWindow.xaml"),
+            Path.Combine(
+                "Shared",
+                "SharedUI",
+                "BaseDialogs",
+                "StandardDialog",
+                "ErrorDialog",
+                "ErrorListWindow.xaml"),
+            Path.Combine(
+                "Shared",
+                "SharedUI",
+                "BaseDialogs",
+                "StandardDialog",
+                "ExceptionHandling",
+                "CustomExceptionWindow.xaml"),
+            Path.Combine(
+                "Shared",
+                "SharedUI",
+                "BaseDialogs",
+                "StandardDialog",
+                "PackFile",
+                "SavePackFileWindow.xaml"),
+            Path.Combine(
+                "Editors",
+                "AnimationReTarget",
+                "Editors.AnimatioReTarget",
+                "Editor",
+                "Saving",
+                "SaveWindow.xaml"),
+        };
+
+        NUnitAssert.That(
+            paths.Select(path => File.ReadAllText(Path.Combine(root, path))),
+            Has.None.Contains("AeSurface.Panel"));
+    }
+
+    [Test]
     public void LoadingAndProgressSurfaces_UseSemanticFeedbackStyles()
     {
         var root = FindSolutionRoot();

--- a/Testing/AssetEditorTests/UiDesignSystemResourceTests.cs
+++ b/Testing/AssetEditorTests/UiDesignSystemResourceTests.cs
@@ -372,6 +372,38 @@ public class UiDesignSystemResourceTests
     }
 
     [Test]
+    public void FoundationStyles_ExposeSharedKeyboardFocusVisual()
+    {
+        WpfTestApplicationHost.Invoke(_ =>
+        {
+            var tokens = Load("Themes/DesignSystem/DesignTokens.xaml");
+            Application.Current.Resources.MergedDictionaries.Add(tokens);
+
+            try
+            {
+                var dictionary = Load(
+                    "Themes/DesignSystem/SurfaceStyles.xaml");
+                var style = (Style)dictionary["AeFocus.Keyboard"];
+
+                NUnitAssert.Multiple(() =>
+                {
+                    NUnitAssert.That(
+                        style.TargetType,
+                        Is.EqualTo(typeof(Control)));
+                    NUnitAssert.That(
+                        dictionary.Contains(typeof(Control)),
+                        Is.False,
+                        "Foundation styles must not replace the implicit Control style.");
+                });
+            }
+            finally
+            {
+                Application.Current.Resources.MergedDictionaries.Remove(tokens);
+            }
+        });
+    }
+
+    [Test]
     public void CanonicalUiStandard_CatalogsEveryPublicControlStyle()
     {
         var solutionRoot = FindSolutionRoot();
@@ -388,7 +420,6 @@ public class UiDesignSystemResourceTests
         };
         var internalKeys = new HashSet<string>(StringComparer.Ordinal)
         {
-            "AeButton.KeyboardFocusVisual",
             "AeButton.Base",
             "AeMenu.TopLevelItemTemplate",
             "AeMenu.SubmenuItemTemplate",

--- a/Testing/AssetEditorTests/UiModelKitbashFamilyTests.cs
+++ b/Testing/AssetEditorTests/UiModelKitbashFamilyTests.cs
@@ -472,7 +472,9 @@ public class UiModelKitbashFamilyTests
             NUnitAssert.That(styles, Does.Contain("Margin=\"16,0,0,0\""));
             NUnitAssert.That(
                 styles,
-                Does.Contain("Property=\"IsKeyboardFocused\" Value=\"True\""));
+                Does.Contain(
+                    "Property=\"FocusVisualStyle\" Value=\"{StaticResource AeFocus.Keyboard}\""));
+            NUnitAssert.That(styles, Does.Not.Contain("IsKeyboardFocused"));
             NUnitAssert.That(styles, Does.Not.Contain("IsKeyboardFocusWithin"));
             NUnitAssert.That(styles, Does.Contain("x:Name=\"CheckMark\""));
             NUnitAssert.That(

--- a/Testing/AssetEditorTests/UiThemeCompletionGallery.cs
+++ b/Testing/AssetEditorTests/UiThemeCompletionGallery.cs
@@ -160,7 +160,7 @@ public class UiThemeCompletionGallery
 
     private static FrameworkElement CreateOptionalRadios()
     {
-        var card = Card();
+        var card = Section();
         var stack = new StackPanel();
         stack.Children.Add(Text("可取消单选按钮", "AeText.SectionTitle"));
         stack.Children.Add(Text(
@@ -177,7 +177,7 @@ public class UiThemeCompletionGallery
 
     private static FrameworkElement CreateSplitters()
     {
-        var card = Card();
+        var card = Section();
         var grid = new Grid { Height = 420 };
         grid.ColumnDefinitions.Add(new ColumnDefinition());
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(10) });
@@ -221,7 +221,7 @@ public class UiThemeCompletionGallery
 
     private static FrameworkElement CreateDenseChinese()
     {
-        var card = Card();
+        var card = Section();
         var grid = new Grid();
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(280) });
         grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(16) });
@@ -271,7 +271,7 @@ public class UiThemeCompletionGallery
 
     private static FrameworkElement CreateWindowFont()
     {
-        var card = Card();
+        var card = Section();
         var stack = new StackPanel();
         stack.Children.Add(Text("窗口字体资源已贯通", "AeText.SectionTitle"));
         stack.Children.Add(Text(
@@ -294,10 +294,9 @@ public class UiThemeCompletionGallery
         return card;
     }
 
-    private static Border Card() => new()
+    private static Border Section() => new()
     {
-        Padding = new Thickness(18),
-        Style = Style("AeSurface.Panel"),
+        Padding = new Thickness(8, 0, 8, 0),
     };
 
     private static OptionalRadioButton Optional(

--- a/docs/ui-design-system.md
+++ b/docs/ui-design-system.md
@@ -98,7 +98,7 @@ UI 修改只改变呈现或用户已明确要求的交互，不得顺带改变 B
 - `AeSurface.Control`：`Surface2`、1 DIP `BorderStrong`、4 DIP 圆角。
 - `AeSurface.Overlay`：`Surface2`、1 DIP `BorderStrong`、7 DIP 圆角。
 
-不得在同一层级重复套用面板、卡片和边框。独立窗口已经提供窗口边界时，内部只保留业务所需的一层内容结构。
+`AeSurface.Panel` 只用于需要明确边界的独立工作区、预览区或数据区，不用于普通标题分区、表单分组或对话框内容外壳。普通分区优先使用留白和必要的单条分隔线。不得在同一层级重复套用面板、卡片和边框；独立窗口已经提供窗口边界时，内部只保留业务所需的一层内容结构。
 
 ## 4. 公共控件契约
 
@@ -125,7 +125,8 @@ UI 修改只改变呈现或用户已明确要求的交互，不得顺带改变 B
 - 鼠标松开：立即回弹到 `1.0`，120 ms，`EaseOut`。
 - 不等待长按，不在松开后才开始完整按压动画。
 - 不创建半透明复制层、残影、光晕或持续状态覆盖层。
-- 所有按钮 `FocusVisualStyle` 为 `null`，不得显示聚焦框、蓝色描边或按下后残留边框；键盘命令、访问键和自动化名称仍必须保留。
+- 所有可聚焦控件复用 `AeFocus.Keyboard`。该视觉只能由 WPF 键盘导航触发；鼠标点击、鼠标选中和按下回弹不得显示或残留蓝紫色聚焦边框。
+- 键盘焦点使用 1 DIP 语义强调描边，不使用光晕、双层描边或持续状态覆盖层；键盘命令、访问键和自动化名称必须保留。
 - 禁用状态降低层级但保持文字可读；危险按钮使用 `Danger`，不能只靠红色表达风险。
 
 播放器播放期间，播放按钮背景持续保持选中高亮，播放图标使用 `AeBrush.Danger`；停止或暂停后恢复普通状态。播放器复用 `AeEditor.PlaybackToggle` 和可拖动的 `AeEditor.PlaybackSlider`，不单独制造另一套按钮或时间轴。
@@ -136,7 +137,7 @@ UI 修改只改变呈现或用户已明确要求的交互，不得顺带改变 B
 - ComboBox 点击整个控件都能展开，不能只让箭头区域响应。
 - 下拉、展开和折叠箭头使用固定尺寸矢量图标；不得使用 Unicode 字符、Emoji 或依赖字体基线的符号。
 - 所有编辑器中的下拉箭头都不使用圆形卡片或独立背景。悬停只高亮箭头本身，不高亮圆形/方形背景。
-- 输入焦点、校验错误、禁用和只读状态必须可区分；输入控件可以使用语义焦点边框，但按钮不得出现聚焦框。
+- 输入焦点、校验错误、禁用和只读状态必须可区分；焦点描边同样只在键盘导航时出现，鼠标点击后不保留。
 
 ### 4.4 图标
 
@@ -229,7 +230,7 @@ UI 修改只改变呈现或用户已明确要求的交互，不得顺带改变 B
 | 输入与表单 | `AssetEditor/Themes/DesignSystem/Controls/Inputs.xaml` | `AeInput.TextBox`、`AeInput.ComboBox`、`AeInput.CheckBox`、`AeInput.RadioButton`、`AeInput.Switch`、`AeInput.ExpandableField`、`AeForm.Label`、`AeForm.TextLabel`、`AeValidation.Message` |
 | 集合控件 | `AssetEditor/Themes/DesignSystem/Controls/Collections.xaml` | `AeTab.Item`、`AeTag.Container`、`AeTag.Text`、`AeTree.View`、`AeTree.Item`、`AeList.View`、`AeList.Item`、`AeTable.Grid`、`AeTable.Header`、`AeTable.Row`、`AeTable.Cell` |
 | 菜单与反馈 | `AssetEditor/Themes/DesignSystem/Controls/MenusAndFeedback.xaml` | `AeMenu.Bar`、`AeMenu.Item`、`AeMenu.Context`、`AeToolTip`、`AeFeedback.Notice`、`AeFeedback.Icon`、`AeFeedback.SuccessIcon`、`AeFeedback.WarningIcon`、`AeFeedback.DangerIcon`、`AeEmptyState.Panel`、`AeEmptyState.Title`、`AeEmptyState.Description`、`AeProgress.Bar`、`AeScrollBar.Compact` |
-| 变量、文字与表面 | `AssetEditor/Themes/DesignSystem/DesignTokens.xaml`、`Typography.xaml`、`SurfaceStyles.xaml` | `AeSpace.*`、`AeSize.*`、`AeRadius.*`、`AeMotion.*`、`AeText.*`、`AeSurface.*` |
+| 变量、文字、表面与焦点 | `AssetEditor/Themes/DesignSystem/DesignTokens.xaml`、`Typography.xaml`、`SurfaceStyles.xaml` | `AeSpace.*`、`AeSize.*`、`AeRadius.*`、`AeMotion.*`、`AeText.*`、`AeSurface.*`、`AeFocus.Keyboard` |
 | 主窗口工作区 | `AssetEditor/Themes/DesignSystem/Shell.xaml` | `AeShell.*` |
 | 设置与标准工作流 | `AssetEditor/Themes/DesignSystem/Workflows.xaml` | `AeWorkflow.*` |
 | 编辑器按钮与播放器 | `Shared/SharedUI/Common/Styles/EditorWorkspaceStyles.xaml` | `AeEditor.ToggleIcon`、`AeEditor.PlaybackToggle`、`AeEditor.PlaybackSlider` |
@@ -305,7 +306,7 @@ rg -n '<(Button|ToggleButton|TextBox|ComboBox|TreeView|DataGrid|ProgressBar)\b' 
 
 - 禁止新增固定主题色、固定字体族、任意字号、任意行高和未登记的间距尺度。
 - 禁止用字体字符或 Emoji 代替图标。
-- 禁止下拉箭头圆卡片、按钮聚焦框、按钮悬停放大、松开后才播放按压动画、残影和半透明复制层。
+- 禁止下拉箭头圆卡片、鼠标点击后出现或残留聚焦框、按钮悬停放大、松开后才播放按压动画、残影和半透明复制层；键盘导航必须保留 `AeFocus.Keyboard`。
 - 禁止控件过高而文字过小，禁止依靠冒号对齐表单。
 - 禁止子分组伪装成父分组，禁止无意义横线和层层嵌套卡片。
 - 禁止嵌入式加载界面、重复加载状态、假进度、假详情和无效取消按钮。


### PR DESCRIPTION
## What changed

- Removed nonessential card-style wrappers from shared workflows and dialogs while preserving semantic preview, data, and problem-list boundaries.
- Added the shared `AeFocus.Keyboard` focus visual and applied it across focusable UI component families.
- Removed mouse-triggered blue-purple focus borders; focus indication now appears only during keyboard navigation.
- Updated UI galleries, resource/workflow tests, and the UI design-system contract.

## Why

Decorative cards added unnecessary visual weight, and focus borders remained visible after mouse selection. The UI should stay visually flat unless a boundary communicates real structure, while keyboard users must retain a clear focus indicator.

## User impact

Dialogs and common controls now use cleaner spacing and dividers. Mouse interaction no longer leaves a distracting focus outline, while Tab/keyboard navigation still provides an accessible focus cue.

## Validation

- Release solution build: 0 errors
- Full solution tests: 2,788 passed, 6 skipped, 0 failed
- WPF UI gallery render: 40/40 passed across dark, light, and high-contrast themes
- `git diff --check`: passed