### PR TITLE
fix(audio): preserve WH3 spatial dialogue and loudness metadata

### DIFF
--- a/Editors/Audio/Shared/AudioProject/Compiler/AudioProjectCompilerService.cs
+++ b/Editors/Audio/Shared/AudioProject/Compiler/AudioProjectCompilerService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Data;
 using System;
 using System.IO;
@@ -238,9 +238,8 @@ namespace Editors.Audio.Shared.AudioProject.Compiler
                     audioProjectFilePath,
                     0,
                     compilationResult.Outputs.Count));
-                await Task.Run(() =>
-                    _audioPackOutputService.SaveBatch(
-                        compilationResult.Outputs));
+                _audioPackOutputService.SaveBatch(
+                    compilationResult.Outputs);
                 progress?.Report(new AudioOperationProgress(
                     "AudioOperation.Saving",
                     audioProjectFilePath,

--- a/Editors/Audio/Shared/Wwise/Generators/SoundBankGeneratorService.cs
+++ b/Editors/Audio/Shared/Wwise/Generators/SoundBankGeneratorService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
@@ -98,6 +98,7 @@ namespace Editors.Audio.Shared.Wwise.Generators
                 // We don't generate the Dialogue Events in this .bnk, we keep them in the merging SoundBank instead
                 var sourceHircsFromDialogue = GenerateSourceHircsFromDialogueEvents(soundBank);
                 hircItems.AddRange(sourceHircsFromDialogue);
+                AddBattleVoiceActorMixer(soundBank, sourceHircsFromDialogue, hircItems);
             }
 
             SortHircs(hircItems);
@@ -430,6 +431,52 @@ namespace Editors.Audio.Shared.Wwise.Generators
             return hircItems;
         }
 
+        private void AddBattleVoiceActorMixer(
+            SoundBank soundBank,
+            List<HircItem> sourceHircs,
+            List<HircItem> hircItems)
+        {
+            var actorMixerId = soundBank.GameSoundBank switch
+            {
+                Wh3SoundBank.BattleVO => Wh3ActorMixerInformation.BattleVOOrders,
+                Wh3SoundBank.BattleVOConversational => Wh3ActorMixerInformation.BattleVOConversational,
+                _ => 0u
+            };
+
+            if (actorMixerId == 0)
+                return;
+
+            var childIds = sourceHircs
+                .Where(hircItem => hircItem.IsTarget)
+                .Select(hircItem => hircItem.Id)
+                .Distinct()
+                .OrderBy(id => id)
+                .ToList();
+            if (childIds.Count == 0)
+                return;
+
+            var template = _audioRepository.GetHircs(actorMixerId)
+                .OfType<CAkActorMixer_V136>()
+                .FirstOrDefault(hircItem => hircItem.IsCAHircItem);
+            if (template == null)
+            {
+                throw new InvalidOperationException(
+                    $"Could not find the vanilla ActorMixer {actorMixerId} required to compile spatial battle dialogue audio.");
+            }
+
+            var actorMixer = new CAkActorMixer_V136
+            {
+                HircType = AkBkHircType.ActorMixer,
+                Id = actorMixerId,
+                LanguageId = soundBank.LanguageId,
+                BnkFilePath = soundBank.FilePath,
+                NodeBaseParams = template.NodeBaseParams,
+                Children = new Children_V136 { ChildIds = childIds }
+            };
+            actorMixer.UpdateSectionSize();
+            hircItems.Add(actorMixer);
+        }
+
         private List<HircItem> GenerateRandomSequenceContainerTargetHircs(SoundBank soundBank, RandomSequenceContainer randomSequenceContainer)
         {
             var hircItems = new List<HircItem>();
@@ -532,6 +579,10 @@ namespace Editors.Audio.Shared.Wwise.Generators
                 .Where(hircItem => hircItem.HircType == AkBkHircType.Event || hircItem.HircType == AkBkHircType.Dialogue_Event)
                 .ToList();
 
+            var actorMixerHircs = hircItems
+                .Where(hircItem => hircItem.HircType == AkBkHircType.ActorMixer)
+                .ToList();
+
             var sortedHircItems = new List<HircItem>();
 
             foreach (var targetHirc in targetHircs.OrderBy(sourceHirc => sourceHirc.Id))
@@ -545,6 +596,8 @@ namespace Editors.Audio.Shared.Wwise.Generators
                 else
                     sortedHircItems.Add(targetHirc);
             }
+
+            sortedHircItems.AddRange(actorMixerHircs.OrderBy(hircItem => hircItem.Id));
 
             foreach (var eventHirc in eventHircs.OrderBy(eventHirc => eventHirc.Id))
             {

--- a/Editors/Audio/Shared/Wwise/WSourcesWrapper.cs
+++ b/Editors/Audio/Shared/Wwise/WSourcesWrapper.cs
@@ -32,8 +32,12 @@ namespace Editors.Audio.Shared.Wwise
             string audioFolderPath,
             string wsourcesPath)
         {
-            var sources = from wavFileName in wavFilesNames 
-                          select new XElement("Source", new XAttribute("Path", wavFileName), new XAttribute("Conversion", "Vorbis Quality High"));
+            var sources = from wavFileName in wavFilesNames
+                          select new XElement(
+                              "Source",
+                              new XAttribute("Path", wavFileName),
+                              new XAttribute("Conversion", "Vorbis Quality High"),
+                              new XAttribute("AnalysisTypes", 2));
 
             var document = new XDocument(
                 new XDeclaration("1.0", "UTF-8", null), 

--- a/Shared/GameFiles/Wwise/Hirc/V136/Shared/AkRtpcGraphPoint_V136.cs
+++ b/Shared/GameFiles/Wwise/Hirc/V136/Shared/AkRtpcGraphPoint_V136.cs
@@ -1,4 +1,4 @@
-﻿using Shared.ByteParsing;
+using Shared.ByteParsing;
 
 namespace Shared.GameFormats.Wwise.Hirc.V136.Shared
 {
@@ -17,5 +17,19 @@ namespace Shared.GameFormats.Wwise.Hirc.V136.Shared
                 Interp = chunk.ReadUInt32()
             };
         }
+
+        public byte[] WriteData()
+        {
+            using var memStream = new MemoryStream();
+            memStream.Write(ByteParsers.Single.EncodeValue(From, out _));
+            memStream.Write(ByteParsers.Single.EncodeValue(To, out _));
+            memStream.Write(ByteParsers.UInt32.EncodeValue(Interp, out _));
+            return memStream.ToArray();
+        }
+
+        public uint GetSize() =>
+            ByteHelper.GetPropertyTypeSize(From) +
+            ByteHelper.GetPropertyTypeSize(To) +
+            ByteHelper.GetPropertyTypeSize(Interp);
     }
 }

--- a/Shared/GameFiles/Wwise/Hirc/V136/Shared/AuxParams_V136.cs
+++ b/Shared/GameFiles/Wwise/Hirc/V136/Shared/AuxParams_V136.cs
@@ -1,4 +1,4 @@
-﻿using Shared.ByteParsing;
+using Shared.ByteParsing;
 
 namespace Shared.GameFormats.Wwise.Hirc.V136.Shared
 {
@@ -26,11 +26,15 @@ namespace Shared.GameFormats.Wwise.Hirc.V136.Shared
 
         public byte[] WriteData()
         {
-            if (BitVector != 0)
-                throw new NotSupportedException("Users probably don't need this complexity.");
-
             using var memStream = new MemoryStream();
             memStream.Write(ByteParsers.Byte.EncodeValue(BitVector, out _));
+            if ((BitVector & 8) != 0)
+            {
+                memStream.Write(ByteParsers.UInt32.EncodeValue(AuxBus0, out _));
+                memStream.Write(ByteParsers.UInt32.EncodeValue(AuxBus1, out _));
+                memStream.Write(ByteParsers.UInt32.EncodeValue(AuxBus2, out _));
+                memStream.Write(ByteParsers.UInt32.EncodeValue(AuxBus3, out _));
+            }
             memStream.Write(ByteParsers.UInt32.EncodeValue(ReflectionsAuxBus, out _));
             return memStream.ToArray();
         }
@@ -38,11 +42,11 @@ namespace Shared.GameFormats.Wwise.Hirc.V136.Shared
         public uint GetSize()
         {
             var bitVectorSize = ByteHelper.GetPropertyTypeSize(BitVector);
-            if (BitVector != 0)
-                throw new NotSupportedException("Users probably don't need this complexity.");
-
+            var auxBusSize = (BitVector & 8) != 0
+                ? 4u * ByteHelper.GetPropertyTypeSize(AuxBus0)
+                : 0u;
             var reflectionsAuxBusSize = ByteHelper.GetPropertyTypeSize(ReflectionsAuxBus);
-            return bitVectorSize + reflectionsAuxBusSize;
+            return bitVectorSize + auxBusSize + reflectionsAuxBusSize;
         }
     }
 }

--- a/Shared/GameFiles/Wwise/Hirc/V136/Shared/InitialRtpc_V136.cs
+++ b/Shared/GameFiles/Wwise/Hirc/V136/Shared/InitialRtpc_V136.cs
@@ -1,4 +1,4 @@
-﻿using Shared.ByteParsing;
+using Shared.ByteParsing;
 
 namespace Shared.GameFormats.Wwise.Hirc.V136.Shared
 {
@@ -21,18 +21,15 @@ namespace Shared.GameFormats.Wwise.Hirc.V136.Shared
         public uint GetSize()
         {
             var numRtpcSize = ByteHelper.GetPropertyTypeSize(NumRtpc);
-            if (RtpcList.Count != 0)
-                throw new NotSupportedException("Users probably don't need this complexity.");
-            return numRtpcSize;
+            return numRtpcSize + (uint)RtpcList.Sum(rtpc => rtpc.GetSize());
         }
 
         public byte[] WriteData()
         {
-            if (RtpcList.Count != 0)
-                throw new NotSupportedException("Users probably don't need this complexity.");
-
             using var memStream = new MemoryStream();
             memStream.Write(ByteParsers.UShort.EncodeValue((ushort)RtpcList.Count, out _));
+            foreach (var rtpc in RtpcList)
+                memStream.Write(rtpc.WriteData());
             return memStream.ToArray();
         }
 
@@ -58,6 +55,34 @@ namespace Shared.GameFormats.Wwise.Hirc.V136.Shared
                 Size = chunk.ReadUShort();
                 for (var i = 0; i < Size; i++)
                     RtpcMgr.Add(AkRtpcGraphPoint_V136.ReadData(chunk));
+            }
+
+            public byte[] WriteData()
+            {
+                using var memStream = new MemoryStream();
+                memStream.Write(ByteParsers.UInt32.EncodeValue(RtpcId, out _));
+                memStream.Write(ByteParsers.Byte.EncodeValue(RtpcType, out _));
+                memStream.Write(ByteParsers.Byte.EncodeValue(RtpcAccum, out _));
+                memStream.Write(ByteParsers.Byte.EncodeValue(ParamId, out _));
+                memStream.Write(ByteParsers.UInt32.EncodeValue(RtpcCurveId, out _));
+                memStream.Write(ByteParsers.Byte.EncodeValue(Scaling, out _));
+                memStream.Write(ByteParsers.UShort.EncodeValue((ushort)RtpcMgr.Count, out _));
+                foreach (var point in RtpcMgr)
+                    memStream.Write(point.WriteData());
+                return memStream.ToArray();
+            }
+
+            public uint GetSize()
+            {
+                var fixedSize =
+                    ByteHelper.GetPropertyTypeSize(RtpcId) +
+                    ByteHelper.GetPropertyTypeSize(RtpcType) +
+                    ByteHelper.GetPropertyTypeSize(RtpcAccum) +
+                    ByteHelper.GetPropertyTypeSize(ParamId) +
+                    ByteHelper.GetPropertyTypeSize(RtpcCurveId) +
+                    ByteHelper.GetPropertyTypeSize(Scaling) +
+                    ByteHelper.GetPropertyTypeSize(Size);
+                return fixedSize + (uint)RtpcMgr.Sum(point => point.GetSize());
             }
         }
     }

--- a/Shared/GameFiles/Wwise/Hirc/V136/Shared/PositioningParams_V136.cs
+++ b/Shared/GameFiles/Wwise/Hirc/V136/Shared/PositioningParams_V136.cs
@@ -1,4 +1,4 @@
-﻿using Shared.ByteParsing;
+using Shared.ByteParsing;
 
 namespace Shared.GameFormats.Wwise.Hirc.V136.Shared
 {
@@ -45,22 +45,28 @@ namespace Shared.GameFormats.Wwise.Hirc.V136.Shared
 
         public byte[] WriteData()
         {
-            if (BitsPositioning == 0x03 && Bits3D == 0x08)
-                return [0x03, 0x08];
-            else if (BitsPositioning == 0x00)
-                return [0x00];
-            else
-                throw new NotSupportedException("Users probably don't need this complexity.");
+            var hasPositioning = (BitsPositioning & 1) != 0;
+            var has3D = (BitsPositioning & 2) != 0;
+            var positionType = BitsPositioning >> 5 & 3;
+
+            if (positionType != 0)
+                throw new NotSupportedException("Automated 3D positioning is not supported.");
+
+            return hasPositioning && has3D
+                ? [BitsPositioning, Bits3D]
+                : [BitsPositioning];
         }
 
         public uint GetSize()
         {
-            if (BitsPositioning == 0x03 && Bits3D == 0x08)
-                return 2;
-            else if (BitsPositioning == 0x00)
-                return 1;
-            else
-                throw new NotSupportedException("Users probably don't need this complexity.");
+            var hasPositioning = (BitsPositioning & 1) != 0;
+            var has3D = (BitsPositioning & 2) != 0;
+            var positionType = BitsPositioning >> 5 & 3;
+
+            if (positionType != 0)
+                throw new NotSupportedException("Automated 3D positioning is not supported.");
+
+            return hasPositioning && has3D ? 2u : 1u;
         }
 
         public class AkPathVertex_V136

--- a/Testing/AssetEditorTests/AudioEditorCompilerTests.cs
+++ b/Testing/AssetEditorTests/AudioEditorCompilerTests.cs
@@ -226,6 +226,48 @@ namespace AssetEditorTests
         }
 
         [TestMethod]
+        public void CreateWsourcesFile_RequestsLoudnessAnalysisForEverySource()
+        {
+            var tempDirectory = Path.Combine(
+                Path.GetTempPath(),
+                $"AssetEditor.CN.Tests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDirectory);
+
+            try
+            {
+                var wsourcesPath = Path.Combine(
+                    tempDirectory,
+                    "loudness-analysis.wsources");
+                var wrapper = new WSourcesWrapper(
+                    new ApplicationSettingsService());
+
+                wrapper.CreateWsourcesFile(
+                    ["first.wav", "second.wav"],
+                    tempDirectory,
+                    wsourcesPath);
+
+                var document = System.Xml.Linq.XDocument.Load(
+                    wsourcesPath);
+                var sources = document
+                    .Root!
+                    .Elements("Source")
+                    .ToList();
+
+                Assert.AreEqual(2, sources.Count);
+                foreach (var source in sources)
+                {
+                    Assert.AreEqual(
+                        "2",
+                        source.Attribute("AnalysisTypes")?.Value);
+                }
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+        }
+
+        [TestMethod]
         public async Task WwiseCommand_NonZeroExitCode_Throws()
         {
             var settings = new ApplicationSettingsService();

--- a/Testing/AssetEditorTests/AudioEditorCompilerTests.cs
+++ b/Testing/AssetEditorTests/AudioEditorCompilerTests.cs
@@ -1,3 +1,6 @@
+using System.Collections.ObjectModel;
+using System.Windows.Data;
+using Editors.Audio.AudioEditor.Core;
 using Editors.Audio.Shared.AudioProject;
 using Editors.Audio.Shared.AudioProject.Compiler;
 using Editors.Audio.Shared.AudioProject.Models;
@@ -8,9 +11,12 @@ using Editors.Audio.Shared.Wwise;
 using Editors.Audio.Shared.Wwise.Generators;
 using Editors.Audio.Shared.Wwise.Generators.Hirc.V136;
 using Moq;
+using Shared.Core.PackFiles.Models;
 using Shared.Core.Settings;
+using Shared.GameFormats.Wwise;
 using Shared.GameFormats.Wwise.Enums;
 using Shared.GameFormats.Wwise.Hirc.V136;
+using Shared.GameFormats.Wwise.Hirc.V136.Shared;
 using AudioProjectAction = Editors.Audio.Shared.AudioProject.Models.Action;
 
 namespace AssetEditorTests
@@ -18,6 +24,181 @@ namespace AssetEditorTests
     [TestClass]
     public class AudioEditorCompilerTests
     {
+        [TestMethod]
+        public async Task Compile_SavesOutputsOnCallingDispatcherThread()
+        {
+            Task<bool>? compilationTask = null;
+            var sourceCollection = new ObservableCollection<int>();
+            ListCollectionView? collectionView = null;
+            var callingThreadId = 0;
+            var savingThreadId = 0;
+
+            WpfTestApplicationHost.Invoke(_ =>
+            {
+                callingThreadId = Environment.CurrentManagedThreadId;
+                collectionView = new ListCollectionView(sourceCollection);
+                var outputService = new Mock<IAudioPackOutputService>();
+                outputService
+                    .Setup(x => x.SaveBatch(
+                        It.IsAny<IReadOnlyCollection<AudioPackOutput>>(),
+                        It.IsAny<bool>()))
+                    .Callback((
+                        IReadOnlyCollection<AudioPackOutput> _,
+                        bool _) =>
+                    {
+                        savingThreadId = Environment.CurrentManagedThreadId;
+                        sourceCollection.Add(1);
+                    })
+                    .Returns(true);
+                var compiler = new AudioProjectCompilerService(
+                    Mock.Of<ISoundBankGeneratorService>(),
+                    Mock.Of<IWemGeneratorService>(),
+                    Mock.Of<IDatGeneratorService>(),
+                    outputService.Object);
+                var project = new AudioProjectFile
+                {
+                    SoundBanks =
+                    [
+                        new SoundBank(
+                            "thread_affinity_test",
+                            Wh3SoundBank.BattleIndividualMagic,
+                            "sfx")
+                    ]
+                };
+
+                compilationTask = compiler.CompileAsync(
+                    project,
+                    "thread_affinity_test.aproj",
+                    "audio\\thread_affinity_test.aproj",
+                    AudioProjectCompileTarget.AllLanguages);
+            });
+
+            var completed = await compilationTask!;
+
+            Assert.IsTrue(completed);
+            Assert.AreEqual(callingThreadId, savingThreadId);
+            Assert.AreEqual(1, sourceCollection.Count);
+            GC.KeepAlive(collectionView);
+        }
+
+        [TestMethod]
+        public void GenerateSoundBank_BattleConversational_IncludesSpatialActorMixer()
+        {
+            AssertCompiledBattleVoiceActorMixer(
+                Wh3SoundBank.BattleVOConversational,
+                Wh3ActorMixerInformation.BattleVOConversational,
+                0x03,
+                0x0A);
+        }
+
+        [TestMethod]
+        public void GenerateSoundBank_BattleOrders_IncludesSpatialActorMixer()
+        {
+            AssertCompiledBattleVoiceActorMixer(
+                Wh3SoundBank.BattleVO,
+                Wh3ActorMixerInformation.BattleVOOrders,
+                0x07,
+                0x1A);
+        }
+
+        private static void AssertCompiledBattleVoiceActorMixer(
+            Wh3SoundBank gameSoundBank,
+            uint actorMixerId,
+            byte bitsPositioning,
+            byte bits3D)
+        {
+            const uint targetId = 42;
+            const uint sourceId = 771;
+            const uint containerId = 43;
+            const uint childSoundId = 44;
+            var sound = Sound.CreateTargetSound(
+                Guid.NewGuid(),
+                targetId,
+                0,
+                actorMixerId,
+                sourceId,
+                "english(uk)",
+                Editors.Audio.Shared.AudioProject.Models.HircSettings
+                    .CreateDefaultSoundSettings());
+            var childSound = Sound.CreateContainerSound(
+                Guid.NewGuid(),
+                childSoundId,
+                containerId,
+                0,
+                sourceId + 1,
+                "english(uk)");
+            var container = new RandomSequenceContainer(
+                Guid.NewGuid(),
+                containerId,
+                0,
+                actorMixerId,
+                new Editors.Audio.Shared.AudioProject.Models.HircSettings(),
+                [childSoundId]);
+            var soundBank = new SoundBank(
+                "battle_voice_spatial_test",
+                gameSoundBank,
+                "english(uk)")
+            {
+                FileName = "battle_voice_spatial_test.bnk",
+                FilePath = "audio\\wwise\\english(uk)\\battle_voice_spatial_test.bnk"
+            };
+            soundBank.Sounds.Add(sound);
+            soundBank.Sounds.Add(childSound);
+            soundBank.RandomSequenceContainers.Add(container);
+            var dialogueEvent = new DialogueEvent("battle_vo_conversation_diplomacy_generic");
+            dialogueEvent.StatePaths.Add(
+                new StatePath([], targetId, AkBkHircType.Sound));
+            dialogueEvent.StatePaths.Add(
+                new StatePath([], containerId, AkBkHircType.RandomSequenceContainer));
+            soundBank.DialogueEvents.Add(dialogueEvent);
+
+            var repository = new Mock<IAudioRepository>();
+            repository
+                .Setup(x => x.GetHircs(actorMixerId))
+                .Returns([
+                    CreateSpatialActorMixerTemplate(
+                        actorMixerId,
+                        bitsPositioning,
+                        bits3D)
+                ]);
+            var generator = new SoundBankGeneratorService(
+                Mock.Of<IAudioPackOutputService>(),
+                new ApplicationSettingsService(GameTypeEnum.Warhammer3),
+                repository.Object,
+                Mock.Of<IAudioEditorIntegrityService>());
+
+            var output = generator.GenerateSoundBankWithoutDialogueEvents(soundBank);
+            var parsed = BnkParser.Parse(
+                new PackFile(output.FileName, new MemorySource(output.Data)),
+                output.FilePath,
+                true);
+
+            var actorMixer = parsed.HircChunk.HircItems
+                .OfType<CAkActorMixer_V136>()
+                .Single(item => item.Id == actorMixerId);
+            Assert.AreEqual(
+                bitsPositioning,
+                actorMixer.NodeBaseParams.PositioningParams.BitsPositioning);
+            Assert.AreEqual(
+                bits3D,
+                actorMixer.NodeBaseParams.PositioningParams.Bits3D);
+            CollectionAssert.AreEqual(
+                new uint[] { targetId, containerId },
+                actorMixer.Children.ChildIds);
+            Assert.AreEqual(
+                1,
+                actorMixer.NodeBaseParams.InitialRtpc.RtpcList.Count);
+            Assert.AreEqual(
+                3482134062u,
+                actorMixer.NodeBaseParams.AuxParams.AuxBus2);
+            var graphPoint = actorMixer.NodeBaseParams.InitialRtpc.RtpcList
+                .Single()
+                .RtpcMgr
+                .Single();
+            Assert.AreEqual(-1f, graphPoint.To);
+            Assert.AreEqual(2u, graphPoint.Interp);
+        }
+
         [TestMethod]
         public void RandomSequenceContainerGenerator_PreservesFractionalTransitionDuration()
         {
@@ -418,6 +599,78 @@ namespace AssetEditorTests
             public List<T> Values { get; } = [];
 
             public void Report(T value) => Values.Add(value);
+        }
+
+        private static CAkActorMixer_V136 CreateSpatialActorMixerTemplate(
+            uint actorMixerId,
+            byte bitsPositioning,
+            byte bits3D)
+        {
+            return new CAkActorMixer_V136
+            {
+                HircType = AkBkHircType.ActorMixer,
+                Id = actorMixerId,
+                IsCAHircItem = true,
+                BnkFilePath = "audio\\wwise\\english(uk)\\battle_vo_conversational_template.bnk",
+                NodeBaseParams = new NodeBaseParams_V136
+                {
+                    NodeInitialFxParams = new NodeInitialFxParams_V136
+                    {
+                        IsOverrideParentFx = 1,
+                        NumFx = 0
+                    },
+                    OverrideBusId = 160824738,
+                    BitVector = 3,
+                    NodeInitialParams = new NodeInitialParams_V136(),
+                    PositioningParams = new PositioningParams_V136
+                    {
+                        BitsPositioning = bitsPositioning,
+                        Bits3D = bits3D
+                    },
+                    AuxParams = new AuxParams_V136
+                    {
+                        BitVector = 0x0B,
+                        AuxBus2 = 3482134062,
+                        AuxBus3 = 3482134061
+                    },
+                    AdvSettingsParams = new AdvSettingsParams_V136
+                    {
+                        BitVector = 0x0C,
+                        VirtualQueueBehavior = 1,
+                        BelowThresholdBehavior = 2,
+                        BitVector2 = 4
+                    },
+                    StateChunk = new StateChunk_V136(),
+                    InitialRtpc = new InitialRtpc_V136
+                    {
+                        RtpcList =
+                        [
+                            new InitialRtpc_V136.Rtpc_V136
+                            {
+                                RtpcId = 205544051,
+                                RtpcType = 0,
+                                RtpcAccum = 2,
+                                ParamId = 0,
+                                RtpcCurveId = 828889223,
+                                Scaling = 2,
+                                RtpcMgr =
+                                [
+                                    new AkRtpcGraphPoint_V136
+                                    {
+                                        From = 0,
+                                        To = -1,
+                                        Interp = 2
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                Children = new Children_V136
+                {
+                    ChildIds = [999]
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
## 修改内容

- 保留转换自原版战斗语音 BNK 的完整根 ActorMixer 参数，使单位自然触发语音继续使用游戏原有的 3D 空间定位。
- 补全 Wwise HIRC 中此前未完整往返写出的定位、RTPC 与辅助发送字段。
- 为每条待编译 WAV 请求 Wwise 响度分析（`AnalysisTypes=2`），使新生成的 WEM 包含 `akd` 响度归一化元数据。

## 根因

音频编译器此前重建根 ActorMixer 时只复制了部分参数，并且 WAV 转 WEM 时没有请求响度分析。因此，单位自然触发语音会丢失空间定位，而新配音会按演员交付的原始电平播放。

## 用户影响

重新编译音频项目后，游戏可以继续区分主动操作语音与战场自然语音的空间表现；当 BNK 启用响度归一化时，Wwise 会使用新配音自身重新计算的增益，而不是直接采用未经处理的 WAV 音量。

## 验证

- 用户使用实际 Mod 工程编译并进游戏测试通过。
- `AudioEditorCompilerTests`：11/11 通过。
- 使用 Wwise 2019.2.15.7667 实际编译临时 WAV，生成 WEM 包含 `akd`，实测 `LoudnessNormalisationGain=0.56609726`。
- `git diff --check` 通过。
