### PR TITLE
修复 FrontendVO 多语言 BNK 编译路径

### DIFF
--- a/Editors/Audio/Shared/AudioProject/Compiler/AudioProjectCompilerService.cs
+++ b/Editors/Audio/Shared/AudioProject/Compiler/AudioProjectCompilerService.cs
@@ -546,27 +546,46 @@ namespace Editors.Audio.Shared.AudioProject.Compiler
                     _logger.Here().Information($"Generating SoundBank {soundBank.FilePath}");
 
                     // Create the .bnk that modders should keep
-                    outputs.Add(
+                    outputs.AddRange(ExpandSoundBankOutput(
+                        soundBank,
                         _soundBankGeneratorService
-                            .GenerateSoundBankWithoutDialogueEvents(soundBank));
+                            .GenerateSoundBankWithoutDialogueEvents(soundBank)));
 
                     if (soundBank.DialogueEvents.Count != 0)
                     {
                         // Create a .bnk of the compiled Dialogue Events merged with vanilla Dialogue Events for modders to test
                         _logger.Here().Information($"Generating SoundBank {soundBank.TestingFilePath} and {soundBank.MergingFilePath}");
-                        outputs.Add(
+                        outputs.AddRange(ExpandSoundBankOutput(
+                            soundBank,
                             _soundBankGeneratorService
-                                .GenerateDialogueEventsForTestingSoundBank(soundBank));
+                                .GenerateDialogueEventsForTestingSoundBank(soundBank)));
 
                         // Create the .bnk that modders should give to the merger
-                        outputs.Add(
+                        outputs.AddRange(ExpandSoundBankOutput(
+                            soundBank,
                             _soundBankGeneratorService
-                                .GenerateMergingSoundBank(soundBank));
+                                .GenerateMergingSoundBank(soundBank)));
                     }
                 }
             }
 
             return outputs;
+        }
+
+        private static IEnumerable<AudioPackOutput> ExpandSoundBankOutput(
+            SoundBank soundBank,
+            AudioPackOutput output)
+        {
+            if (soundBank.GameSoundBank != Wh3SoundBank.FrontendVO)
+                return [output];
+
+            return Enum.GetValues<Wh3Language>()
+                .Where(language => language != Wh3Language.Sfx)
+                .Select(language => output with
+                {
+                    FilePath =
+                        $"{AudioProjectCompileTarget.AllLanguages.OutputDirectory}\\{Wh3LanguageInformation.GetLanguageAsString(language)}\\{output.FileName}"
+                });
         }
 
         private List<AudioPackOutput> GenerateDatFiles(

--- a/Testing/AssetEditorTests/AudioEditorCompilerTests.cs
+++ b/Testing/AssetEditorTests/AudioEditorCompilerTests.cs
@@ -526,8 +526,75 @@ namespace AssetEditorTests
                 "audio\\wwise\\771.wem");
         }
 
+        [TestMethod]
+        public async Task Compile_FrontendVo_WritesBnkToEveryVoiceLanguageRegardlessOfTarget()
+        {
+            var allLanguagesOutputPaths = await CompileAndCaptureOutputPaths(
+                AudioProjectCompileTarget.AllLanguages,
+                Wh3SoundBank.FrontendVO);
+            var selectedLanguageOutputPaths = await CompileAndCaptureOutputPaths(
+                new AudioProjectCompileTarget(Wh3Language.Chinese),
+                Wh3SoundBank.FrontendVO);
+            string[] voiceLanguages =
+            [
+                "chinese",
+                "english(uk)",
+                "french(france)",
+                "german",
+                "italian",
+                "polish",
+                "russian",
+                "spanish(spain)"
+            ];
+            string[] soundBankFileNames =
+            [
+                "frontend_vo_target.bnk",
+                "frontend_vo_1_target_for_testing.bnk",
+                "frontend_vo_target_for_merging.bnk"
+            ];
+
+            foreach (var outputPaths in new[]
+                     {
+                         allLanguagesOutputPaths,
+                         selectedLanguageOutputPaths
+                     })
+            {
+                var soundBankPaths = outputPaths
+                    .Where(path => path.EndsWith(
+                        ".bnk",
+                        StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                Assert.AreEqual(24, soundBankPaths.Count);
+
+                foreach (var language in voiceLanguages)
+                {
+                    foreach (var soundBankFileName in soundBankFileNames)
+                    {
+                        CollectionAssert.Contains(
+                            soundBankPaths,
+                            $"audio\\wwise\\{language}\\{soundBankFileName}");
+                    }
+                }
+
+                foreach (var soundBankFileName in soundBankFileNames)
+                {
+                    CollectionAssert.DoesNotContain(
+                        soundBankPaths,
+                        $"audio\\wwise\\{soundBankFileName}");
+                }
+            }
+
+            CollectionAssert.Contains(
+                allLanguagesOutputPaths,
+                "audio\\wwise\\771.wem");
+            CollectionAssert.Contains(
+                selectedLanguageOutputPaths,
+                "audio\\wwise\\chinese\\771.wem");
+        }
+
         private static async Task<List<string>> CompileAndCaptureOutputPaths(
-            AudioProjectCompileTarget compileTarget)
+            AudioProjectCompileTarget compileTarget,
+            Wh3SoundBank gameSoundBank = Wh3SoundBank.BattleIndividualMagic)
         {
             const uint sourceId = 771;
             var audioFile = new AudioFile(
@@ -544,20 +611,33 @@ namespace AssetEditorTests
                 "english(uk)",
                 Editors.Audio.Shared.AudioProject.Models.HircSettings
                     .CreateDefaultSoundSettings());
+            var soundBankName =
+                $"{Wh3SoundBankInformation.GetName(gameSoundBank)}_target";
             var soundBank = new SoundBank(
-                "battle_individual_magic_target",
-                Wh3SoundBank.BattleIndividualMagic,
+                soundBankName,
+                gameSoundBank,
                 "english(uk)");
             soundBank.Sounds.Add(sound);
-            soundBank.ActionEvents.Add(new ActionEvent(
-                44,
-                "target_event",
-                [AudioProjectAction.CreatePlay(
-                    43,
-                    AkBkHircType.Sound,
-                    sound.Id,
-                    soundBank.Id)],
-                Wh3ActionEventType.BattleAbilities));
+            if (gameSoundBank == Wh3SoundBank.FrontendVO)
+            {
+                var dialogueEvent = new DialogueEvent(
+                    "frontend_vo_character_select");
+                dialogueEvent.StatePaths.Add(
+                    new StatePath([], sound.Id, AkBkHircType.Sound));
+                soundBank.DialogueEvents.Add(dialogueEvent);
+            }
+            else
+            {
+                soundBank.ActionEvents.Add(new ActionEvent(
+                    44,
+                    "target_event",
+                    [AudioProjectAction.CreatePlay(
+                        43,
+                        AkBkHircType.Sound,
+                        sound.Id,
+                        soundBank.Id)],
+                    Wh3ActionEventType.BattleAbilities));
+            }
             var project = new AudioProjectFile
             {
                 Language = "english(uk)",
@@ -599,6 +679,20 @@ namespace AssetEditorTests
                 .Returns((SoundBank bank) => new AudioPackOutput(
                     bank.FileName,
                     bank.FilePath,
+                    [1]));
+            soundBankGenerator
+                .Setup(x => x.GenerateDialogueEventsForTestingSoundBank(
+                    It.IsAny<SoundBank>()))
+                .Returns((SoundBank bank) => new AudioPackOutput(
+                    bank.TestingFileName,
+                    bank.TestingFilePath,
+                    [1]));
+            soundBankGenerator
+                .Setup(x => x.GenerateMergingSoundBank(
+                    It.IsAny<SoundBank>()))
+                .Returns((SoundBank bank) => new AudioPackOutput(
+                    bank.MergingFileName,
+                    bank.MergingFilePath,
                     [1]));
             var savedOutputs = new List<AudioPackOutput>();
             var outputService = new Mock<IAudioPackOutputService>();


### PR DESCRIPTION
## 变更

- FrontendVO 的主 BNK、测试 BNK 和合并 BNK 各生成到 8 个实际配音语言目录
- 不再把 FrontendVO BNK 输出到 audio\\wwise 根目录，也不创建 sfx 目录副本
- WEM 继续遵循用户选择的编译目标，其他 SoundBank 行为保持不变
- BNK 数据只生成一次，再复制到各语言路径

## 根因

所有语言编译此前把所有 BNK 统一写到 audio\\wwise，但战锤 3 的 FrontendVO 不使用普通根目录回退，因此选人界面会继续播放原始英文语音。

## 验证

- 新回归测试在修复前失败：期望 24 个 FrontendVO BNK，实际 3 个
- 修复后针对性测试通过：1/1
- AudioEditorCompilerTests 回归通过：12/12
- Release 构建成功，0 错误
- 用户已完成游戏内实测并确认通过