### PR TITLE
Add truthful progress and harden the updater

### DIFF
--- a/AssetEditor/Language_Cn.json
+++ b/AssetEditor/Language_Cn.json
@@ -227,6 +227,7 @@
   "OperationProgress.AudioMerge": "正在合并音频工程",
   "AudioOperation.Compile.Preparing": "正在准备音频工程数据",
   "AudioOperation.Compile.Wems": "正在生成 WEM 音频",
+  "AudioOperation.Compile.Wwise": "正在通过 Wwise 转换音频",
   "AudioOperation.Compile.SoundBanks": "正在生成 SoundBank",
   "AudioOperation.Compile.EventData": "正在生成事件数据",
   "AudioOperation.Convert.Parsing": "正在读取待转换的 SoundBank",

--- a/AssetEditor/ViewModels/FolderProjectHistoryViewModel.cs
+++ b/AssetEditor/ViewModels/FolderProjectHistoryViewModel.cs
@@ -149,7 +149,7 @@ public partial class FolderProjectHistoryViewModel : ObservableObject
             return;
 
         await RunOperation(
-            () => LoadSnapshot(projectRoot),
+            () => LoadSnapshot(projectRoot, validateUnrecordedChanges: true),
             ApplySnapshot);
     }
 
@@ -254,7 +254,8 @@ public partial class FolderProjectHistoryViewModel : ObservableObject
             {
                 HistorySnapshot? snapshot = null;
                 ReportProgress(new FolderProjectHistoryProgress(
-                    FolderProjectHistoryProgressStage.PreparingEditors));
+                    FolderProjectHistoryProgressStage.PreparingEditors,
+                    project.ProjectRoot));
                 await _coordinator.ExecuteTransactionalAsync(
                     project.ProjectRoot,
                     () =>
@@ -265,14 +266,16 @@ public partial class FolderProjectHistoryViewModel : ObservableObject
                             ReportProgress);
                         ReportProgress(new FolderProjectHistoryProgress(
                             FolderProjectHistoryProgressStage
-                                .ReconcilingProject));
+                                .ReconcilingProject,
+                            project.ProjectRoot));
                         return result;
                     },
                     _ =>
                     {
                         ReportProgress(new FolderProjectHistoryProgress(
                             FolderProjectHistoryProgressStage
-                                .RefreshingInterface));
+                                .RefreshingInterface,
+                            project.ProjectRoot));
                         snapshot = LoadSnapshot(project.ProjectRoot);
                     },
                     result => _historyService.RollbackProjectRestore(
@@ -301,13 +304,27 @@ public partial class FolderProjectHistoryViewModel : ObservableObject
         await RunOperation(
             () => ExecuteWorkspaceFileOperation(
                 project,
-                () => _historyService.BeginRestoreFile(
-                    project.ProjectRoot,
-                    change.Kind == FolderProjectRestorePointChangeKind.Deleted
-                        ? restorePoint.PreviousRestorePointId!
-                        : restorePoint.Id,
-                    change.Path,
-                    overwrite),
+                () =>
+                {
+                    ReportProgress(new FolderProjectHistoryProgress(
+                        FolderProjectHistoryProgressStage.WritingProjectFiles,
+                        change.Path,
+                        0,
+                        1));
+                    var operation = _historyService.BeginRestoreFile(
+                        project.ProjectRoot,
+                        change.Kind == FolderProjectRestorePointChangeKind.Deleted
+                            ? restorePoint.PreviousRestorePointId!
+                            : restorePoint.Id,
+                        change.Path,
+                        overwrite);
+                    ReportProgress(new FolderProjectHistoryProgress(
+                        FolderProjectHistoryProgressStage.WritingProjectFiles,
+                        change.Path,
+                        1,
+                        1));
+                    return operation;
+                },
                 _historyService.CompleteRestoreFile,
                 _historyService.RollbackRestoreFile),
             ApplySnapshot);
@@ -425,14 +442,16 @@ public partial class FolderProjectHistoryViewModel : ObservableObject
             {
                 var result = operation();
                 ReportProgress(new FolderProjectHistoryProgress(
-                    FolderProjectHistoryProgressStage.ReconcilingProject));
+                    FolderProjectHistoryProgressStage.ReconcilingProject,
+                    project.ProjectRoot));
                 return result;
             },
             result =>
             {
                 project.RefreshFromDisk();
                 ReportProgress(new FolderProjectHistoryProgress(
-                    FolderProjectHistoryProgressStage.RefreshingInterface));
+                    FolderProjectHistoryProgressStage.RefreshingInterface,
+                    project.ProjectRoot));
                 snapshot = LoadSnapshot(project.ProjectRoot);
                 complete(result);
             },
@@ -519,9 +538,13 @@ public partial class FolderProjectHistoryViewModel : ObservableObject
         }
     }
 
-    private HistorySnapshot LoadSnapshot(string projectRoot)
+    private HistorySnapshot LoadSnapshot(
+        string projectRoot,
+        bool validateUnrecordedChanges = false)
     {
-        var status = _historyService.GetDisplayStatus(projectRoot);
+        var status = validateUnrecordedChanges
+            ? _historyService.GetStatus(projectRoot, ReportProgress)
+            : _historyService.GetDisplayStatus(projectRoot);
         var restorePoints = status.Availability ==
                             FolderProjectHistoryAvailability.NotInitialized
             ? []

--- a/AssetEditorUpdater/AssetEditorUpdater.cs
+++ b/AssetEditorUpdater/AssetEditorUpdater.cs
@@ -16,34 +16,77 @@ namespace AssetEditorUpdater
         private const string AssetEditorExe = "AssetEditor.CN.exe";
         private const string AssetEditorUpdaterExe = "AssetEditor.CN.Updater.exe";
          
-        public static async Task Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
-            var currentDirectory = AppContext.BaseDirectory;
-            var invocation = ParseInvocation(currentDirectory, args);
-
-            Console.WriteLine($"国区版更新器运行目录：{currentDirectory}");
-
-            if (invocation.IsInitialLaunch)
+            try
             {
-                var layout = UpdaterWorkspaceFactory.GetLayout(
-                    UpdaterWorkspaceFactory.IsProcessElevated(),
-                    Guid.NewGuid());
-                var workspace = UpdaterWorkspaceFactory.Create(layout);
-                RelaunchFromUpdateDirectory(
-                    currentDirectory,
-                    workspace,
-                    invocation.InstallationDirectory);
+                var currentDirectory = AppContext.BaseDirectory;
+                var invocation = ParseInvocation(currentDirectory, args);
+
+                Console.WriteLine($"国区版更新器运行目录：{currentDirectory}");
+
+                if (invocation.IsInitialLaunch)
+                {
+                    var layout = UpdaterWorkspaceFactory.GetLayout(
+                        UpdaterWorkspaceFactory.IsProcessElevated(),
+                        Guid.NewGuid());
+                    var workspace = UpdaterWorkspaceFactory.Create(layout);
+                    RelaunchFromUpdateDirectory(
+                        currentDirectory,
+                        workspace,
+                        invocation.InstallationDirectory);
+                }
+                else
+                {
+                    var updateDirectory = invocation.UpdateDirectory!;
+                    var workspace = UpdateInstaller.ValidateDirectoryLayout(
+                        invocation.InstallationDirectory,
+                        updateDirectory,
+                        UpdaterWorkspaceFactory.IsProcessElevated());
+                    await RunUpdateAndWaitAsync(
+                        () => UpdateAsync(
+                            invocation.InstallationDirectory,
+                            workspace),
+                        WaitForExit);
+                }
+
+                return 0;
             }
-            else
+            catch (Exception exception)
             {
-                var updateDirectory = invocation.UpdateDirectory!;
-                var workspace = UpdateInstaller.ValidateDirectoryLayout(
-                    invocation.InstallationDirectory,
-                    updateDirectory,
-                    UpdaterWorkspaceFactory.IsProcessElevated());
-                await UpdateAsync(
-                    invocation.InstallationDirectory,
-                    workspace);
+                Console.Error.WriteLine($"更新失败：{exception.Message}");
+                Console.Error.WriteLine(exception);
+                WaitForExit();
+                return 1;
+            }
+        }
+
+        internal static async Task RunUpdateAndWaitAsync(
+            Func<Task> updateAsync,
+            Action waitForExit)
+        {
+            ArgumentNullException.ThrowIfNull(updateAsync);
+            ArgumentNullException.ThrowIfNull(waitForExit);
+
+            await updateAsync();
+            waitForExit();
+        }
+
+        private static void WaitForExit()
+        {
+            Console.WriteLine("按任意键关闭。");
+            if (Console.IsInputRedirected || Console.IsOutputRedirected)
+                return;
+
+            try
+            {
+                Console.ReadKey(intercept: true);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+            catch (IOException)
+            {
             }
         }
 
@@ -103,7 +146,7 @@ namespace AssetEditorUpdater
                     AssetEditorUpdaterExe);
                 var processStartInfo = CreateUpdaterProcessStartInfo(
                     newUpdaterPath,
-                    workspace.UpdateDirectory,
+                    installationDirectory,
                     installationDirectory,
                     workspace.UpdateDirectory);
 
@@ -313,8 +356,6 @@ namespace AssetEditorUpdater
             else
                 Console.WriteLine("更新失败：未找到 AssetEditor.CN.exe。");
 
-            Console.WriteLine("按任意键关闭。");
-            Console.ReadKey();
         }
 
         private static async Task<GiteeRelease?> GetLatestReleaseAsync(HttpClient httpClient)
@@ -525,12 +566,14 @@ namespace AssetEditorUpdater
             return UpdateInstaller.GetBackupRootDirectory(GetUpdateDirectory());
         }
 
-        private static async Task<bool> DownloadAssetAsync(
+        internal static async Task<bool> DownloadAssetAsync(
             HttpClient httpClient,
             GiteeDownloadPlan downloadPlan,
             string downloadPath,
             string installationDirectory,
-            UpdaterWorkspace workspace)
+            UpdaterWorkspace workspace,
+            string? localApplicationDataRoot = null,
+            string? commonApplicationDataRoot = null)
         {
             Console.WriteLine("正在下载最新版本……");
 
@@ -541,13 +584,17 @@ namespace AssetEditorUpdater
                     downloadPlan,
                     downloadPath,
                     installationDirectory,
-                    workspace);
+                    workspace,
+                    localApplicationDataRoot,
+                    commonApplicationDataRoot);
 
                 return true;
             }
-            catch
+            catch (Exception exception)
             {
-                Console.WriteLine("无法从 Gitee 下载并校验最新版本。");
+                Console.Error.WriteLine(
+                    $"无法从 Gitee 下载并校验最新版本：{exception.Message}");
+                Console.Error.WriteLine(exception);
                 return false;
             }
         }

--- a/Editors/Audio/AudioEditor/Presentation/AudioEditorView.xaml
+++ b/Editors/Audio/AudioEditor/Presentation/AudioEditorView.xaml
@@ -27,6 +27,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/Editors.Audio;component/AudioUiStyles.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Shared.Ui;component/Common/Styles/GridSplitterStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter"/>
         </ResourceDictionary>
@@ -208,11 +209,13 @@
 
                     <Grid.RowDefinitions>
                         <RowDefinition 
-                            Height="*"/>
+                            Height="3*"
+                            MinHeight="180"/>
                         <RowDefinition 
                             Height="Auto"/>
                         <RowDefinition 
-                            Height="*"/>
+                            Height="2*"
+                            MinHeight="160"/>
                         <RowDefinition 
                             Height="Auto"/>
                         <RowDefinition 
@@ -227,7 +230,7 @@
                     <GridSplitter
                         Grid.Row="1"
                         Height="5"
-                        Background="{DynamicResource AeBrush.Border}"
+                        Style="{StaticResource AeHorizontalGridSplitterStyle}"
                         VerticalAlignment="Center"
                         HorizontalAlignment="Stretch"
                         ResizeBehavior="PreviousAndNext"
@@ -241,7 +244,7 @@
                     <GridSplitter
                         Grid.Row="3"
                         Height="5"
-                        Background="{DynamicResource AeBrush.Border}"
+                        Style="{StaticResource AeHorizontalGridSplitterStyle}"
                         VerticalAlignment="Center"
                         HorizontalAlignment="Stretch"
                         ResizeBehavior="PreviousAndNext"

--- a/Editors/Audio/Shared/AudioProject/Compiler/AudioProjectCompilerService.cs
+++ b/Editors/Audio/Shared/AudioProject/Compiler/AudioProjectCompilerService.cs
@@ -150,7 +150,8 @@ namespace Editors.Audio.Shared.AudioProject.Compiler
                             compileTarget.OutputDirectory,
                             audioFiles,
                             sounds,
-                            cancellationToken);
+                            cancellationToken,
+                            progress);
                         progress?.Report(new AudioOperationProgress(
                             "AudioOperation.Compile.Preparing",
                             audioProjectFileName,
@@ -170,7 +171,8 @@ namespace Editors.Audio.Shared.AudioProject.Compiler
                                 audioFiles,
                                 sounds,
                                 workspacePath,
-                                cancellationToken));
+                                cancellationToken,
+                                progress));
                         progress?.Report(new AudioOperationProgress(
                             "AudioOperation.Compile.Wems",
                             $"{wemCount} WEM",
@@ -194,7 +196,8 @@ namespace Editors.Audio.Shared.AudioProject.Compiler
                             soundBankCount));
                         generatedOutputs.AddRange(GenerateSoundBanks(
                             audioProject,
-                            cancellationToken));
+                            cancellationToken,
+                            progress));
                         progress?.Report(new AudioOperationProgress(
                             "AudioOperation.Compile.SoundBanks",
                             audioProjectFileName,
@@ -235,9 +238,7 @@ namespace Editors.Audio.Shared.AudioProject.Compiler
 
                 progress?.Report(new AudioOperationProgress(
                     "AudioOperation.Saving",
-                    audioProjectFilePath,
-                    0,
-                    compilationResult.Outputs.Count));
+                    audioProjectFilePath));
                 _audioPackOutputService.SaveBatch(
                     compilationResult.Outputs);
                 progress?.Report(new AudioOperationProgress(
@@ -286,13 +287,17 @@ namespace Editors.Audio.Shared.AudioProject.Compiler
             string outputDirectory,
             List<AudioFile> audioFiles,
             List<Sound> sounds,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            IProgress<AudioOperationProgress>? progress)
         {
             _logger.Here().Information($"Setting SoundBank data");
 
-            foreach (var soundBank in audioProject.SoundBanks)
+            for (var index = 0;
+                 index < audioProject.SoundBanks.Count;
+                 index++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                var soundBank = audioProject.SoundBanks[index];
 
                 soundBank.FileName = $"{soundBank.Name}.bnk";
                 soundBank.FilePath =
@@ -340,6 +345,12 @@ namespace Editors.Audio.Shared.AudioProject.Compiler
                         workspacePath,
                         outputDirectory,
                         cancellationToken);
+
+                progress?.Report(new AudioOperationProgress(
+                    "AudioOperation.Compile.Preparing",
+                    soundBank.FilePath,
+                    index + 1,
+                    audioProject.SoundBanks.Count));
             }
         }
 
@@ -485,7 +496,8 @@ namespace Editors.Audio.Shared.AudioProject.Compiler
             List<AudioFile> audioFiles,
             List<Sound> sounds,
             string workspacePath,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            IProgress<AudioOperationProgress>? progress)
         {
             var uniqueAudioFiles = audioFiles
                 .DistinctBy(audioFile => audioFile.Id)
@@ -497,10 +509,22 @@ namespace Editors.Audio.Shared.AudioProject.Compiler
             if (uniqueAudioFiles.Count > 0)
             {
                 _logger.Here().Information($"Generating {uniqueAudioFiles.Count} WEMs");
-                await _wemGeneratorService.GenerateWemsAsync(
-                    uniqueAudioFiles,
-                    workspacePath,
-                    cancellationToken);
+                if (_wemGeneratorService is IWemGeneratorProgressService
+                    progressService)
+                {
+                    await progressService.GenerateWemsAsync(
+                        uniqueAudioFiles,
+                        workspacePath,
+                        progress,
+                        cancellationToken);
+                }
+                else
+                {
+                    await _wemGeneratorService.GenerateWemsAsync(
+                        uniqueAudioFiles,
+                        workspacePath,
+                        cancellationToken);
+                }
                 if (cancellationToken.IsCancellationRequested)
                     return [];
 
@@ -534,39 +558,49 @@ namespace Editors.Audio.Shared.AudioProject.Compiler
 
         private List<AudioPackOutput> GenerateSoundBanks(
             AudioProjectFile audioProject,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            IProgress<AudioOperationProgress>? progress)
         {
             var outputs = new List<AudioPackOutput>();
-            foreach (var soundBank in audioProject.SoundBanks)
+            var soundBanks = audioProject.SoundBanks
+                .Where(soundBank =>
+                    soundBank.ActionEvents.Count != 0 ||
+                    soundBank.DialogueEvents.Count != 0)
+                .ToList();
+            for (var index = 0; index < soundBanks.Count; index++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                var soundBank = soundBanks[index];
 
-                if (soundBank.ActionEvents.Count != 0 || soundBank.DialogueEvents.Count != 0)
+                _logger.Here().Information($"Generating SoundBank {soundBank.FilePath}");
+
+                // Create the .bnk that modders should keep
+                outputs.AddRange(ExpandSoundBankOutput(
+                    soundBank,
+                    _soundBankGeneratorService
+                        .GenerateSoundBankWithoutDialogueEvents(soundBank)));
+
+                if (soundBank.DialogueEvents.Count != 0)
                 {
-                    _logger.Here().Information($"Generating SoundBank {soundBank.FilePath}");
-
-                    // Create the .bnk that modders should keep
+                    // Create a .bnk of the compiled Dialogue Events merged with vanilla Dialogue Events for modders to test
+                    _logger.Here().Information($"Generating SoundBank {soundBank.TestingFilePath} and {soundBank.MergingFilePath}");
                     outputs.AddRange(ExpandSoundBankOutput(
                         soundBank,
                         _soundBankGeneratorService
-                            .GenerateSoundBankWithoutDialogueEvents(soundBank)));
+                            .GenerateDialogueEventsForTestingSoundBank(soundBank)));
 
-                    if (soundBank.DialogueEvents.Count != 0)
-                    {
-                        // Create a .bnk of the compiled Dialogue Events merged with vanilla Dialogue Events for modders to test
-                        _logger.Here().Information($"Generating SoundBank {soundBank.TestingFilePath} and {soundBank.MergingFilePath}");
-                        outputs.AddRange(ExpandSoundBankOutput(
-                            soundBank,
-                            _soundBankGeneratorService
-                                .GenerateDialogueEventsForTestingSoundBank(soundBank)));
-
-                        // Create the .bnk that modders should give to the merger
-                        outputs.AddRange(ExpandSoundBankOutput(
-                            soundBank,
-                            _soundBankGeneratorService
-                                .GenerateMergingSoundBank(soundBank)));
-                    }
+                    // Create the .bnk that modders should give to the merger
+                    outputs.AddRange(ExpandSoundBankOutput(
+                        soundBank,
+                        _soundBankGeneratorService
+                            .GenerateMergingSoundBank(soundBank)));
                 }
+
+                progress?.Report(new AudioOperationProgress(
+                    "AudioOperation.Compile.SoundBanks",
+                    soundBank.FilePath,
+                    index + 1,
+                    soundBanks.Count));
             }
 
             return outputs;

--- a/Editors/Audio/Shared/Wwise/Generators/WemGeneratorService.cs
+++ b/Editors/Audio/Shared/Wwise/Generators/WemGeneratorService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Editors.Audio.Shared.AudioProject;
 using Editors.Audio.Shared.AudioProject.Models;
+using Editors.Audio.Shared.Storage;
 using Shared.Core.Misc;
 using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
@@ -22,7 +23,16 @@ namespace Editors.Audio.Shared.Wwise.Generators
             List<AudioFile> audioFiles);
     }
 
-    public class WemGeneratorService(IPackFileService packFileService, WSourcesWrapper wSourcesWrapper) : IWemGeneratorService
+    public interface IWemGeneratorProgressService
+    {
+        Task GenerateWemsAsync(
+            List<AudioFile> audioFiles,
+            string workspacePath,
+            IProgress<AudioOperationProgress>? progress,
+            CancellationToken cancellationToken = default);
+    }
+
+    public class WemGeneratorService(IPackFileService packFileService, WSourcesWrapper wSourcesWrapper) : IWemGeneratorService, IWemGeneratorProgressService
     {
         private readonly IPackFileService _packFileService = packFileService;
         private readonly WSourcesWrapper _wSourcesWrapper = wSourcesWrapper;
@@ -30,6 +40,17 @@ namespace Editors.Audio.Shared.Wwise.Generators
         public async Task GenerateWemsAsync(
             List<AudioFile> audioFiles,
             string workspacePath,
+            CancellationToken cancellationToken = default) =>
+            await GenerateWemsAsync(
+                audioFiles,
+                workspacePath,
+                progress: null,
+                cancellationToken);
+
+        public async Task GenerateWemsAsync(
+            List<AudioFile> audioFiles,
+            string workspacePath,
+            IProgress<AudioOperationProgress>? progress,
             CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -49,10 +70,11 @@ namespace Editors.Audio.Shared.Wwise.Generators
             var wavFileNames = new List<string>(audioFiles.Count);
             var preparationCompleted = await Task.Run(() =>
             {
-                foreach (var audioFile in audioFiles)
+                for (var index = 0; index < audioFiles.Count; index++)
                 {
                     if (cancellationToken.IsCancellationRequested)
                         return false;
+                    var audioFile = audioFiles[index];
 
                     var wavFile =
                         _packFileService.FindFile(
@@ -68,6 +90,11 @@ namespace Editors.Audio.Shared.Wwise.Generators
                         wavFileName);
                     ExportWav(wavFilePath, wavFile.DataSource);
                     wavFileNames.Add(wavFileName);
+                    progress?.Report(new AudioOperationProgress(
+                        "AudioOperation.Compile.Wems",
+                        audioFile.WavPackFilePath,
+                        index + 1,
+                        audioFiles.Count));
                 }
 
                 if (cancellationToken.IsCancellationRequested)
@@ -88,6 +115,9 @@ namespace Editors.Audio.Shared.Wwise.Generators
                 return;
 
             var arguments = $"\"{wprojPath}\" -ConvertExternalSources \"{wsourcesPath}\" -ExternalSourcesOutput \"{workspacePath}\"";
+            progress?.Report(new AudioOperationProgress(
+                "AudioOperation.Compile.Wwise",
+                wsourcesPath));
             try
             {
                 await _wSourcesWrapper.RunExternalCommandAsync(

--- a/Shared/SharedCore/PackFiles/Models/FolderProjectVersionControlModels.cs
+++ b/Shared/SharedCore/PackFiles/Models/FolderProjectVersionControlModels.cs
@@ -88,6 +88,7 @@ internal enum FolderProjectVersionControlProgressStage
 {
     PreparingRepository,
     ScanningWorkingTree,
+    CatalogingWorkingChanges,
     ProcessingWorkingChanges,
     IndexingFiles,
     CreatingInitialCommit,

--- a/Shared/SharedCore/PackFiles/Utility/FolderProjectHistoryService.cs
+++ b/Shared/SharedCore/PackFiles/Utility/FolderProjectHistoryService.cs
@@ -260,7 +260,8 @@ public sealed class FolderProjectHistoryService : IFolderProjectHistoryService
         {
             var summary = _versionControl.CommitAll(
                 projectRoot,
-                normalizedDescription);
+                normalizedDescription,
+                progress => reportProgress(MapProgress(progress)));
             var changes = LoadAndCacheRestorePointChanges(
                 projectRoot,
                 summary.Id,
@@ -691,6 +692,10 @@ public sealed class FolderProjectHistoryService : IFolderProjectHistoryService
                 FolderProjectVersionControlProgressStage.ScanningWorkingTree =>
                     FolderProjectHistoryProgressStage
                         .ScanningUnrecordedChanges,
+                FolderProjectVersionControlProgressStage
+                    .CatalogingWorkingChanges =>
+                    FolderProjectHistoryProgressStage
+                        .ProcessingUnrecordedChanges,
                 FolderProjectVersionControlProgressStage
                     .ProcessingWorkingChanges =>
                     FolderProjectHistoryProgressStage

--- a/Shared/SharedCore/PackFiles/Utility/FolderProjectVersionControlService.RestoreAndBranches.cs
+++ b/Shared/SharedCore/PackFiles/Utility/FolderProjectVersionControlService.RestoreAndBranches.cs
@@ -298,6 +298,17 @@ internal sealed partial class FolderProjectVersionControlService
                         new CheckoutOptions
                         {
                             CheckoutModifiers = CheckoutModifiers.Force,
+                            OnCheckoutProgress = (
+                                path,
+                                completedSteps,
+                                totalSteps) =>
+                                reportProgress(
+                                    new FolderProjectVersionControlProgress(
+                                        FolderProjectVersionControlProgressStage
+                                            .ProcessingWorkingChanges,
+                                        path?.Replace('\\', '/'),
+                                        completedSteps,
+                                        totalSteps)),
                         });
                 }
                 catch (Exception failure)

--- a/Shared/SharedCore/PackFiles/Utility/FolderProjectVersionControlService.cs
+++ b/Shared/SharedCore/PackFiles/Utility/FolderProjectVersionControlService.cs
@@ -51,6 +51,11 @@ internal interface IFolderProjectVersionControlService
         string projectRoot,
         string message);
 
+    FolderProjectCommitSummary CommitAll(
+        string projectRoot,
+        string message,
+        Action<FolderProjectVersionControlProgress> reportProgress);
+
     void StageChanges(
         string projectRoot,
         IReadOnlyList<string> relativePaths);
@@ -619,7 +624,7 @@ internal sealed partial class FolderProjectVersionControlService :
                 previousPaths[repositoryPath] = previousPath;
             reportProgress?.Invoke(new FolderProjectVersionControlProgress(
                 FolderProjectVersionControlProgressStage
-                    .ProcessingWorkingChanges,
+                    .CatalogingWorkingChanges,
                 repositoryPath,
                 index + 1,
                 statusEntries.Count));
@@ -1090,8 +1095,15 @@ internal sealed partial class FolderProjectVersionControlService :
 
     public FolderProjectCommitSummary CommitAll(
         string projectRoot,
-        string message)
+        string message) =>
+        CommitAll(projectRoot, message, _ => { });
+
+    public FolderProjectCommitSummary CommitAll(
+        string projectRoot,
+        string message,
+        Action<FolderProjectVersionControlProgress> reportProgress)
     {
+        ArgumentNullException.ThrowIfNull(reportProgress);
         if (string.IsNullOrWhiteSpace(message))
         {
             throw new FolderProjectVersionControlException(
@@ -1107,8 +1119,10 @@ internal sealed partial class FolderProjectVersionControlService :
                 var identity = ReadLocalIdentity(repository);
                 ValidateIdentity(identity);
                 var signature = CreateSignature(identity);
-                var changes = RetrieveWorkingStatus(repository);
-                if (!changes.Any())
+                var changes = RetrieveWorkingStatus(repository)
+                    .Where(entry => entry.State != FileStatus.Ignored)
+                    .ToList();
+                if (changes.Count == 0)
                 {
                     throw new FolderProjectVersionControlException(
                         FolderProjectVersionControlError.NothingToCommit,
@@ -1121,7 +1135,26 @@ internal sealed partial class FolderProjectVersionControlService :
                 Commit commit;
                 try
                 {
-                    Commands.Stage(repository, "*");
+                    for (var index = 0; index < changes.Count; index++)
+                    {
+                        var change = changes[index];
+                        var repositoryPath = change.FilePath.Replace('\\', '/');
+                        var paths = new[]
+                            {
+                                repositoryPath,
+                                GetPreviousRepositoryPath(change),
+                            }
+                            .Where(path => !string.IsNullOrWhiteSpace(path))
+                            .Distinct(StringComparer.OrdinalIgnoreCase)
+                            .Cast<string>()
+                            .ToArray();
+                        Commands.Stage(repository, paths);
+                        reportProgress(new FolderProjectVersionControlProgress(
+                            FolderProjectVersionControlProgressStage.IndexingFiles,
+                            repositoryPath,
+                            index + 1,
+                            changes.Count));
+                    }
                     commit = _platform.Commit(
                         repository,
                         message.Trim(),

--- a/Testing/AssetEditorTests/AudioEditorCompilerTests.cs
+++ b/Testing/AssetEditorTests/AudioEditorCompilerTests.cs
@@ -11,6 +11,7 @@ using Editors.Audio.Shared.Wwise;
 using Editors.Audio.Shared.Wwise.Generators;
 using Editors.Audio.Shared.Wwise.Generators.Hirc.V136;
 using Moq;
+using Shared.Core.PackFiles;
 using Shared.Core.PackFiles.Models;
 using Shared.Core.Settings;
 using Shared.GameFormats.Wwise;
@@ -419,6 +420,85 @@ namespace AssetEditorTests
                 .All(value =>
                     value.Completed >= 0 &&
                     value.Completed <= value.Total));
+            Assert.IsTrue(progress.Values.Any(value =>
+                value.StageResourceKey ==
+                    "AudioOperation.Compile.SoundBanks" &&
+                value.Detail.EndsWith(
+                    "battle_individual_magic_test.bnk",
+                    StringComparison.OrdinalIgnoreCase) &&
+                value.Completed == 1 &&
+                value.Total == 1));
+        }
+
+        [TestMethod]
+        public async Task WemGenerator_ReportsEachExportedWavWithExactProgress()
+        {
+            var workspacePath = Path.Combine(
+                Path.GetTempPath(),
+                $"ae-wem-progress-{Guid.NewGuid():N}");
+            var audioFiles = new List<AudioFile>
+            {
+                new(
+                    Guid.NewGuid(),
+                    101,
+                    "first.wav",
+                    "audio\\first.wav"),
+                new(
+                    Guid.NewGuid(),
+                    102,
+                    "second.wav",
+                    "audio\\second.wav"),
+            };
+            var packFiles = audioFiles.ToDictionary(
+                audioFile => audioFile.WavPackFilePath,
+                audioFile => PackFile.CreateFromBytes(
+                    audioFile.WavPackFileName,
+                    [1, 2, 3]),
+                StringComparer.OrdinalIgnoreCase);
+            var packFileService = new Mock<IPackFileService>();
+            packFileService.Setup(service => service.FindFile(
+                    It.IsAny<string>(),
+                    It.IsAny<PackFileContainer?>()))
+                .Returns((string path, PackFileContainer? _) =>
+                    packFiles.GetValueOrDefault(path));
+            using var cancellationTokenSource =
+                new CancellationTokenSource();
+            var progress = new RecordingProgress<AudioOperationProgress>(
+                value =>
+                {
+                    if (value.Completed == audioFiles.Count)
+                        cancellationTokenSource.Cancel();
+                });
+            var generator = new WemGeneratorService(
+                packFileService.Object,
+                new WSourcesWrapper(null!));
+
+            try
+            {
+                await generator.GenerateWemsAsync(
+                    audioFiles,
+                    workspacePath,
+                    progress,
+                    cancellationTokenSource.Token);
+            }
+            finally
+            {
+                if (Directory.Exists(workspacePath))
+                    Directory.Delete(workspacePath, recursive: true);
+            }
+
+            var wavProgress = progress.Values.Where(value =>
+                    value.StageResourceKey ==
+                        "AudioOperation.Compile.Wems" &&
+                    value.Total > 0)
+                .ToArray();
+            CollectionAssert.AreEqual(
+                new[] { "audio\\first.wav", "audio\\second.wav" },
+                wavProgress.Select(value => value.Detail).ToArray());
+            CollectionAssert.AreEqual(
+                new[] { 1, 2 },
+                wavProgress.Select(value => value.Completed).ToArray());
+            Assert.IsTrue(wavProgress.All(value => value.Total == 2));
         }
 
         [TestMethod]
@@ -496,6 +576,52 @@ namespace AssetEditorTests
                     It.IsAny<IReadOnlyCollection<AudioPackOutput>>(),
                     It.IsAny<bool>()),
                 Times.Never);
+        }
+
+        [TestMethod]
+        public async Task Compile_ReportsEachPreparedSoundBankWithExactProgress()
+        {
+            var project = new AudioProjectFile
+            {
+                Language = "sfx",
+                SoundBanks =
+                [
+                    new SoundBank(
+                        "bank_one",
+                        Wh3SoundBank.BattleIndividualMagic,
+                        "sfx"),
+                    new SoundBank(
+                        "bank_two",
+                        Wh3SoundBank.BattleIndividualMagic,
+                        "sfx"),
+                ],
+            };
+            var compiler = new AudioProjectCompilerService(
+                Mock.Of<ISoundBankGeneratorService>(),
+                Mock.Of<IWemGeneratorService>(),
+                Mock.Of<IDatGeneratorService>(),
+                Mock.Of<IAudioPackOutputService>());
+            var progress = new RecordingProgress<AudioOperationProgress>();
+
+            var completed = await ((IAudioProjectCompilerProgressService)
+                compiler).CompileAsync(
+                project,
+                "test.aproj",
+                "audio\\test.aproj",
+                AudioProjectCompileTarget.AllLanguages,
+                progress);
+
+            Assert.IsTrue(completed);
+            Assert.IsTrue(progress.Values.Any(value =>
+                value.StageResourceKey == "AudioOperation.Compile.Preparing" &&
+                value.Detail?.EndsWith("bank_one.bnk") == true &&
+                value.Completed == 1 &&
+                value.Total == 2));
+            Assert.IsTrue(progress.Values.Any(value =>
+                value.StageResourceKey == "AudioOperation.Compile.Preparing" &&
+                value.Detail?.EndsWith("bank_two.bnk") == true &&
+                value.Completed == 2 &&
+                value.Total == 2));
         }
 
         [TestMethod]
@@ -730,11 +856,16 @@ namespace AssetEditorTests
             return savedOutputs.Select(output => output.FilePath).ToList();
         }
 
-        private sealed class RecordingProgress<T> : IProgress<T>
+        private sealed class RecordingProgress<T>(
+            Action<T>? onReport = null) : IProgress<T>
         {
             public List<T> Values { get; } = [];
 
-            public void Report(T value) => Values.Add(value);
+            public void Report(T value)
+            {
+                Values.Add(value);
+                onReport?.Invoke(value);
+            }
         }
 
         private static CAkActorMixer_V136 CreateSpatialActorMixerTemplate(

--- a/Testing/AssetEditorTests/FolderProjectHistoryViewModelTests.cs
+++ b/Testing/AssetEditorTests/FolderProjectHistoryViewModelTests.cs
@@ -25,12 +25,14 @@ public class FolderProjectHistoryViewModelTests
     }
 
     [Test]
-    public async Task Refresh_UsesDisplayStatusAndShowsHistorySnapshot()
+    public async Task Refresh_UsesValidatedStatusAndShowsHistorySnapshot()
     {
         using var directory = new TemporaryDirectory();
         using var project = CreateProject(directory.Path);
         var history = CreateHistoryService(project.ProjectRoot);
-        history.Setup(item => item.GetDisplayStatus(project.ProjectRoot))
+        history.Setup(item => item.GetStatus(
+                project.ProjectRoot,
+                It.IsAny<Action<FolderProjectHistoryProgress>>()))
             .Returns(new FolderProjectHistoryStatus(
                 FolderProjectHistoryAvailability.Ready,
                 "head",
@@ -67,7 +69,7 @@ public class FolderProjectHistoryViewModelTests
         });
         history.Verify(item => item.GetStatus(
             project.ProjectRoot,
-            It.IsAny<Action<FolderProjectHistoryProgress>>()), Times.Never);
+            It.IsAny<Action<FolderProjectHistoryProgress>>()), Times.Once);
     }
 
     [Test]
@@ -92,8 +94,11 @@ public class FolderProjectHistoryViewModelTests
                     FolderProjectUnrecordedChangeKind.Modified),
             ]);
         var history = new Mock<IFolderProjectHistoryService>();
-        history.SetupSequence(item => item.GetDisplayStatus(projectRoot))
-            .Returns(recoveryStatus)
+        history.Setup(item => item.GetStatus(
+                projectRoot,
+                It.IsAny<Action<FolderProjectHistoryProgress>>()))
+            .Returns(recoveryStatus);
+        history.Setup(item => item.GetDisplayStatus(projectRoot))
             .Returns(readyStatus);
         history.Setup(item => item.GetRestorePoints(
                 projectRoot,
@@ -735,6 +740,16 @@ public class FolderProjectHistoryViewModelTests
         var viewModel = CreateViewModel(
             history.Object,
             dialogs: dialogs.Object);
+        var operationDetails = new List<string>();
+        viewModel.PropertyChanged += (_, eventArgs) =>
+        {
+            if (eventArgs.PropertyName ==
+                nameof(FolderProjectHistoryViewModel.OperationDetailText) &&
+                !string.IsNullOrWhiteSpace(viewModel.OperationDetailText))
+            {
+                operationDetails.Add(viewModel.OperationDetailText);
+            }
+        };
         viewModel.OpenProject(project);
         await viewModel.RefreshCommand.ExecuteAsync(null);
         viewModel.SelectedRestorePoint = point;
@@ -751,6 +766,7 @@ public class FolderProjectHistoryViewModelTests
             point.Id,
             change.Path,
             true), Times.Once);
+        NUnitAssert.That(operationDetails, Does.Contain(change.Path));
     }
 
     [Test]

--- a/Testing/AssetEditorTests/FolderProjectHistoryWorkspaceViewModelTests.cs
+++ b/Testing/AssetEditorTests/FolderProjectHistoryWorkspaceViewModelTests.cs
@@ -23,8 +23,9 @@ public sealed class FolderProjectHistoryWorkspaceViewModelTests
             directory.Path,
             new FolderProjectSettings { Name = "测试工程" });
         var historyService = new Mock<IFolderProjectHistoryService>();
-        historyService.Setup(item =>
-                item.GetDisplayStatus(project.ProjectRoot))
+        historyService.Setup(item => item.GetStatus(
+                project.ProjectRoot,
+                It.IsAny<Action<FolderProjectHistoryProgress>>()))
             .Returns(new FolderProjectHistoryStatus(
                 FolderProjectHistoryAvailability.Ready,
                 "head",
@@ -62,8 +63,9 @@ public sealed class FolderProjectHistoryWorkspaceViewModelTests
         workspace.SelectedSidebarTabIndex = 1;
         await history.RefreshCommand.ExecutionTask!;
 
-        historyService.Verify(item =>
-            item.GetDisplayStatus(project.ProjectRoot), Times.Once);
+        historyService.Verify(item => item.GetStatus(
+            project.ProjectRoot,
+            It.IsAny<Action<FolderProjectHistoryProgress>>()), Times.Once);
 
         workspace.SelectedSidebarTabIndex = 0;
         eventHub.Publish(new FolderProjectChangedEvent(
@@ -72,8 +74,9 @@ public sealed class FolderProjectHistoryWorkspaceViewModelTests
         workspace.SelectedSidebarTabIndex = 1;
         await history.RefreshCommand.ExecutionTask!;
 
-        historyService.Verify(item =>
-            item.GetDisplayStatus(project.ProjectRoot),
+        historyService.Verify(item => item.GetStatus(
+            project.ProjectRoot,
+            It.IsAny<Action<FolderProjectHistoryProgress>>()),
             Times.Exactly(2));
 
         workspace.SetEditableContainer(new PackFileContainer("普通.pack"));

--- a/Testing/AssetEditorTests/UiAudioEditorFamilyTests.cs
+++ b/Testing/AssetEditorTests/UiAudioEditorFamilyTests.cs
@@ -139,6 +139,33 @@ public class UiAudioEditorFamilyTests
         });
     }
 
+    [Test]
+    public void AudioEditor_EventSelectionGetsMostOfTheResizableLeftPane()
+    {
+        var source = ReadAudioSources().Single(item =>
+            item.Contains("AudioEditor.Menu.File.CompileAudioProject"));
+
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(
+                source,
+                Does.Match("<RowDefinition\\s+Height=\\\"3\\*\\\""));
+            NUnitAssert.That(
+                source,
+                Does.Match("<RowDefinition\\s+Height=\\\"2\\*\\\""));
+            NUnitAssert.That(
+                Regex.Matches(
+                    source,
+                    "Style=\\\"\\{StaticResource AeHorizontalGridSplitterStyle\\}\\\"")
+                    .Count,
+                Is.EqualTo(2));
+            NUnitAssert.That(
+                source,
+                Does.Contain(
+                    "Shared.Ui;component/Common/Styles/GridSplitterStyles.xaml"));
+        });
+    }
+
     private static IReadOnlyList<string> ReadAudioSources()
     {
         var root = FindSolutionRoot();

--- a/Testing/AssetEditorUpdaterTests/GiteeUpdateSourceTests.cs
+++ b/Testing/AssetEditorUpdaterTests/GiteeUpdateSourceTests.cs
@@ -94,6 +94,48 @@ public class GiteeUpdateSourceTests
     }
 
     [Test]
+    [NonParallelizable]
+    public async Task DownloadAssetAsync_FailureReportsOriginalException()
+    {
+        var root = CreateTemporaryDirectory();
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var originalOutput = Console.Out;
+        var originalError = Console.Error;
+        try
+        {
+            var testData = CreateTestDownload(root);
+            using var client = new HttpClient(
+                new PartResponseHandler(new Dictionary<Uri, byte[]>()));
+            Console.SetOut(output);
+            Console.SetError(error);
+
+            var result = await UpdaterProgram.DownloadAssetAsync(
+                client,
+                testData.Plan,
+                testData.ArchivePath,
+                testData.InstallationDirectory,
+                testData.Workspace,
+                testData.LocalRoot,
+                testData.CommonRoot);
+
+            var consoleText = output + error.ToString();
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.False);
+                Assert.That(consoleText, Does.Contain("无法从 Gitee 下载并校验最新版本"));
+                Assert.That(consoleText, Does.Contain("404"));
+            });
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+            Console.SetError(originalError);
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Test]
     [Explicit("Downloads and installs the current public Gitee release.")]
     public async Task LiveGiteeRelease_DownloadsVerifiesAndInstallsInIsolation()
     {

--- a/Testing/AssetEditorUpdaterTests/UpdaterWorkspaceTests.cs
+++ b/Testing/AssetEditorUpdaterTests/UpdaterWorkspaceTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text;
@@ -8,6 +9,64 @@ namespace AssetEditorUpdaterTests;
 
 public class UpdaterWorkspaceTests
 {
+    [Test]
+    public async Task RunUpdateAndWait_NormalEarlyReturnStillWaitsForUser()
+    {
+        var updateCount = 0;
+        var waitCount = 0;
+
+        await UpdaterProgram.RunUpdateAndWaitAsync(
+            () =>
+            {
+                updateCount++;
+                return Task.CompletedTask;
+            },
+            () => waitCount++);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(updateCount, Is.EqualTo(1));
+            Assert.That(waitCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void Main_SecondaryLaunchFailureReportsErrorBeforeClosing()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var originalOutput = Console.Out;
+        var originalError = Console.Error;
+        try
+        {
+            Console.SetOut(output);
+            Console.SetError(error);
+
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                Task mainTask = UpdaterProgram.Main(
+                [
+                    Path.Combine(Path.GetTempPath(), "missing-installation"),
+                    Path.Combine(Path.GetTempPath(), "missing-transaction", "Update"),
+                ]);
+                await mainTask;
+            });
+
+            var consoleText = output + error.ToString();
+            Assert.Multiple(() =>
+            {
+                Assert.That(consoleText, Does.Contain("更新失败"));
+                Assert.That(consoleText, Does.Contain("按任意键关闭"));
+            });
+        }
+        finally
+        {
+            Console.SetOut(originalOutput);
+            Console.SetError(originalError);
+        }
+    }
+
     [Test]
     public void ParseInvocation_ZeroArgumentsUsesCurrentUpdaterParentAsInstallationDirectory()
     {
@@ -82,6 +141,34 @@ public class UpdaterWorkspaceTests
                 startInfo.ArgumentList,
                 Is.EqualTo(new[] { installationDirectory, updateDirectory }));
         });
+    }
+
+    [Test]
+    public void RelaunchFromUpdateDirectory_UsesInstallationAsSecondaryWorkingDirectory()
+    {
+        var transactionRoot = Path.Combine(Path.GetTempPath(), "transaction");
+        var updateDirectory = Path.Combine(transactionRoot, "Update");
+        var installationDirectory = Path.Combine(Path.GetTempPath(), "installation");
+        var workspace = new UpdaterWorkspace(
+            transactionRoot,
+            updateDirectory,
+            IsProtected: false);
+        ProcessStartInfo? capturedStartInfo = null;
+
+        UpdaterProgram.RelaunchFromUpdateDirectory(
+            Path.Combine(Path.GetTempPath(), "payload"),
+            workspace,
+            installationDirectory,
+            (_, _, _) => new Dictionary<string, string>(),
+            (_, _) => workspace,
+            _ => null,
+            startInfo => capturedStartInfo = startInfo,
+            _ => Assert.Fail("Local relaunch failure must not request protected cleanup."));
+
+        Assert.That(capturedStartInfo, Is.Not.Null);
+        Assert.That(
+            capturedStartInfo!.WorkingDirectory,
+            Is.EqualTo(installationDirectory));
     }
 
     [Test]

--- a/Testing/Shared.Core.Test/PackFiles/FolderProjectHistoryServiceTests.cs
+++ b/Testing/Shared.Core.Test/PackFiles/FolderProjectHistoryServiceTests.cs
@@ -279,6 +279,14 @@ public sealed class FolderProjectHistoryServiceTests
                     change.Path == "db/entry.bin" &&
                     change.Kind.HasFlag(
                         FolderProjectUnrecordedChangeKind.Unreadable)));
+            Assert.That(
+                progress,
+                Has.Some.Matches<FolderProjectHistoryProgress>(item =>
+                    item.Stage == FolderProjectHistoryProgressStage
+                        .ProcessingUnrecordedChanges &&
+                    item.Detail == "db/entry.bin" &&
+                    item.Completed == item.Total &&
+                    item.Total == 1));
         });
     }
 
@@ -549,6 +557,43 @@ public sealed class FolderProjectHistoryServiceTests
     }
 
     [Test]
+    public void CreateRestorePoint_ReportsEachIndexedPathWithExactTotal()
+    {
+        using var project = new TemporaryProject();
+        var modifiedPath = Path.Combine(project.Root, "db", "modified.bin");
+        File.WriteAllBytes(modifiedPath, [1]);
+        var service = CreateService();
+        service.Initialize(project.Root);
+        File.WriteAllBytes(modifiedPath, [2]);
+        File.WriteAllBytes(
+            Path.Combine(project.Root, "db", "added.bin"),
+            [3]);
+        var progress = new List<FolderProjectHistoryProgress>();
+
+        service.CreateRestorePoint(
+            project.Root,
+            "记录两项修改",
+            progress.Add);
+
+        var indexedFiles = progress.Where(item =>
+                item.Stage == FolderProjectHistoryProgressStage.UpdatingHistory &&
+                item.Total > 0)
+            .ToList();
+        Assert.Multiple(() =>
+        {
+            Assert.That(indexedFiles, Is.Not.Empty);
+            Assert.That(indexedFiles.Last().Completed, Is.EqualTo(2));
+            Assert.That(indexedFiles.Last().Total, Is.EqualTo(2));
+            Assert.That(
+                indexedFiles.Select(item => item.Detail),
+                Does.Contain("db/modified.bin"));
+            Assert.That(
+                indexedFiles.Select(item => item.Detail),
+                Does.Contain("db/added.bin"));
+        });
+    }
+
+    [Test]
     public void CreateRestorePoint_StillReportsExactRenames()
     {
         using var project = new TemporaryProject();
@@ -591,6 +636,41 @@ public sealed class FolderProjectHistoryServiceTests
         Assert.That(
             service.GetRestorePoints(project.Root).Select(item => item.Id),
             Is.EqualTo(originalHistory.Select(item => item.Id)));
+    }
+
+    [Test]
+    public void RestoreProject_ReportsEachWrittenPathWithExactProgress()
+    {
+        using var project = new TemporaryProject();
+        var firstPath = Path.Combine(project.Root, "db", "first.bin");
+        var secondPath = Path.Combine(project.Root, "db", "second.bin");
+        File.WriteAllBytes(firstPath, [1]);
+        File.WriteAllBytes(secondPath, [2]);
+        var service = CreateService();
+        var target = service.Initialize(project.Root);
+        File.WriteAllBytes(firstPath, [3]);
+        File.WriteAllBytes(secondPath, [4]);
+        service.CreateRestorePoint(project.Root, "后续状态");
+        var progress = new List<FolderProjectHistoryProgress>();
+
+        service.RestoreProject(project.Root, target, progress.Add);
+
+        var writtenFiles = progress.Where(item =>
+                item.Stage == FolderProjectHistoryProgressStage
+                    .WritingProjectFiles &&
+                item.Total > 0)
+            .ToList();
+        Assert.Multiple(() =>
+        {
+            Assert.That(writtenFiles, Is.Not.Empty);
+            Assert.That(
+                writtenFiles.Last().Completed,
+                Is.EqualTo(writtenFiles.Last().Total));
+            Assert.That(
+                writtenFiles.Select(item => item.Detail),
+                Has.Some.EqualTo("db/first.bin")
+                    .Or.EqualTo("db/second.bin"));
+        });
     }
 
     [Test]
@@ -1192,7 +1272,8 @@ public sealed class FolderProjectHistoryServiceTests
         var firstVersionControl = new Mock<IFolderProjectVersionControlService>();
         firstVersionControl.Setup(item => item.CommitAll(
                 project.Root,
-                "记录当前状态"))
+                "记录当前状态",
+                It.IsAny<Action<FolderProjectVersionControlProgress>>()))
             .Returns(commit);
         firstVersionControl.Setup(item => item.GetCommitChangeSummary(
                 project.Root,
@@ -1294,7 +1375,8 @@ public sealed class FolderProjectHistoryServiceTests
             [new string('0', 40)]);
         versionControl.Setup(item => item.CommitAll(
                 "project",
-                "记录当前状态"))
+                "记录当前状态",
+                It.IsAny<Action<FolderProjectVersionControlProgress>>()))
             .Returns(commit);
         versionControl.Setup(item => item.GetCommitChanges(
                 "project",


### PR DESCRIPTION
## Summary
- report real file paths and exact counts for audio compilation and Folder Project History operations
- give the audio event-selection area more vertical space and use the shared horizontal splitter style
- keep the updater console open on every terminal path, show the original download failure, and prevent the updater from locking its own Update workspace

## Root cause
The updater waited for user input only after the fully successful path, so early returns and unhandled exceptions closed the console. The relaunched updater also used the Update directory as its working directory, which conflicted with its own pinned directory identity lease on Windows.

## Validation
- affected audio, history ViewModel, and UI tests: 44 passed
- Folder Project History service and recovery tests: 42 passed
- shared UI architecture and splitter tests: 14 passed
- updater tests: 129 passed, 5 skipped, 0 failed
- live public Gitee isolated download, verification, reconstruction, and install: passed
- WPF four-theme render and visual inspection: passed
- manual updater acceptance test: passed
- git diff --check: passed

No version, README, or release configuration changes.
