### PR TITLE
修复菜单悬停与工作区分隔条外观

### DIFF
--- a/AssetEditor/Themes/DesignSystem/Controls/MenusAndFeedback.xaml
+++ b/AssetEditor/Themes/DesignSystem/Controls/MenusAndFeedback.xaml
@@ -21,27 +21,18 @@
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="{StaticResource AeRadius.Compact}">
-                <Grid>
-                    <Border
-                        x:Name="StateOverlay"
-                        Background="{DynamicResource AeBrush.AccentSoft}"
-                        CornerRadius="{StaticResource AeRadius.Compact}"
-                        IsHitTestVisible="False"
-                        Opacity="0" />
-                    <ContentPresenter
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        ContentSource="Header"
-                        RecognizesAccessKey="True" />
-                </Grid>
+                <ContentPresenter
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    ContentSource="Header"
+                    RecognizesAccessKey="True" />
             </Border>
             <Popup
                 x:Name="PART_Popup"
                 AllowsTransparency="True"
                 Focusable="False"
                 IsOpen="{Binding IsSubmenuOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                Placement="Bottom"
-                PopupAnimation="Fade">
+                Placement="Bottom">
                 <Border
                     MaxHeight="640"
                     Margin="0,2,0,0"
@@ -61,7 +52,7 @@
         </Grid>
         <ControlTemplate.Triggers>
             <Trigger Property="IsHighlighted" Value="True">
-                <Setter TargetName="StateOverlay" Property="Opacity" Value="1" />
+                <Setter TargetName="Chrome" Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
@@ -85,13 +76,6 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
-                    <Border
-                        x:Name="StateOverlay"
-                        Grid.ColumnSpan="4"
-                        Background="{DynamicResource AeBrush.AccentSoft}"
-                        CornerRadius="{StaticResource AeRadius.Compact}"
-                        IsHitTestVisible="False"
-                        Opacity="0" />
                     <Grid VerticalAlignment="Center">
                         <ContentPresenter
                             x:Name="IconPresenter"
@@ -145,7 +129,6 @@
                 HorizontalOffset="-2"
                 IsOpen="{Binding IsSubmenuOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                 Placement="Right"
-                PopupAnimation="Fade"
                 VerticalOffset="-2">
                 <Border
                     MaxHeight="640"
@@ -172,7 +155,7 @@
                 <Setter TargetName="SubmenuArrow" Property="Visibility" Value="Visible" />
             </Trigger>
             <Trigger Property="IsHighlighted" Value="True">
-                <Setter TargetName="StateOverlay" Property="Opacity" Value="1" />
+                <Setter TargetName="Chrome" Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>

--- a/AssetEditor/Themes/DesignSystem/Shell.xaml
+++ b/AssetEditor/Themes/DesignSystem/Shell.xaml
@@ -83,7 +83,7 @@
         <Setter Property="Padding" Value="0" />
         <Setter Property="Background" Value="{DynamicResource AeBrush.Surface1}" />
         <Setter Property="BorderBrush" Value="{DynamicResource AeBrush.Border}" />
-        <Setter Property="BorderThickness" Value="0,0,1,0" />
+        <Setter Property="BorderThickness" Value="0" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="Template">

--- a/AssetEditor/Views/MainWindow.xaml
+++ b/AssetEditor/Views/MainWindow.xaml
@@ -137,6 +137,7 @@
 
             <GridSplitter
                 Grid.Column="1"
+                Margin="0,24,0,0"
                 Style="{StaticResource AeVerticalGridSplitterStyle}"
                 Visibility="{Binding IsPackFileExplorerVisible, Converter={StaticResource BoolToVisibilityConverter}}" />
 

--- a/AssetEditor/Views/MainWindow.xaml
+++ b/AssetEditor/Views/MainWindow.xaml
@@ -45,7 +45,7 @@
 
         <views:MenuBarView x:Name="MainMenuBar" Grid.Row="0" />
 
-        <Grid Grid.Row="1">
+        <Grid Grid.Row="1" Background="{DynamicResource AeBrush.Surface1}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="{Binding FileTreeColumnWidth}" />
                 <ColumnDefinition Width="Auto" />
@@ -137,7 +137,6 @@
 
             <GridSplitter
                 Grid.Column="1"
-                Margin="0,24,0,0"
                 Style="{StaticResource AeVerticalGridSplitterStyle}"
                 Visibility="{Binding IsPackFileExplorerVisible, Converter={StaticResource BoolToVisibilityConverter}}" />
 

--- a/Testing/AssetEditorTests/UiCommonControlResourceTests.cs
+++ b/Testing/AssetEditorTests/UiCommonControlResourceTests.cs
@@ -475,6 +475,9 @@ public class UiCommonControlResourceTests
                             contextMenu.Padding,
                             Is.EqualTo(new Thickness(2)));
                         NUnitAssert.That(popup.IsOpen, Is.True);
+                        NUnitAssert.That(
+                            popup.PopupAnimation,
+                            Is.EqualTo(PopupAnimation.None));
                     });
                 }
                 finally
@@ -1143,7 +1146,17 @@ public class UiCommonControlResourceTests
             "DesignSystem",
             "Controls",
             "MenusAndFeedback.xaml"));
-        NUnitAssert.That(menuSource, Does.Contain("AeBrush.AccentSoft"));
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(menuSource, Does.Contain("AeBrush.AccentSoft"));
+            NUnitAssert.That(menuSource, Does.Not.Contain("PopupAnimation"));
+            NUnitAssert.That(menuSource, Does.Not.Contain("StateOverlay"));
+            NUnitAssert.That(
+                menuSource.Split(
+                    "<Setter TargetName=\"Chrome\" Property=\"Background\"",
+                    StringSplitOptions.None),
+                Has.Length.EqualTo(3));
+        });
     }
 
     private static ResourceDictionary[] LoadDictionaries() =>

--- a/Testing/AssetEditorTests/UiMainShellTests.cs
+++ b/Testing/AssetEditorTests/UiMainShellTests.cs
@@ -49,6 +49,15 @@ public class UiMainShellTests
                         dictionary.Keys.OfType<Type>(),
                         Is.Empty,
                         "Shell styles must not replace implicit styles.");
+                    var sidebar = (Style)dictionary[
+                        "AeShell.WorkspaceSidebar"];
+                    var sidebarBorder = sidebar.Setters
+                        .OfType<Setter>()
+                        .Single(setter =>
+                            setter.Property == Control.BorderThicknessProperty);
+                    NUnitAssert.That(
+                        sidebarBorder.Value,
+                        Is.EqualTo(new Thickness(0)));
                 });
             });
     }
@@ -68,6 +77,14 @@ public class UiMainShellTests
             "Themes",
             "DesignSystem",
             "Shell.xaml"));
+        var splitterStart = mainWindow.IndexOf(
+            "<GridSplitter",
+            StringComparison.Ordinal);
+        var splitterEnd = mainWindow.IndexOf(
+            "/>",
+            splitterStart,
+            StringComparison.Ordinal);
+        var workspaceSplitter = mainWindow[splitterStart..splitterEnd];
 
         NUnitAssert.Multiple(() =>
         {
@@ -100,8 +117,15 @@ public class UiMainShellTests
                 Does.Contain(
                     "<RowDefinition Height=\"{StaticResource AeSize.TabGridLength}\" />"));
             NUnitAssert.That(
+                workspaceSplitter,
+                Does.Not.Contain("Margin="));
+            NUnitAssert.That(
+                workspaceSplitter,
+                Does.Not.Contain("Background="));
+            NUnitAssert.That(
                 mainWindow,
-                Does.Contain("Margin=\"0,24,0,0\""));
+                Does.Contain(
+                    "<Grid Grid.Row=\"1\" Background=\"{DynamicResource AeBrush.Surface1}\">"));
             NUnitAssert.That(shell, Does.Contain("PART_ItemsHolder"));
             NUnitAssert.That(shell, Does.Contain("EmptyEditorState"));
         });

--- a/Testing/AssetEditorTests/UiMainShellTests.cs
+++ b/Testing/AssetEditorTests/UiMainShellTests.cs
@@ -118,7 +118,7 @@ public class UiMainShellTests
                     "<RowDefinition Height=\"{StaticResource AeSize.TabGridLength}\" />"));
             NUnitAssert.That(
                 workspaceSplitter,
-                Does.Not.Contain("Margin="));
+                Does.Contain("Margin=\"0,24,0,0\""));
             NUnitAssert.That(
                 workspaceSplitter,
                 Does.Not.Contain("Background="));


### PR DESCRIPTION
## 修改内容

- 让顶部菜单、子菜单和右键菜单的悬停背景覆盖完整条目区域。
- 移除菜单弹出淡入动画，避免在菜单间移动时出现残影式渐变。
- 移除资源区与工作区之间的常驻竖线和顶部多余色块，同时保留三个拖拽点及拖拽功能。
- 将分隔条悬停高亮对齐到资源区标题横线下方，不再向上突出。

## 原因

菜单模板原先使用内层状态遮罩，无法自然覆盖条目的完整内边距，并且 Popup 启用了 Fade 动画。工作区分隔处则同时受侧栏边框、分隔条边距和父级背景影响，导致常态竖线、顶部色块及悬停突出。

## 用户影响

菜单悬停区域现在尺寸一致且切换即时；资源区分隔条在常态下不显示竖线，悬停时也与内容区域顶部对齐，拖拽点和调整宽度功能保持不变。

## 验证

- 用户桌面人工验收通过。
- 主窗口、共享分隔条与架构门禁测试：11/11 通过。
- 主窗口四主题离屏渲染：17/17 通过。
- 菜单与界面相关针对性测试：57/57 通过（补充边界修复前的同一稳定菜单差异）。
- `git diff --check` 通过。