### PR TITLE
修复复制文件导致工程历史还原点无法读取

### DIFF
--- a/Shared/SharedCore/PackFiles/Utility/FolderProjectVersionControlService.cs
+++ b/Shared/SharedCore/PackFiles/Utility/FolderProjectVersionControlService.cs
@@ -1296,7 +1296,8 @@ internal sealed partial class FolderProjectVersionControlService :
                     });
                 return new FolderProjectCommitChangeSummary(
                     changes.Count(change =>
-                        change.Status == ChangeKind.Added),
+                        change.Status is ChangeKind.Added or
+                            ChangeKind.Copied),
                     changes.Count(change =>
                         change.Status == ChangeKind.Modified),
                     changes.Count(change =>
@@ -1534,7 +1535,7 @@ internal sealed partial class FolderProjectVersionControlService :
     {
         var kind = change.Status switch
         {
-            ChangeKind.Added =>
+            ChangeKind.Added or ChangeKind.Copied =>
                 FolderProjectCommitChangeKind.Added,
             ChangeKind.Modified =>
                 FolderProjectCommitChangeKind.Modified,

--- a/Testing/Shared.Core.Test/PackFiles/FolderProjectHistoryServiceTests.cs
+++ b/Testing/Shared.Core.Test/PackFiles/FolderProjectHistoryServiceTests.cs
@@ -370,6 +370,36 @@ public sealed class FolderProjectHistoryServiceTests
     }
 
     [Test]
+    public void CreateRestorePoint_RecordsCopiedFileAsAdded()
+    {
+        using var project = new TemporaryProject();
+        var sourcePath = Path.Combine(project.Root, "db", "source.bin");
+        File.WriteAllBytes(sourcePath, [1, 2, 3]);
+        var service = CreateService();
+        service.Initialize(project.Root);
+        var copiedPath = Path.Combine(project.Root, "db", "copied.bin");
+        File.Copy(sourcePath, copiedPath);
+
+        var restorePoint = service.CreateRestorePoint(
+            project.Root,
+            "复制文件");
+        var changes = service.GetRestorePointChanges(
+            project.Root,
+            restorePoint.Id);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(restorePoint.ChangeSummary.Added, Is.EqualTo(1));
+            Assert.That(restorePoint.ChangeSummary.Total, Is.EqualTo(1));
+            Assert.That(changes, Has.Count.EqualTo(1));
+            Assert.That(changes[0].Path, Is.EqualTo("db/copied.bin"));
+            Assert.That(
+                changes[0].Kind,
+                Is.EqualTo(FolderProjectRestorePointChangeKind.Added));
+        });
+    }
+
+    [Test]
     public void GetStatus_AfterRestartOpensOnlyAddedAndModifiedFiles()
     {
         using var project = new TemporaryProject();


### PR DESCRIPTION
## 修改内容
- 工程历史统计把 LibGit2Sharp 的 `Copied` 变更计为新增文件
- 还原点详情把复制目标映射为“新增”，避免读取历史提交时报错
- 增加真实临时 Git 工程回归测试，覆盖复制文件创建与读取还原点

## 验证
- 回归用例修复前稳定失败：`Unsupported commit change type: Copied`
- 回归用例修复后：1/1 通过
- `FolderProjectHistoryServiceTests`：39/39 通过
- `Test.Shared.Core` Debug 构建：0 错误
- `git diff --check`：通过