### PR TITLE
fix(audio): hide invalid SFX option and resize merger

### DIFF
--- a/Editors/Audio/AudioEditor/Presentation/NewAudioProject/NewAudioProjectViewModel.cs
+++ b/Editors/Audio/AudioEditor/Presentation/NewAudioProject/NewAudioProjectViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -32,7 +33,9 @@ namespace Editors.Audio.AudioEditor.Presentation.NewAudioProject
         [ObservableProperty] private string _audioProjectFileName;
         [ObservableProperty] private string _audioProjectDirectory;
         [ObservableProperty] private Wh3Language _selectedLanguage;
-        [ObservableProperty] private ObservableCollection<Wh3Language> _languages = new (Enum.GetValues<Wh3Language>());
+        [ObservableProperty] private ObservableCollection<Wh3Language> _languages = new (
+            Enum.GetValues<Wh3Language>()
+                .Where(language => language != Wh3Language.Sfx));
 
         [ObservableProperty] private bool _isAudioProjectFileNameSet;
         [ObservableProperty] private bool _isAudioProjectDirectorySet;

--- a/Editors/Audio/DialogueEventMerger/DialogueEventMergerWindow.xaml
+++ b/Editors/Audio/DialogueEventMerger/DialogueEventMergerWindow.xaml
@@ -11,7 +11,10 @@
     d:DataContext="{d:DesignInstance Type=DialogueEventMerger:DialogueEventMergerViewModel}"
     mc:Ignorable="d"
     Width="700"
-    SizeToContent="Height"
+    Height="420"
+    MinHeight="320"
+    SizeToContent="Manual"
+    ResizeMode="CanResizeWithGrip"
     WindowStartupLocation="CenterOwner"
     Closing="OnClosing"
     Closed="OnClosed"
@@ -31,7 +34,7 @@
             <RowDefinition
                 Height="Auto"/>
             <RowDefinition
-                Height="Auto"/>
+                Height="*"/>
             <RowDefinition 
                 Height="Auto"/>
             <RowDefinition 
@@ -52,7 +55,7 @@
 
             <Grid.RowDefinitions>
                 <RowDefinition 
-                    Height="Auto"/>
+                    Height="*"/>
             </Grid.RowDefinitions>
 
             <Grid 
@@ -64,7 +67,7 @@
                     <RowDefinition 
                         Height="Auto"/>
                     <RowDefinition 
-                        Height="Auto"/>
+                        Height="*"/>
                 </Grid.RowDefinitions>
                 
                 <Grid.ColumnDefinitions>

--- a/Testing/AssetEditorTests/AudioEditorReliabilityTests.cs
+++ b/Testing/AssetEditorTests/AudioEditorReliabilityTests.cs
@@ -674,6 +674,23 @@ namespace AssetEditorTests
         }
 
         [TestMethod]
+        public void NewAudioProject_LanguagesExcludeSfx()
+        {
+            var viewModel = new NewAudioProjectViewModel(
+                Mock.Of<IPackFileService>(),
+                Mock.Of<IAudioEditorFileService>(),
+                new ApplicationSettingsService(GameTypeEnum.Warhammer3),
+                Mock.Of<IStandardDialogs>());
+
+            CollectionAssert.DoesNotContain(
+                viewModel.Languages,
+                Wh3Language.Sfx);
+            Assert.AreEqual(
+                Wh3Language.EnglishUK,
+                viewModel.SelectedLanguage);
+        }
+
+        [TestMethod]
         public async Task NewAudioProject_WhenSaveIsCancelled_KeepsDialogAndState()
         {
             var packFileService = new Mock<IPackFileService>();

--- a/Testing/AssetEditorTests/UiAudioEditorFamilyGallery.cs
+++ b/Testing/AssetEditorTests/UiAudioEditorFamilyGallery.cs
@@ -57,6 +57,53 @@ public class UiAudioEditorFamilyGallery
             () => Render(theme, variant));
     }
 
+    [Test]
+    public void DialogueMerger_DefaultWindowShowsPrimaryAction()
+    {
+        using var services = new ServiceCollection()
+            .AddSingleton(LocalizationManager.Instance)
+            .BuildServiceProvider();
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            services,
+            () =>
+            {
+                Application.Current.Resources["InvBoolConverter"] =
+                    new InverseBooleanConverter();
+                Application.Current.Resources["BoolToVisibilityConverter"] =
+                    new Shared.Ui.Common.ValueConverters
+                        .BoolToVisibilityConverter();
+                var window = new DialogueEventMergerWindow
+                {
+                    DataContext = CreateDialogueMerger(),
+                };
+                try
+                {
+                    window.Show();
+                    window.UpdateLayout();
+                    var primaryAction = FindVisualDescendants<Button>(window)
+                        .Single(button => button.IsDefault);
+                    var buttonBottom = primaryAction.TranslatePoint(
+                        new Point(0, primaryAction.ActualHeight),
+                        window);
+
+                    NUnitAssert.Multiple(() =>
+                    {
+                        NUnitAssert.That(
+                            window.SizeToContent,
+                            Is.EqualTo(SizeToContent.Manual));
+                        NUnitAssert.That(primaryAction.IsVisible, Is.True);
+                        NUnitAssert.That(
+                            buttonBottom.Y,
+                            Is.LessThan(window.ActualHeight));
+                    });
+                }
+                finally
+                {
+                    window.Close();
+                }
+            });
+    }
+
     private static IEnumerable<TestCaseData> Cases()
     {
         foreach (var theme in new[]


### PR DESCRIPTION
## Summary
- remove the invalid SFX language option from new audio projects
- keep the dialogue event merger actions visible at the default window size
- add regressions for language filtering and default-window button visibility

## Validation
- `dotnet build Testing\AssetEditorTests\AssetEditorTests.csproj --configuration Release` (0 errors)
- focused regressions: 3 passed
- audio UI theme and style contracts: 42 passed
- `git diff --cached --check`