### PR TITLE
修复音频项目树首次点击无法收起

### DIFF
--- a/Editors/Audio/AudioEditor/Presentation/AudioProjectExplorer/AudioProjectExplorerView.xaml
+++ b/Editors/Audio/AudioEditor/Presentation/AudioProjectExplorer/AudioProjectExplorerView.xaml
@@ -292,6 +292,10 @@
                 </TreeView.ItemContainerStyle>
 
                 <TreeView.Resources>
+                    <Style TargetType="{x:Type ToggleButton}">
+                        <Setter Property="ClickMode" Value="Press" />
+                    </Style>
+
                     <HierarchicalDataTemplate 
                         DataType="{x:Type Models:AudioProjectTreeNode}" 
                         ItemsSource="{Binding Children}">

--- a/Testing/AssetEditorTests/AudioProjectExplorerInteractionTests.cs
+++ b/Testing/AssetEditorTests/AudioProjectExplorerInteractionTests.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
 using Editors.Audio.AudioEditor.Core;
@@ -96,6 +97,56 @@ public class AudioProjectExplorerInteractionTests
                         actionItem.Visibility,
                         Is.EqualTo(Visibility.Visible));
                 });
+            }
+            finally
+            {
+                viewModel.Dispose();
+                window.Close();
+            }
+        });
+    }
+
+    [Test]
+    public void TreeExpander_CollapsesOnMousePress_WhenChildRemainsSelected()
+    {
+        using var services = new ServiceCollection()
+            .AddSingleton(LocalizationManager.Instance)
+            .BuildServiceProvider();
+        WpfTestApplicationHost.InvokeWithThemeResources(services, () =>
+        {
+            var (viewModel, view, window) = CreateView();
+            try
+            {
+                var dialogueEvents = Flatten(viewModel.AudioProjectTree)
+                    .Single(node =>
+                        node.Type == AudioProjectTreeNodeType.DialogueEvents &&
+                        node.GameSoundBank == Wh3SoundBank.CampaignVO);
+                var selectedDialogue = dialogueEvents.Children.Last();
+                var selectedItem = FindTreeViewItem(view, selectedDialogue);
+                var dialogueEventsItem = FindTreeViewItem(
+                    view,
+                    dialogueEvents);
+                selectedItem.IsSelected = true;
+                dialogueEventsItem.BringIntoView();
+                FlushBindings(view);
+                Assert.That(selectedItem.IsSelected, Is.True);
+
+                var expander = dialogueEventsItem.Template.FindName(
+                    "Expander",
+                    dialogueEventsItem) as ToggleButton;
+                Assert.That(expander, Is.Not.Null);
+
+                expander!.RaiseEvent(new MouseButtonEventArgs(
+                    Mouse.PrimaryDevice,
+                    Environment.TickCount,
+                    MouseButton.Left)
+                {
+                    RoutedEvent = Mouse.MouseDownEvent,
+                    Source = expander,
+                });
+                FlushBindings(view);
+
+                Assert.That(dialogueEvents.IsExpanded, Is.False);
             }
             finally
             {


### PR DESCRIPTION
## 摘要

- 让音频项目浏览器的树展开箭头在首次 MouseDown 时立即收起，避免点击因选中子事件自动定位而被吞掉
- 将行为限定在音频项目树，不影响其他编辑器或公共树样式
- 新增真实渲染的 WPF 交互回归测试

## 验证

- `dotnet restore AssetEditor.CN.sln`
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore`（0 错误）
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal`（退出码 0）
- 新增回归测试 1/1 通过，既有音频项目树交互测试 2/2 通过
- 提交前与提交后 Standards/Spec 审查均无阻断问题