### PR TITLE
Fix stale Kitbash render target bindings

### DIFF
--- a/Editors/Kitbashing/Test.KitbashEditor/Rendering/RenderEngineRenderTargetLifecycleTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/Rendering/RenderEngineRenderTargetLifecycleTests.cs
@@ -1,0 +1,125 @@
+using GameWorld.Core.Components;
+using GameWorld.Core.Components.Input;
+using GameWorld.Core.Components.Rendering;
+using GameWorld.Core.Services;
+using GameWorld.Core.Utility;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+using Shared.Core.Events;
+using Shared.Core.PackFiles;
+using Shared.Core.Services;
+using Shared.Core.Settings;
+using Test.TestingUtility.Shared;
+
+namespace GameWorld.Core.Test.Rendering;
+
+[NonParallelizable]
+public class RenderEngineRenderTargetLifecycleTests
+{
+    [Test]
+    public void Draw_ReenablingSelectionOutlineAfterViewportReturnsToPreviousSizeDoesNotReuseDisposedTarget()
+    {
+        const int originalSize = 64;
+        const int temporaryWidth = 80;
+        var game = new WpfGameMock();
+        var device = game.GraphicsDevice;
+        var deviceResolver = new Mock<IDeviceResolver>();
+        deviceResolver
+            .SetupGet(resolver => resolver.Device)
+            .Returns(device);
+        var camera = new ArcBallCamera(
+            deviceResolver.Object,
+            Mock.Of<IKeyboardComponent>(),
+            Mock.Of<IMouseComponent>());
+        camera.Initialize();
+        var resources = new ResourceLibrary(
+            Mock.Of<IPackFileService>());
+        resources.Initialize(device, game.Content);
+        var renderEngine = new RenderEngineComponent(
+            game,
+            resources,
+            camera,
+            deviceResolver.Object,
+            new ApplicationSettingsService(),
+            new SceneRenderParametersStore(),
+            Mock.Of<IEventHub>(),
+            new GridComponent(
+                camera,
+                resources,
+                deviceResolver.Object)
+            {
+                ShowGrid = false
+            });
+        renderEngine.Initialize();
+
+        using var originalTarget = CreateHostTarget(
+            device,
+            originalSize,
+            originalSize);
+        using var temporaryTarget = CreateHostTarget(
+            device,
+            temporaryWidth,
+            originalSize);
+
+        try
+        {
+            DrawFrame(
+                renderEngine,
+                device,
+                originalTarget,
+                requestSelectionOutline: true);
+            DrawFrame(
+                renderEngine,
+                device,
+                temporaryTarget,
+                requestSelectionOutline: false);
+            DrawFrame(
+                renderEngine,
+                device,
+                originalTarget,
+                requestSelectionOutline: false);
+
+            Assert.That(
+                () => DrawFrame(
+                    renderEngine,
+                    device,
+                    originalTarget,
+                    requestSelectionOutline: true),
+                Throws.Nothing);
+        }
+        finally
+        {
+            device.SetRenderTarget(null);
+            renderEngine.Dispose();
+        }
+    }
+
+    private static RenderTarget2D CreateHostTarget(
+        GraphicsDevice device,
+        int width,
+        int height)
+    {
+        return new RenderTarget2D(
+            device,
+            width,
+            height,
+            false,
+            SurfaceFormat.Color,
+            DepthFormat.Depth24);
+    }
+
+    private static void DrawFrame(
+        RenderEngineComponent renderEngine,
+        GraphicsDevice device,
+        RenderTarget2D hostTarget,
+        bool requestSelectionOutline)
+    {
+        device.SetRenderTarget(hostTarget);
+        renderEngine.Update(new GameTime());
+        if (requestSelectionOutline)
+            renderEngine.RequestSelectionOutline();
+
+        renderEngine.Draw(new GameTime());
+    }
+}

--- a/GameWorld/View3D/Components/Rendering/RenderEngineComponent.cs
+++ b/GameWorld/View3D/Components/Rendering/RenderEngineComponent.cs
@@ -935,6 +935,16 @@ namespace GameWorld.Core.Components.Rendering
                     DepthFormat.None,
                     msaaCount,
                     RenderTargetUsage.DiscardContents);
+            }
+
+            if (_mainRenderTargets == null ||
+                !ReferenceEquals(
+                    _mainRenderTargets[0].RenderTarget,
+                    _defaultRenderTarget) ||
+                !ReferenceEquals(
+                    _mainRenderTargets[1].RenderTarget,
+                    _selectionMaskTarget))
+            {
                 _mainRenderTargets =
                 [
                     new RenderTargetBinding(


### PR DESCRIPTION
## Summary
- Refresh the cached main render-target bindings whenever the default or selection-mask target is recreated.
- Add a regression test for disabling the selection outline across viewport-size changes and re-enabling it after returning to the original size.

## Verification
- Regression test: 1/1 passed.
- Kitbash rendering tests: 16/16 passed.
- Shared selection mask, outline, and render-state tests: 20/20 passed.
- Pin mesh command test: 1/1 passed.
- Real UI reproduction: pinned a mesh, stayed in vertex mode, clicked blank space 100 times, repeated Tab/1 cycles, resized/restored the viewport, then clicked 30 more times; no error dialog or hang, and the log contained no matching render-target exception.