### PR TITLE
Fix folder project display name renaming

### DIFF
--- a/AssetEditor/Language_Cn.json
+++ b/AssetEditor/Language_Cn.json
@@ -252,6 +252,8 @@
   "FolderProject.Context.DisableCorruptionDetection": "关闭 Pack 保存损坏检测",
   "FolderProject.Output.Failed": "无法更改生成位置。生成的 Pack 必须位于工程目录之外。",
   "FolderProject.Rename.Failed": "无法重命名该文件夹。请检查名称是否合法以及目录是否正被占用。",
+  "FolderProject.RenameProject.Title": "重命名工程",
+  "FolderProject.RenameProject.Failed": "无法重命名工程。请检查工程目录权限或配置文件是否正被占用。",
   "FolderProject.Import.OverwriteTitle": "确认覆盖",
   "FolderProject.Import.ConfirmOverwrite": "文件夹工程中已有 {0} 个同路径文件。导入后会立即覆盖磁盘原文件，且无法撤销。\n\n是否继续？",
 

--- a/Shared/SharedCore/PackFiles/Models/FolderProjectContainer.cs
+++ b/Shared/SharedCore/PackFiles/Models/FolderProjectContainer.cs
@@ -423,6 +423,36 @@ public sealed class FolderProjectContainer :
             });
     }
 
+    public void SetProjectDisplayName(string name)
+    {
+        var normalizedName = name.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedName))
+        {
+            throw new ArgumentException(
+                "Project name cannot be empty.",
+                nameof(name));
+        }
+
+        ExecuteSynchronizedMutation(
+            () =>
+            {
+                var previousName = Name;
+                var previousSettingsName = ProjectSettings.Name;
+                try
+                {
+                    ProjectSettings.Name = normalizedName;
+                    ProjectSettings.Save(ProjectRoot);
+                    Name = normalizedName;
+                }
+                catch
+                {
+                    Name = previousName;
+                    ProjectSettings.Name = previousSettingsName;
+                    throw;
+                }
+            });
+    }
+
     public bool IsIgnored(string relativePath)
     {
         return ExecuteSynchronized(

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/OnRenameNodeCommand.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/OnRenameNodeCommand.cs
@@ -13,6 +13,40 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.Commands
         public void Execute(TreeNode _selectedNode)
         {
             var FileOwner = _selectedNode.FileOwner;
+            if (_selectedNode.NodeType == NodeType.Root &&
+                FileOwner is FolderProjectContainer project)
+            {
+                var result = standardDialogs.ShowTextInputDialog(
+                    LocalizationManager.Instance.Get(
+                        "FolderProject.RenameProject.Title"),
+                    project.Name);
+                var newProjectName = result.Text.Trim();
+                if (!result.Result ||
+                    string.IsNullOrWhiteSpace(newProjectName) ||
+                    string.Equals(
+                        newProjectName,
+                        project.Name,
+                        System.StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                try
+                {
+                    project.SetProjectDisplayName(newProjectName);
+                    _selectedNode.Name = project.Name;
+                    _selectedNode.UnsavedChanged = true;
+                }
+                catch (System.Exception exception)
+                {
+                    standardDialogs.ShowExceptionWindow(
+                        exception,
+                        LocalizationManager.Instance.Get(
+                            "FolderProject.RenameProject.Failed"));
+                }
+                return;
+            }
+
             if (FileOwner.IsCaPackFile)
             {
                 standardDialogs.ShowDialogBox(LocalizationManager.Instance.Get("Msg.UnableToEditPackfile"), LocalizationManager.Instance.Get("Msg.GeneralError"));

--- a/Testing/AssetEditorTests/FolderProjectContextMenuTests.cs
+++ b/Testing/AssetEditorTests/FolderProjectContextMenuTests.cs
@@ -17,6 +17,122 @@ namespace AssetEditorTests;
 public class FolderProjectContextMenuTests
 {
     [NUnit.Framework.Test]
+    public void FolderProjectRootRename_PersistsProjectDisplayName()
+    {
+        new LocalizationManager().LoadLanguage();
+        using var projectRoot = new TemporaryDirectory();
+        var outputPackPath = Path.Combine(
+            Path.GetTempPath(),
+            $"ae-folder-project-output-{Guid.NewGuid():N}.pack");
+        using var project = FolderProjectContainer.Create(
+            projectRoot.Path,
+            new FolderProjectSettings
+            {
+                Name = "旧工程名",
+                OutputPackPath = outputPackPath,
+            });
+        var root = new TreeNode(
+            project.Name,
+            NodeType.Root,
+            project,
+            null);
+        var dialogs = new Mock<IStandardDialogs>();
+        dialogs.Setup(item => item.ShowTextInputDialog(
+                "重命名工程",
+                "旧工程名"))
+            .Returns(new TextInputDialogResult(true, "  新工程名  "));
+        var command = new OnRenameNodeCommand(
+            Mock.Of<IPackFileService>(),
+            dialogs.Object);
+
+        command.Execute(root);
+
+        var savedSettings = FolderProjectSettings.Load(projectRoot.Path);
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(root.Name, NUnit.Framework.Is.EqualTo("新工程名"));
+            NUnitAssert.That(
+                project.Name,
+                NUnit.Framework.Is.EqualTo("新工程名"));
+            NUnitAssert.That(
+                project.ProjectSettings.Name,
+                NUnit.Framework.Is.EqualTo("新工程名"));
+            NUnitAssert.That(
+                savedSettings.Name,
+                NUnit.Framework.Is.EqualTo("新工程名"));
+            NUnitAssert.That(
+                project.ProjectRoot,
+                NUnit.Framework.Is.EqualTo(projectRoot.Path));
+            NUnitAssert.That(
+                project.ProjectSettings.OutputPackPath,
+                NUnit.Framework.Is.EqualTo(outputPackPath));
+            NUnitAssert.That(
+                savedSettings.OutputPackPath,
+                NUnit.Framework.Is.EqualTo(outputPackPath));
+            NUnitAssert.That(
+                root.UnsavedChanged,
+                NUnit.Framework.Is.True);
+        });
+    }
+
+    [NUnit.Framework.Test]
+    public void FolderProjectRootRename_SaveFailurePreservesOldName()
+    {
+        new LocalizationManager().LoadLanguage();
+        using var projectRoot = new TemporaryDirectory();
+        using var project = FolderProjectContainer.Create(
+            projectRoot.Path,
+            new FolderProjectSettings { Name = "旧工程名" });
+        var root = new TreeNode(
+            project.Name,
+            NodeType.Root,
+            project,
+            null);
+        var dialogs = new Mock<IStandardDialogs>();
+        dialogs.Setup(item => item.ShowTextInputDialog(
+                "重命名工程",
+                "旧工程名"))
+            .Returns(new TextInputDialogResult(true, "新工程名"));
+        var command = new OnRenameNodeCommand(
+            Mock.Of<IPackFileService>(),
+            dialogs.Object);
+        var settingsPath = Path.Combine(
+            projectRoot.Path,
+            FolderProjectSettings.CnFileName);
+
+        using (File.Open(
+                   settingsPath,
+                   FileMode.Open,
+                   FileAccess.Read,
+                   FileShare.None))
+        {
+            NUnitAssert.DoesNotThrow(() => command.Execute(root));
+        }
+
+        var savedSettings = FolderProjectSettings.Load(projectRoot.Path);
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(root.Name, NUnit.Framework.Is.EqualTo("旧工程名"));
+            NUnitAssert.That(
+                project.Name,
+                NUnit.Framework.Is.EqualTo("旧工程名"));
+            NUnitAssert.That(
+                project.ProjectSettings.Name,
+                NUnit.Framework.Is.EqualTo("旧工程名"));
+            NUnitAssert.That(
+                savedSettings.Name,
+                NUnit.Framework.Is.EqualTo("旧工程名"));
+            NUnitAssert.That(
+                root.UnsavedChanged,
+                NUnit.Framework.Is.False);
+        });
+        dialogs.Verify(item => item.ShowExceptionWindow(
+            It.IsAny<Exception>(),
+            "无法重命名工程。请检查工程目录权限或配置文件是否正被占用。"),
+            Times.Once);
+    }
+
+    [NUnit.Framework.Test]
     [NUnit.Framework.Apartment(ApartmentState.STA)]
     public void CopyFromReferencePack_TargetsActiveFolderProject()
     {


### PR DESCRIPTION
## Summary

- Enable renaming the folder-project root display name and persist it to aeproject.cn.json.
- Keep the physical project root and Pack output path unchanged.
- Restore the old name and show a localized error when settings cannot be saved.
- Add regression coverage for successful persistence and save-failure rollback.

## Validation

- dotnet build AssetEditor.CN.sln --configuration Release --no-restore --verbosity minimal
- 16 targeted FolderProjectContextMenuTests and ChineseLocalizationTests passed
- Chinese localization JSON parse passed
- git diff --check passed

## UI verification

- Real desktop click-through was not performed because desktop-control permission was not granted.