### PR TITLE
修复资源树多选操作、META 保存状态和模型贴图

### DIFF
--- a/GameWorld/View3D/Rendering/Materials/Capabilities/Utility/CapabilityHelper.cs
+++ b/GameWorld/View3D/Rendering/Materials/Capabilities/Utility/CapabilityHelper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using CommunityToolkit.Diagnostics;
 using Microsoft.Xna.Framework;
 using Shared.GameFormats.RigidModel.MaterialHeaders;
+using Shared.GameFormats.RigidModel.Types;
 using Shared.GameFormats.WsModel;
 
 namespace GameWorld.Core.Rendering.Materials.Capabilities.Utility
@@ -26,10 +27,10 @@ namespace GameWorld.Core.Rendering.Materials.Capabilities.Utility
             if (rmvMaterial != null)
             {
                 var textureType = textureInput.Type;
-                var modelTexture = rmvMaterial.GetTexture(textureType);
-                if (modelTexture != null)
+                var texturePath = GetRmvTexturePath(rmvMaterial, textureType);
+                if (texturePath != null)
                 {
-                    textureInput.TexturePath = modelTexture.Value.Path;
+                    textureInput.TexturePath = texturePath;
                     textureInput.UseTexture = true;
                     return;
                 }
@@ -37,6 +38,57 @@ namespace GameWorld.Core.Rendering.Materials.Capabilities.Utility
 
             textureInput.TexturePath = defaultPath;
             textureInput.UseTexture = false;
+        }
+
+        private static string? GetRmvTexturePath(
+            IRmvMaterial rmvMaterial,
+            TextureType textureType)
+        {
+            var texture = rmvMaterial.GetTexture(textureType);
+            if (texture != null)
+                return texture.Value.Path;
+
+            return textureType switch
+            {
+                TextureType.BaseColour => GetRenamedLegacyTexturePath(
+                    rmvMaterial,
+                    TextureType.Diffuse,
+                    "_diffuse",
+                    "_base_colour"),
+                TextureType.MaterialMap => GetRenamedLegacyTexturePath(
+                    rmvMaterial,
+                    TextureType.Specular,
+                    "_specular",
+                    "_material_map"),
+                _ => null,
+            };
+        }
+
+        private static string? GetRenamedLegacyTexturePath(
+            IRmvMaterial rmvMaterial,
+            TextureType legacyType,
+            string legacySuffix,
+            string currentSuffix)
+        {
+            var legacyTexture = rmvMaterial.GetTexture(legacyType);
+            if (legacyTexture == null)
+                return null;
+
+            var texturePath = legacyTexture.Value.Path;
+            var extension = System.IO.Path.GetExtension(texturePath);
+            var nameWithoutExtension = System.IO.Path.GetFileNameWithoutExtension(
+                texturePath);
+            if (!nameWithoutExtension.EndsWith(
+                    legacySuffix,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            return texturePath[..^(
+                extension.Length + legacySuffix.Length)] +
+                currentSuffix +
+                extension;
         }
 
         public static float GetParameterFloat(WsModelMaterialFile? wsModelMaterial, WsModelParamters.Instance parameterInstance, float defaultValue)

--- a/Shared/SharedCore/PackFiles/IPackFileService.cs
+++ b/Shared/SharedCore/PackFiles/IPackFileService.cs
@@ -46,6 +46,10 @@ namespace Shared.Core.PackFiles
         string GetFullPath(PackFile file, PackFileContainer? container = null);
         PackFileContainer? GetPackFileContainer(PackFile file);
         void MoveFile(PackFileContainer pf, PackFile file, string newFolderPath);
+        void MoveFolder(
+            PackFileContainer pf,
+            string folderPath,
+            string newParentPath);
         void RenameDirectory(PackFileContainer pf, string currentNodeName, string newName);
         void RenameFile(PackFileContainer pf, PackFile file, string newName);
         void SaveFile(PackFile file, byte[] data);

--- a/Shared/SharedCore/PackFiles/Models/FolderProjectContainer.cs
+++ b/Shared/SharedCore/PackFiles/Models/FolderProjectContainer.cs
@@ -924,63 +924,85 @@ public sealed class FolderProjectContainer :
                 var newPath =
                     FolderProjectPathPolicy.EnsureResourceDirectoryPath(
                         Path.Combine(parent ?? "", newName));
-                var oldFullPath =
-                    FolderProjectPathPolicy.ResolveFilePath(
-                        ProjectRoot,
-                        oldPath);
-                var newFullPath =
-                    FolderProjectPathPolicy.ResolveFilePath(
-                        ProjectRoot,
-                        newPath);
-
-                MovePathCaseAware(oldFullPath, newFullPath, true);
-
-                var oldPrefix = oldPath + "\\";
-                var affected = FileList
-                    .Where(
-                        pair =>
-                            pair.Key.StartsWith(
-                                oldPrefix,
-                                StringComparison.OrdinalIgnoreCase))
-                    .ToList();
-                foreach (var (oldKey, file) in affected)
-                {
-                    var suffix = oldKey[oldPath.Length..];
-                    var newKey =
-                        (newPath + suffix).ToLowerInvariant();
-                    FileList.Remove(oldKey);
-                    _fingerprints.Remove(oldKey);
-                    var filePath =
-                        FolderProjectPathPolicy.ResolveFilePath(
-                            ProjectRoot,
-                            newKey);
-                    file.DataSource = new FileSystemSource(filePath);
-                    FileList[newKey] = file;
-                    _pathsByFile[file] = newKey;
-                    UpdateFingerprint(newKey, filePath);
-                }
-
-                var renamedEmptyDirectories = EmptyDirectories
-                    .Where(
-                        path =>
-                            path.Equals(
-                                oldPath,
-                                StringComparison.OrdinalIgnoreCase) ||
-                            path.StartsWith(
-                                oldPrefix,
-                                StringComparison.OrdinalIgnoreCase))
-                    .ToList();
-                foreach (var oldEmptyPath in renamedEmptyDirectories)
-                {
-                    EmptyDirectories.Remove(oldEmptyPath);
-                    EmptyDirectories.Add(
-                        newPath +
-                        oldEmptyPath[oldPath.Length..]);
-                }
-                MoveIgnoredPaths(oldPath, newPath);
-                SaveEmptyDirectorySettings();
-                return newPath;
+                return MoveDirectoryCore(oldPath, newPath);
             });
+    }
+
+    public string MoveDirectoryOnDisk(
+        string currentPath,
+        string newParentPath)
+    {
+        return ExecuteSynchronizedMutation(
+            () =>
+            {
+                var oldPath =
+                    FolderProjectPathPolicy.EnsureResourceDirectoryPath(
+                        currentPath);
+                var parent = string.IsNullOrWhiteSpace(newParentPath)
+                    ? ""
+                    : FolderProjectPathPolicy
+                        .EnsureResourceDirectoryPath(newParentPath);
+                var newPath =
+                    FolderProjectPathPolicy.EnsureResourceDirectoryPath(
+                        Path.Combine(
+                            parent,
+                            Path.GetFileName(oldPath)));
+                return MoveDirectoryCore(oldPath, newPath);
+            });
+    }
+
+    private string MoveDirectoryCore(string oldPath, string newPath)
+    {
+        var oldFullPath = FolderProjectPathPolicy.ResolveFilePath(
+            ProjectRoot,
+            oldPath);
+        var newFullPath = FolderProjectPathPolicy.ResolveFilePath(
+            ProjectRoot,
+            newPath);
+
+        MovePathCaseAware(oldFullPath, newFullPath, true);
+
+        var oldPrefix = oldPath + "\\";
+        var affected = FileList
+            .Where(pair => pair.Key.StartsWith(
+                oldPrefix,
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        foreach (var (oldKey, file) in affected)
+        {
+            var suffix = oldKey[oldPath.Length..];
+            var newKey = (newPath + suffix).ToLowerInvariant();
+            FileList.Remove(oldKey);
+            _fingerprints.Remove(oldKey);
+            var filePath = FolderProjectPathPolicy.ResolveFilePath(
+                ProjectRoot,
+                newKey);
+            file.DataSource = new FileSystemSource(filePath);
+            FileList[newKey] = file;
+            _pathsByFile[file] = newKey;
+            UpdateFingerprint(newKey, filePath);
+        }
+
+        var renamedEmptyDirectories = EmptyDirectories
+            .Where(path =>
+                path.Equals(
+                    oldPath,
+                    StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith(
+                    oldPrefix,
+                    StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        foreach (var oldEmptyPath in renamedEmptyDirectories)
+        {
+            EmptyDirectories.Remove(oldEmptyPath);
+            EmptyDirectories.Add(
+                newPath + oldEmptyPath[oldPath.Length..]);
+        }
+        MoveIgnoredPaths(oldPath, newPath);
+        MarkParentEmptyIfNeeded(oldPath);
+        MarkPathHasContent(newPath);
+        SaveEmptyDirectorySettings();
+        return newPath;
     }
 
     public void Dispose()

--- a/Shared/SharedCore/PackFiles/PackFileService.cs
+++ b/Shared/SharedCore/PackFiles/PackFileService.cs
@@ -741,6 +741,87 @@ namespace Shared.Core.PackFiles
             _globalEventHub?.PublishGlobalEvent(new PackFileContainerFilesAddedEvent(pf, [file]));
         }
 
+        public void MoveFolder(
+            PackFileContainer pf,
+            string folderPath,
+            string newParentPath)
+        {
+            EnsureWritable(pf);
+            if (pf.IsCaPackFile)
+                throw new Exception("Can not move folders inside CA pack files");
+
+            var oldPath = folderPath.TrimEnd('\\', '/');
+            var newPath = Path.Combine(
+                newParentPath ?? "",
+                Path.GetFileName(oldPath));
+            if (newPath.Equals(
+                    oldPath,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var oldPrefix = oldPath + "\\";
+            if (newPath.StartsWith(
+                    oldPrefix,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    "A folder can not be moved into itself.");
+            }
+
+            if (pf is FolderProjectContainer folderProject)
+            {
+                var affectedFiles = folderProject.FileList
+                    .Where(pair => pair.Key.StartsWith(
+                        oldPrefix,
+                        StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                newPath = folderProject.MoveDirectoryOnDisk(
+                    oldPath,
+                    newParentPath);
+                var fileChanges = affectedFiles
+                    .Select(pair => new FolderProjectFileChange(
+                        newPath + pair.Key[oldPath.Length..],
+                        FolderProjectFileChangeKind.Moved,
+                        pair.Value,
+                        pair.Key))
+                    .ToList();
+                _globalEventHub?.PublishGlobalEvent(
+                    new FolderProjectChangedEvent(
+                        folderProject,
+                        new FolderProjectChangeSet(
+                            folderProject.NextRevision(),
+                            fileChanges,
+                            [
+                                new FolderProjectDirectoryChange(
+                                    newPath,
+                                    FolderProjectDirectoryChangeKind.Moved,
+                                    oldPath),
+                            ])));
+                return;
+            }
+
+            var affected = pf.FileList
+                .Where(pair => pair.Key.StartsWith(
+                    oldPrefix,
+                    StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            _globalEventHub?.PublishGlobalEvent(
+                new PackFileContainerFilesRemovedEvent(
+                    pf,
+                    affected.Select(pair => pair.Value).ToList()));
+            foreach (var (path, file) in affected)
+            {
+                pf.FileList.Remove(path);
+                pf.FileList[newPath + path[oldPath.Length..]] = file;
+            }
+            _globalEventHub?.PublishGlobalEvent(
+                new PackFileContainerFilesAddedEvent(
+                    pf,
+                    affected.Select(pair => pair.Value).ToList()));
+        }
+
         public void RenameDirectory(PackFileContainer pf, string currentNodeName, string newName)
         {
             EnsureWritable(pf);

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/CopyTreeNodesCommand.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/CopyTreeNodesCommand.cs
@@ -3,21 +3,21 @@ using Shared.Core.Services;
 
 namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.Commands
 {
-    public sealed class DeleteNodeCommand(
+    public sealed class CopyTreeNodesCommand(
         PackFileTreeOperations operations) : IContextMenuCommand
     {
         public string GetDisplayName(TreeNode node) =>
-            LocalizationManager.Instance.Get("ContextMenu.Delete");
+            LocalizationManager.Instance.Get("General.Copy");
 
         public bool IsEnabled(TreeNode node) =>
-            operations.CanDelete([node]);
+            operations.CanCopy([node]);
 
-        public void Execute(TreeNode node) => operations.Delete([node]);
+        public void Execute(TreeNode node) => operations.Copy([node]);
 
         public bool IsEnabled(IReadOnlyList<TreeNode> nodes) =>
-            operations.CanDelete(nodes);
+            operations.CanCopy(nodes);
 
         public void Execute(IReadOnlyList<TreeNode> nodes) =>
-            operations.Delete(nodes);
+            operations.Copy(nodes);
     }
 }

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/IContextMenuCommand.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/IContextMenuCommand.cs
@@ -1,4 +1,6 @@
-﻿using Shared.Core.Events;
+﻿using System;
+using System.Collections.Generic;
+using Shared.Core.Events;
 
 namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.Commands
 {
@@ -7,5 +9,21 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.Commands
         public string GetDisplayName(TreeNode node);
         public bool IsEnabled(TreeNode node);
         public void Execute(TreeNode node);
+
+        public string GetDisplayName(IReadOnlyList<TreeNode> nodes) =>
+            GetDisplayName(nodes[0]);
+
+        public bool IsEnabled(IReadOnlyList<TreeNode> nodes) =>
+            nodes.Count == 1 && IsEnabled(nodes[0]);
+
+        public void Execute(IReadOnlyList<TreeNode> nodes)
+        {
+            if (nodes.Count != 1)
+            {
+                throw new InvalidOperationException(
+                    "This command only supports one tree node.");
+            }
+            Execute(nodes[0]);
+        }
     }
 }

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/PasteTreeNodesCommand.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/Commands/PasteTreeNodesCommand.cs
@@ -1,0 +1,15 @@
+﻿using Shared.Core.Services;
+
+namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu.Commands
+{
+    public sealed class PasteTreeNodesCommand(
+        PackFileTreeOperations operations) : IContextMenuCommand
+    {
+        public string GetDisplayName(TreeNode node) =>
+            LocalizationManager.Instance.Get("General.Paste");
+
+        public bool IsEnabled(TreeNode node) => operations.CanPaste(node);
+
+        public void Execute(TreeNode node) => operations.Paste(node);
+    }
+}

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/ContextMenuBuilder.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/ContextMenuBuilder.cs
@@ -30,6 +30,8 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu
     {
         ContextMenuType Type { get; }
         public ObservableCollection<ContextMenuItem2> Build(TreeNode? node);
+        public ObservableCollection<ContextMenuItem2> Build(
+            IReadOnlyList<TreeNode> nodes);
     }
 
     public abstract class ContextMenuBuilder : IContextMenuBuilder
@@ -46,14 +48,27 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu
 
         protected abstract void Create(ContextMenuItem2 rootNode, TreeNode selectedNode);
 
+        protected virtual void Create(
+            ContextMenuItem2 rootNode,
+            IReadOnlyList<TreeNode> selectedNodes) =>
+            Create(rootNode, selectedNodes[0]);
+
         public ObservableCollection<ContextMenuItem2> Build(TreeNode? node)
         {
+            return node == null
+                ? []
+                : Build([node]);
+        }
+
+        public ObservableCollection<ContextMenuItem2> Build(
+            IReadOnlyList<TreeNode> nodes)
+        {
             var output = new ObservableCollection<ContextMenuItem2>();
-            if (node == null)
+            if (nodes.Count == 0)
                 return output;
 
             var placeholderRoot = new ContextMenuItem2("Root", null);
-            Create(placeholderRoot, node);
+            Create(placeholderRoot, nodes);
 
             foreach (var item in placeholderRoot.ContextMenu)
                 output.Add(item);
@@ -78,6 +93,26 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu
             var item = new ContextMenuItem2(
                 name,
                 () => instance.Execute(node),
+                isEnabled);
+            parent.ContextMenu.Add(item);
+        }
+
+        protected void Add<T>(
+            IReadOnlyList<TreeNode> nodes,
+            ContextMenuItem2 parent,
+            bool includeWhenDisabled = false)
+            where T : IContextMenuCommand
+        {
+            var instance = _commandFactory.Create<T>();
+            var isEnabled = instance.IsEnabled(nodes);
+
+            if (!isEnabled && !includeWhenDisabled)
+                return;
+
+            var name = instance.GetDisplayName(nodes);
+            var item = new ContextMenuItem2(
+                name,
+                () => instance.Execute(nodes),
                 isEnabled);
             parent.ContextMenu.Add(item);
         }

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/MainApplicationContextMenuBuilder.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/ContextMenu/MainApplicationContextMenuBuilder.cs
@@ -33,6 +33,28 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu
             }
         }
 
+        protected override void Create(
+            ContextMenuItem2 rootNode,
+            System.Collections.Generic.IReadOnlyList<TreeNode> selectedNodes)
+        {
+            if (selectedNodes.Count == 1)
+            {
+                Create(rootNode, selectedNodes[0]);
+                return;
+            }
+
+            Add<CopyTreeNodesCommand>(selectedNodes, rootNode);
+            if (System.Linq.Enumerable.All(
+                    selectedNodes,
+                    IsCurrentProject) &&
+                System.Linq.Enumerable.All(
+                    selectedNodes,
+                    node => node.NodeType != NodeType.Root))
+            {
+                Add<DeleteNodeCommand>(selectedNodes, rootNode);
+            }
+        }
+
         void CreateForFile(ContextMenuItem2 rootNode, TreeNode selectedNode)
         {
             var isCurrentProject = IsCurrentProject(selectedNode);
@@ -47,6 +69,7 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu
             if (isCurrentProject)
             {
                 AddSeperator(rootNode);
+                Add<CopyTreeNodesCommand>(selectedNode, rootNode);
                 Add<DuplicateFileCommand>(selectedNode, rootNode);
                 Add<OnRenameNodeCommand>(selectedNode, rootNode);
                 Add<DeleteNodeCommand>(selectedNode, rootNode);
@@ -144,6 +167,12 @@ namespace Shared.Ui.BaseDialogs.PackFileTree.ContextMenu
                 Add<CreateFolderCommand>(selectedNode, createMenu);
 
                 AddSeperator(rootNode);
+                if (selectedNode.NodeType != NodeType.Root)
+                    Add<CopyTreeNodesCommand>(selectedNode, rootNode);
+                Add<PasteTreeNodesCommand>(
+                    selectedNode,
+                    rootNode,
+                    includeWhenDisabled: true);
                 Add<OnRenameNodeCommand>(selectedNode, rootNode);
                 Add<DeleteNodeCommand>(selectedNode, rootNode);
                 if (selectedNode.FileOwner is FolderProjectContainer &&

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/PackFileBrowserView.xaml
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/PackFileBrowserView.xaml
@@ -91,7 +91,7 @@
         </Grid>
 
         <!-- TreeView -->
-        <TreeView x:Name="tvParameters" AllowDrop="True" Grid.Row="2" Margin="0, 2.5, 0, 5" behaviors:TreeViewExtension.SelectItemOnRightClick="True" 
+        <TreeView x:Name="tvParameters" AllowDrop="True" Grid.Row="2" Margin="0, 2.5, 0, 5" PreviewKeyDown="TreeView_PreviewKeyDown"
                   ScrollViewer.HorizontalScrollBarVisibility="Disabled" ItemsSource="{Binding Path=Files, UpdateSourceTrigger=PropertyChanged}" 
                   VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling" VirtualizingPanel.IsVirtualizingWhenGrouping="True"
                   BorderBrush="Transparent" Background="Transparent"
@@ -132,16 +132,19 @@
                     <EventSetter Event="TreeViewItem.MouseMove" Handler="treeView_MouseMove"/>
                     <EventSetter Event="TreeViewItem.Drop" Handler="treeView_Drop"/>
                     <EventSetter Event="TreeViewItem.PreviewMouseLeftButtonDown" Handler="TreeView_MouseDown"/>
-                    <EventSetter Event="TreeViewItem.PreviewMouseRightButtonDown" Handler="TreeViewItem_PreviewMouseRightButtonDown"/>
+                    <EventSetter Event="TreeViewItem.MouseRightButtonDown" Handler="TreeViewItem_MouseRightButtonDown"/>
                     <Setter Property="behaviors:MouseDoubleClick.Command" Value="{Binding DataContext.DoubleClickCommand,  RelativeSource={RelativeSource FindAncestor, AncestorType=TreeView}, Mode=OneTime}"/>
                     <Setter Property="ContextMenu" Value="{StaticResource NodeContextMenu}"/>
                     <Setter Property="IsExpanded" Value="{Binding IsNodeExpanded, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"/>
-                    <Setter Property="IsSelected" Value="{Binding IsSelected, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"/>
                     <Setter Property="Visibility" Value="Visible" />
                     <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextPrimary}"/>
                     <Style.Triggers>
                         <DataTrigger Binding="{Binding IsVisible}" Value="False">
                             <Setter Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource AeBrush.AccentSoft}" />
+                            <Setter Property="Foreground" Value="{DynamicResource AeBrush.TextPrimary}" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding IsMainEditabelPack, UpdateSourceTrigger=PropertyChanged}" Value="True">
                             <Setter Property="FontWeight" Value="Bold" />

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/PackFileBrowserView.xaml.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/PackFileBrowserView.xaml.cs
@@ -1,8 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Media;
 using Shared.Ui.Common;
+using Shared.Ui.Common.Behaviors;
 
 namespace Shared.Ui.BaseDialogs.PackFileTree
 {
@@ -14,7 +19,9 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
         }
 
         Point _lastMouseDown;
-        TreeNode? _draggedItem;
+        IReadOnlyList<TreeNode> _draggedItems = [];
+        TreeNode? _pendingSingleClickNode;
+        bool _dragInProgress;
 
         public System.Windows.Controls.ContextMenu CustomContextMenu
         {
@@ -28,16 +35,59 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
             set { SetValue(ShowTitleProperty, value); }
         }
 
-        private void TreeView_MouseDown(object sender, MouseButtonEventArgs e)
+        private void TreeView_MouseDown(
+            object sender,
+            MouseButtonEventArgs e)
         {
-            if (e.ChangedButton == MouseButton.Left)
+            if (e.ChangedButton != MouseButton.Left ||
+                sender is not TreeViewItem item ||
+                e.OriginalSource is not DependencyObject source ||
+                !ReferenceEquals(
+                    item,
+                    TreeViewExtension.VisualUpwardSearch(source)) ||
+                WasExpanderClicked(source) ||
+                item.DataContext is not TreeNode node ||
+                DataContext is not PackFileBrowserViewModel viewModel)
             {
-                var item = (TreeViewItem)sender;
-
-                _lastMouseDown = e.GetPosition(tvParameters);
-
-                _draggedItem = item.DataContext as TreeNode;
+                return;
             }
+
+            _lastMouseDown = e.GetPosition(tvParameters);
+            _pendingSingleClickNode = null;
+            var modifiers = Keyboard.Modifiers;
+            if (modifiers.HasFlag(ModifierKeys.Shift))
+            {
+                viewModel.SelectNode(
+                    node,
+                    PackFileTreeSelectionMode.Range);
+            }
+            else if (modifiers.HasFlag(ModifierKeys.Control))
+            {
+                var wasSelected = node.IsSelected;
+                viewModel.SelectNode(
+                    node,
+                    PackFileTreeSelectionMode.Toggle);
+                if (wasSelected)
+                {
+                    item.Focus();
+                    e.Handled = true;
+                }
+            }
+            else if (node.IsSelected)
+            {
+                viewModel.ActivateNode(node);
+                _pendingSingleClickNode = node;
+            }
+            else
+            {
+                viewModel.SelectNode(
+                    node,
+                    PackFileTreeSelectionMode.Replace);
+            }
+
+            _draggedItems = node.IsSelected
+                ? viewModel.SelectedItems.ToList()
+                : [];
         }
 
         public void TriggerPreviewKeyDown()
@@ -57,43 +107,56 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
 
         private void treeView_MouseMove(object sender, MouseEventArgs e)
         {
-            if (e.LeftButton == MouseButtonState.Pressed)
+            if (e.LeftButton != MouseButtonState.Pressed)
             {
-                var currentPosition = e.GetPosition(tvParameters);
-
-                if (Math.Abs(currentPosition.X - _lastMouseDown.X) > 10.0 ||
-                    Math.Abs(currentPosition.Y - _lastMouseDown.Y) > 10.0)
-                {
-                    if (_draggedItem != null)
-                    {
-                        DragDrop.DoDragDrop(tvParameters, tvParameters.SelectedValue, DragDropEffects.Move);
-                    }
-                }
+                _draggedItems = [];
+                return;
             }
-            else
+
+            if (_dragInProgress)
+                return;
+
+            var currentPosition = e.GetPosition(tvParameters);
+            if (Math.Abs(currentPosition.X - _lastMouseDown.X) <= 10.0 &&
+                Math.Abs(currentPosition.Y - _lastMouseDown.Y) <= 10.0)
             {
-                _draggedItem = null;
+                return;
+            }
+
+            if (_draggedItems.Count == 0)
+                return;
+
+            _dragInProgress = true;
+            _pendingSingleClickNode = null;
+            try
+            {
+                DragDrop.DoDragDrop(
+                    tvParameters,
+                    _draggedItems,
+                    DragDropEffects.Move);
+            }
+            finally
+            {
+                _draggedItems = [];
+                _dragInProgress = false;
             }
         }
 
         private void treeView_Drop(object sender, DragEventArgs e)
         {
-            if (DataContext is IDropTarget<TreeNode> dropContainer)
+            if (DataContext is not PackFileBrowserViewModel viewModel ||
+                _draggedItems.Count == 0 ||
+                sender is not TreeViewItem dropTargetItem ||
+                dropTargetItem.DataContext is not TreeNode dropTargetNode)
             {
-                if (_draggedItem == null)
-                    return;
+                return;
+            }
 
-                var dropTargetItem = sender as TreeViewItem;
-                var dropTargetNode = dropTargetItem?.DataContext as TreeNode;
-                if (dropTargetNode == null)
-                    return;
-
-                if (dropContainer.AllowDrop(_draggedItem, dropTargetNode))
-                {
-                    dropContainer.Drop(_draggedItem, dropTargetNode);
-                    e.Effects = DragDropEffects.None;
-                    e.Handled = true;
-                }
+            if (viewModel.AllowDrop(_draggedItems, dropTargetNode))
+            {
+                viewModel.Drop(_draggedItems, dropTargetNode);
+                e.Effects = DragDropEffects.None;
+                e.Handled = true;
             }
         }
 
@@ -102,14 +165,71 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
             FilterTextBoxItem.Focus();
         }
 
-        private void TreeViewItem_PreviewMouseRightButtonDown(object sender, MouseEventArgs e)
+        private void TreeViewItem_MouseRightButtonDown(
+            object sender,
+            MouseEventArgs e)
         {
-            var item = sender as TreeViewItem;
-            if (item != null)
+            if (sender is TreeViewItem item &&
+                item.DataContext is TreeNode node &&
+                DataContext is PackFileBrowserViewModel viewModel)
             {
+                viewModel.ActivateNode(node);
                 item.Focus();
                 e.Handled = true;
             }
+        }
+
+        private void TreeView_PreviewKeyDown(
+            object sender,
+            KeyEventArgs e)
+        {
+            if (DataContext is not PackFileBrowserViewModel viewModel)
+                return;
+
+            if (Keyboard.Modifiers == ModifierKeys.Control &&
+                e.Key == Key.C)
+            {
+                viewModel.CopySelection();
+                e.Handled = true;
+            }
+            else if (Keyboard.Modifiers == ModifierKeys.Control &&
+                     e.Key == Key.V)
+            {
+                viewModel.PasteSelection();
+                e.Handled = true;
+            }
+            else if (Keyboard.Modifiers == ModifierKeys.None &&
+                     e.Key == Key.Delete)
+            {
+                viewModel.DeleteSelection();
+                e.Handled = true;
+            }
+        }
+
+        protected override void OnPreviewMouseLeftButtonUp(
+            MouseButtonEventArgs e)
+        {
+            base.OnPreviewMouseLeftButtonUp(e);
+            if (_pendingSingleClickNode != null &&
+                DataContext is PackFileBrowserViewModel viewModel)
+            {
+                viewModel.SelectNode(
+                    _pendingSingleClickNode,
+                    PackFileTreeSelectionMode.Replace);
+            }
+            _pendingSingleClickNode = null;
+            _draggedItems = [];
+        }
+
+        private static bool WasExpanderClicked(DependencyObject? source)
+        {
+            while (source != null)
+            {
+                if (source is ToggleButton { Name: "Expander" })
+                    return true;
+                source = VisualTreeHelper.GetParent(source);
+            }
+            return false;
         }
 
         public static readonly DependencyProperty CustomContextMenuProperty = DependencyProperty.Register("CustomContextMenu", typeof(System.Windows.Controls.ContextMenu), typeof(PackFileBrowserView), new UIPropertyMetadata(null));

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/PackFileBrowserViewModel.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/PackFileBrowserViewModel.cs
@@ -21,6 +21,13 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
     public delegate void FileSelectedDelegate(PackFile file);
     public delegate void NodeSelectedDelegate(TreeNode node);
 
+    public enum PackFileTreeSelectionMode
+    {
+        Replace,
+        Toggle,
+        Range,
+    }
+
     public partial class PackFileBrowserViewModel : ObservableObject, IDisposable, IDropTarget<TreeNode>
     {
         protected IPackFileService _packFileService;
@@ -28,7 +35,11 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
         private readonly ApplicationSettingsService _applicationSettingsService;
         private readonly IContextMenuBuilder _contextMenuBuilder;
         private readonly IFolderProjectHistoryService? _historyService;
+        private readonly PackFileTreeOperations? _operations;
         private readonly bool _showCaFiles;
+        private readonly List<TreeNode> _selectedItems = [];
+        private TreeNode? _selectionAnchor;
+        private bool _isSelectingNode;
         private readonly Dictionary<string, FolderProjectTreeState>
             _detachedFolderProjectStates =
                 new(StringComparer.OrdinalIgnoreCase);
@@ -41,6 +52,7 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
         public event NodeSelectedDelegate NodeSelected;
 
         public ObservableCollection<TreeNode> Files { get; set; } = [];
+        public IReadOnlyList<TreeNode> SelectedItems => _selectedItems;
         public SearchFilter Filter { get; private set; }
         public Task HistoryStatusRefreshTask { get; private set; } =
             Task.CompletedTask;
@@ -57,13 +69,14 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
 
         public bool ShowFoldersOnly { get; }
 
-        public PackFileBrowserViewModel(ApplicationSettingsService applicationSettingsService, IContextMenuBuilder contextMenuBuilder, IPackFileService packFileService, IEventHub? eventHub, bool showCaFiles, bool showFoldersOnly, IFolderProjectHistoryService? historyService = null)
+        public PackFileBrowserViewModel(ApplicationSettingsService applicationSettingsService, IContextMenuBuilder contextMenuBuilder, IPackFileService packFileService, IEventHub? eventHub, bool showCaFiles, bool showFoldersOnly, IFolderProjectHistoryService? historyService = null, PackFileTreeOperations? operations = null)
         {
             _packFileService = packFileService;
             _eventHub = eventHub;
             _applicationSettingsService = applicationSettingsService;
             _contextMenuBuilder = contextMenuBuilder;
             _historyService = historyService;
+            _operations = operations;
             _showCaFiles = showCaFiles;
 
             ShowFoldersOnly = showFoldersOnly;
@@ -142,10 +155,167 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
 
         partial void OnSelectedItemChanged(TreeNode value)
         {
+            if (!_isSelectingNode)
+            {
+                SetSelection(
+                    value == null ? [] : [value],
+                    value);
+                _selectionAnchor = value;
+            }
+            else
+                RefreshContextMenu();
+
             if (value != null)
-                value.IsSelected = true;
-            ContextMenu = _contextMenuBuilder.Build(value);
-            NodeSelected?.Invoke(_selectedItem);
+                NodeSelected?.Invoke(value);
+        }
+
+        public void SelectNode(
+            TreeNode node,
+            PackFileTreeSelectionMode mode)
+        {
+            ArgumentNullException.ThrowIfNull(node);
+
+            IReadOnlyList<TreeNode> selection;
+            TreeNode? activeNode = node;
+            if (mode == PackFileTreeSelectionMode.Range &&
+                _selectionAnchor != null)
+            {
+                var visibleNodes = GetVisibleNodesInDisplayOrder();
+                var anchorIndex = visibleNodes.FindIndex(candidate =>
+                    ReferenceEquals(candidate, _selectionAnchor));
+                var targetIndex = visibleNodes.FindIndex(candidate =>
+                    ReferenceEquals(candidate, node));
+                if (anchorIndex >= 0 && targetIndex >= 0)
+                {
+                    var start = Math.Min(anchorIndex, targetIndex);
+                    var count = Math.Abs(anchorIndex - targetIndex) + 1;
+                    selection = visibleNodes.GetRange(start, count);
+                }
+                else
+                    selection = [node];
+            }
+            else if (mode == PackFileTreeSelectionMode.Toggle)
+            {
+                var toggled = _selectedItems.ToList();
+                if (toggled.Remove(node))
+                    activeNode = toggled.LastOrDefault();
+                else
+                    toggled.Add(node);
+                selection = toggled;
+                _selectionAnchor = node;
+            }
+            else
+            {
+                selection = [node];
+                _selectionAnchor = node;
+            }
+
+            SetSelection(selection, activeNode);
+        }
+
+        public void ActivateNode(TreeNode node)
+        {
+            if (_selectedItems.Contains(node))
+                SetSelection(_selectedItems.ToList(), node);
+            else
+                SelectNode(node, PackFileTreeSelectionMode.Replace);
+        }
+
+        public void CopySelection() => _operations?.Copy(_selectedItems);
+
+        public void PasteSelection()
+        {
+            if (SelectedItem != null)
+                _operations?.Paste(SelectedItem);
+        }
+
+        public void DeleteSelection() =>
+            _operations?.Delete(_selectedItems);
+
+        private void SetSelection(
+            IEnumerable<TreeNode> nodes,
+            TreeNode? activeNode)
+        {
+            var selection = nodes.Distinct().ToList();
+            foreach (var selected in _selectedItems)
+                selected.IsSelected = false;
+            _selectedItems.Clear();
+            foreach (var selected in selection)
+            {
+                selected.IsSelected = true;
+                _selectedItems.Add(selected);
+            }
+
+            _isSelectingNode = true;
+            try
+            {
+                SelectedItem = activeNode;
+            }
+            finally
+            {
+                _isSelectingNode = false;
+            }
+            RefreshContextMenu();
+        }
+
+        private void RefreshContextMenu()
+        {
+            ContextMenu = _selectedItems.Count switch
+            {
+                0 => [],
+                1 => _contextMenuBuilder.Build(_selectedItems[0]),
+                _ => _contextMenuBuilder.Build(_selectedItems) ?? [],
+            };
+        }
+
+        private List<TreeNode> GetVisibleNodesInDisplayOrder()
+        {
+            var output = new List<TreeNode>();
+            foreach (var root in Files)
+                AddVisibleNode(root, output);
+            return output;
+        }
+
+        private static void AddVisibleNode(
+            TreeNode node,
+            List<TreeNode> output)
+        {
+            if (!node.IsVisible)
+                return;
+
+            output.Add(node);
+            if (!node.IsNodeExpanded)
+                return;
+
+            foreach (var child in node.Children
+                         .OrderBy(candidate => candidate.NodeType)
+                         .ThenBy(candidate => candidate.Name))
+            {
+                AddVisibleNode(child, output);
+            }
+        }
+
+        private void PruneSelection()
+        {
+            var retained = _selectedItems
+                .Where(IsNodeInTree)
+                .ToList();
+            if (retained.Count == _selectedItems.Count)
+                return;
+
+            var active = SelectedItem != null && IsNodeInTree(SelectedItem)
+                ? SelectedItem
+                : retained.LastOrDefault();
+            SetSelection(retained, active);
+            _selectionAnchor = active;
+        }
+
+        private bool IsNodeInTree(TreeNode node)
+        {
+            var root = node;
+            while (root.Parent != null)
+                root = root.Parent;
+            return Files.Contains(root);
         }
 
         private void Database_PackFileFolderRemoved(PackFileContainer container, string folder)
@@ -164,6 +334,7 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
             nodeToDelete.RemoveSelf();
 
             root.UnsavedChanged = true;
+            PruneSelection();
         }
 
         private void Database_PackFileFolderRenamed(PackFileContainer container, string folder)
@@ -221,16 +392,23 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
                 var node = GetNodeFromPackFile(container, file, false);
                 node.Parent.Children.Remove(node);
             }
+            PruneSelection();
         }
 
         private void Database_PackFilesUpdated(PackFileContainerFilesUpdatedEvent e)
         {
-            if (e.Container is FolderProjectContainer)
+            if (e.Container is FolderProjectContainer project)
             {
-                ReloadTree(e.Container);
                 MarkFolderProjectFilesChanged(
-                    e.Container,
+                    project,
                     e.ChangedFiles);
+                var root = GetPackFileCollectionRootNode(project);
+                if (root != null)
+                {
+                    QueueFolderProjectHistoryStatusRefresh(
+                        project,
+                        root);
+                }
                 return;
             }
 
@@ -309,19 +487,13 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
                         continue;
 
                     var parent = removedNode.Parent;
-                    var selectionRemoved =
-                        ReferenceEquals(SelectedItem, removedNode);
-                    if (selectionRemoved)
-                        removedNode.IsSelected = false;
-
                     parent?.Children.Remove(removedNode);
                     removedNode.RemoveSelf();
                     var retainedParent = PruneMissingAncestors(
                         parent,
                         root,
                         e.Container);
-                    if (selectionRemoved)
-                        SelectedItem = retainedParent;
+                    RemoveSelectionUnder(removedNode, retainedParent);
                     while (parent != null)
                     {
                         parent.UnsavedChanged = true;
@@ -374,6 +546,7 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
             }
 
             Filter.Refresh();
+            PruneSelection();
             QueueFolderProjectHistoryStatusRefresh(e.Container, root);
         }
 
@@ -480,11 +653,7 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
             var oldParent = node.Parent;
             if (change.Kind == FolderProjectDirectoryChangeKind.Removed)
             {
-                if (IsNodeOrDescendant(node, SelectedItem))
-                {
-                    SelectedItem.IsSelected = false;
-                    SelectedItem = oldParent ?? root;
-                }
+                RemoveSelectionUnder(node, oldParent ?? root);
 
                 oldParent?.Children.Remove(node);
                 node.RemoveSelf();
@@ -518,6 +687,31 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
                 node = node.Parent;
             }
             return false;
+        }
+
+        private void RemoveSelectionUnder(
+            TreeNode removedNode,
+            TreeNode fallback)
+        {
+            var removedSelection = _selectedItems
+                .Where(node => IsNodeOrDescendant(removedNode, node))
+                .ToList();
+            if (removedSelection.Count == 0)
+                return;
+
+            var activeRemoved = IsNodeOrDescendant(
+                removedNode,
+                SelectedItem);
+            var retained = _selectedItems
+                .Except(removedSelection)
+                .ToList();
+            if (activeRemoved && !retained.Contains(fallback))
+                retained.Add(fallback);
+
+            var active = activeRemoved ? fallback : SelectedItem;
+            SetSelection(retained, active);
+            if (IsNodeOrDescendant(removedNode, _selectionAnchor))
+                _selectionAnchor = active;
         }
 
         private static bool IsCoveredByDirectoryChange(
@@ -807,6 +1001,20 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
             var state =
                 CaptureTreeState(existingNode) ??
                 detachedState;
+            var selectedOutsideContainer = _selectedItems
+                .Where(node => node.FileOwner != container)
+                .ToList();
+            var activeOutsideContainer =
+                SelectedItem?.FileOwner != container
+                    ? SelectedItem
+                    : null;
+            foreach (var selected in _selectedItems.Where(
+                         node => node.FileOwner == container))
+            {
+                selected.IsSelected = false;
+            }
+            _selectedItems.Clear();
+            _selectedItems.AddRange(selectedOutsideContainer);
             if (existingNode != null)
                 Files.Remove(existingNode);
 
@@ -903,7 +1111,11 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
                 Files.Insert(existingIndex, root);
 
             Filter.Refresh();
-            RestoreTreeState(container, root, state);
+            RestoreTreeState(
+                root,
+                state,
+                selectedOutsideContainer,
+                activeOutsideContainer);
             if (container is FolderProjectContainer project)
                 QueueFolderProjectHistoryStatusRefresh(project, root);
         }
@@ -1022,20 +1234,28 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
                     expandedPaths.Add(node.GetFullPath());
             });
 
-            var selected = SelectedItem?.FileOwner == root.FileOwner
+            var selected = _selectedItems
+                .Where(node => node.FileOwner == root.FileOwner)
+                .Select(node => new FolderProjectTreeSelection(
+                    node.Item,
+                    node.GetFullPath()))
+                .ToList();
+            var active = SelectedItem?.FileOwner == root.FileOwner
                 ? SelectedItem
                 : null;
             return new FolderProjectTreeState(
                 expandedPaths,
-                selected?.Item,
-                selected?.GetFullPath(),
-                selected != null);
+                selected,
+                active?.Item,
+                active?.GetFullPath(),
+                selected.Count != 0);
         }
 
         private void RestoreTreeState(
-            PackFileContainer container,
             TreeNode root,
-            FolderProjectTreeState? state)
+            FolderProjectTreeState? state,
+            IReadOnlyList<TreeNode> selectedOutsideContainer,
+            TreeNode? activeOutsideContainer)
         {
             if (state == null)
                 return;
@@ -1044,28 +1264,60 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
                 node.IsNodeExpanded = state.ExpandedPaths.Contains(
                     node.GetFullPath()));
 
-            TreeNode? selected = null;
-            if (state.SelectedFile != null)
+            var selectedNodes = new List<TreeNode>();
+            foreach (var selection in state.Selections)
             {
-                root.ForeachNode(node =>
+                TreeNode? selected = null;
+                if (selection.SelectedFile != null)
                 {
-                    if (selected == null &&
-                        ReferenceEquals(node.Item, state.SelectedFile))
+                    root.ForeachNode(node =>
                     {
-                        selected = node;
-                    }
-                });
-            }
-
-            var selectedPath = state.SelectedPath;
-            while (selected == null && selectedPath != null)
-            {
-                selected = FindNodeByPath(root, selectedPath);
-                selectedPath = GetParentPath(selectedPath);
+                        if (selected == null &&
+                            ReferenceEquals(
+                                node.Item,
+                                selection.SelectedFile))
+                        {
+                            selected = node;
+                        }
+                    });
+                }
+                selected ??= FindNodeByPath(root, selection.SelectedPath);
+                if (selected != null)
+                    selectedNodes.Add(selected);
             }
 
             if (state.HadSelection)
-                SelectedItem = selected ?? root;
+            {
+                TreeNode? active = null;
+                if (state.ActiveFile != null)
+                {
+                    root.ForeachNode(node =>
+                    {
+                        if (active == null &&
+                            ReferenceEquals(
+                                node.Item,
+                                state.ActiveFile))
+                        {
+                            active = node;
+                        }
+                    });
+                }
+
+                var activePath = state.ActivePath;
+                while (active == null && activePath != null)
+                {
+                    active = FindNodeByPath(root, activePath);
+                    activePath = GetParentPath(activePath);
+                }
+
+                if (active != null && !selectedNodes.Contains(active))
+                    selectedNodes.Add(active);
+                if (selectedNodes.Count == 0)
+                    selectedNodes.Add(root);
+                SetSelection(
+                    selectedOutsideContainer.Concat(selectedNodes),
+                    active ?? activeOutsideContainer ?? selectedNodes[0]);
+            }
         }
 
         private static TreeNode? FindNodeByPath(
@@ -1104,9 +1356,14 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
 
         private sealed record FolderProjectTreeState(
             HashSet<string> ExpandedPaths,
-            PackFile? SelectedFile,
-            string? SelectedPath,
+            IReadOnlyList<FolderProjectTreeSelection> Selections,
+            PackFile? ActiveFile,
+            string? ActivePath,
             bool HadSelection);
+
+        private sealed record FolderProjectTreeSelection(
+            PackFile? SelectedFile,
+            string SelectedPath);
 
         private void PackFileContainerAdded(PackFileContainerAddedEvent e)
         {
@@ -1147,11 +1404,21 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
                 {
                     _detachedFolderProjectStates[
                         NormalizeProjectRoot(folderProject.ProjectRoot)] =
-                            state with { SelectedFile = null };
+                            state with
+                            {
+                                Selections = state.Selections
+                                    .Select(selection => selection with
+                                    {
+                                        SelectedFile = null,
+                                    })
+                                    .ToList(),
+                                ActiveFile = null,
+                            };
                 }
             }
 
             Files.Remove(node);
+            PruneSelection();
         }
 
         private static string NormalizeProjectRoot(string projectRoot)
@@ -1168,33 +1435,27 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
 
         public bool AllowDrop(TreeNode node, TreeNode targetNode = null)
         {
-            if (node.Item == null) // dragging a folder not supported
-                return false;
-
-            if (node.FileOwner != targetNode.FileOwner) // dragging between different packs not supported
-                return false;
-
-            if (node.FileOwner.IsCaPackFile) // dragging inside CA pack not supported
-                return false;
-
-            if (targetNode.Item != null) // dragging file onto a file not supported
-                return false;
-
-            return true;
+            return AllowDrop([node], targetNode);
         }
 
         public bool Drop(TreeNode node, TreeNode targeNode)
         {
-            var container = node.FileOwner;
-            var draggedFile = node.Item;
-            var dropPath = targeNode.GetFullPath();
+            return Drop([node], targeNode);
+        }
 
-            var newFullPath = dropPath + "\\" + draggedFile.Name;
-            if (newFullPath == _packFileService.GetFullPath(draggedFile, container))
+        public bool AllowDrop(
+            IReadOnlyList<TreeNode> nodes,
+            TreeNode? targetNode) =>
+            _operations?.CanMove(nodes, targetNode) == true;
+
+        public bool Drop(
+            IReadOnlyList<TreeNode> nodes,
+            TreeNode targetNode)
+        {
+            if (_operations?.CanMove(nodes, targetNode) != true)
                 return false;
 
-            _packFileService.MoveFile(container, draggedFile, dropPath);
-
+            _operations.Move(nodes, targetNode);
             return true;
         }
     }

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/PackFileTreeOperations.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/PackFileTreeOperations.cs
@@ -1,0 +1,373 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Services;
+using Shared.Ui.Common;
+
+namespace Shared.Ui.BaseDialogs.PackFileTree
+{
+    public sealed class PackFileTreeClipboard
+    {
+        internal IReadOnlyList<PackFileTreeClipboardSelection> Selections
+        {
+            get;
+            private set;
+        } = [];
+
+        internal void Set(
+            IReadOnlyList<PackFileTreeClipboardSelection> selections) =>
+            Selections = selections;
+    }
+
+    internal sealed record PackFileTreeClipboardSelection(
+        string RootName,
+        IReadOnlyList<PackFileTreeClipboardEntry> Entries);
+
+    internal sealed record PackFileTreeClipboardEntry(
+        string RelativePath,
+        bool IsDirectory,
+        byte[]? Data);
+
+    public sealed class PackFileTreeOperations
+    {
+        private readonly IPackFileService _packFileService;
+        private readonly PackFileTreeClipboard _clipboard;
+        private readonly Func<bool> _confirmDelete;
+
+        public PackFileTreeOperations(
+            IPackFileService packFileService,
+            PackFileTreeClipboard clipboard)
+            : this(
+                packFileService,
+                clipboard,
+                ShowDeleteConfirmation)
+        {
+        }
+
+        internal PackFileTreeOperations(
+            IPackFileService packFileService,
+            PackFileTreeClipboard clipboard,
+            Func<bool> confirmDelete)
+        {
+            _packFileService = packFileService;
+            _clipboard = clipboard;
+            _confirmDelete = confirmDelete;
+        }
+
+        public bool CanCopy(IReadOnlyList<TreeNode> nodes) =>
+            Normalize(nodes).Count != 0;
+
+        public void Copy(IReadOnlyList<TreeNode> nodes)
+        {
+            var selectedNodes = Normalize(nodes);
+            if (selectedNodes.Count == 0)
+                return;
+
+            using (new WaitCursor())
+            {
+                _clipboard.Set(selectedNodes
+                    .Select(CreateClipboardSelection)
+                    .ToList());
+            }
+        }
+
+        public bool CanPaste(TreeNode? target) =>
+            target is { NodeType: not NodeType.File } &&
+            _clipboard.Selections.Count != 0 &&
+            ReferenceEquals(
+                _packFileService.GetEditablePack(),
+                target.FileOwner) &&
+            !target.FileOwner.IsCaPackFile;
+
+        public void Paste(TreeNode target)
+        {
+            if (!CanPaste(target))
+                return;
+
+            var occupiedNames = target.Children
+                .Select(child => child.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            using (new WaitCursor())
+            {
+                foreach (var selection in _clipboard.Selections)
+                {
+                    var destinationName = CreateUniqueName(
+                        selection.RootName,
+                        occupiedNames);
+                    occupiedNames.Add(destinationName);
+                    PasteSelection(target, selection, destinationName);
+                }
+            }
+        }
+
+        public bool CanDelete(IReadOnlyList<TreeNode> nodes)
+        {
+            var selectedNodes = Normalize(nodes);
+            return selectedNodes.Count != 0 &&
+                   selectedNodes.All(node =>
+                       !node.FileOwner.IsCaPackFile &&
+                       ReferenceEquals(
+                           _packFileService.GetEditablePack(),
+                           node.FileOwner));
+        }
+
+        public void Delete(IReadOnlyList<TreeNode> nodes)
+        {
+            var selectedNodes = Normalize(nodes);
+            if (!CanDelete(selectedNodes))
+                return;
+
+            if (!_confirmDelete())
+                return;
+
+            using (new WaitCursor())
+            {
+                foreach (var node in selectedNodes)
+                {
+                    if (node.NodeType == NodeType.File)
+                    {
+                        _packFileService.DeleteFile(
+                            node.FileOwner,
+                            node.Item!);
+                    }
+                    else
+                    {
+                        _packFileService.DeleteFolder(
+                            node.FileOwner,
+                            node.GetFullPath());
+                    }
+                }
+            }
+        }
+
+        public bool CanMove(
+            IReadOnlyList<TreeNode> nodes,
+            TreeNode? target)
+        {
+            if (target is not { NodeType: not NodeType.File } ||
+                target.FileOwner.IsCaPackFile ||
+                !ReferenceEquals(
+                    _packFileService.GetEditablePack(),
+                    target.FileOwner))
+            {
+                return false;
+            }
+
+            var selectedNodes = Normalize(nodes);
+            if (selectedNodes.Count == 0 ||
+                selectedNodes.Any(node =>
+                    !ReferenceEquals(node.FileOwner, target.FileOwner) ||
+                    IsNodeOrDescendant(node, target)))
+            {
+                return false;
+            }
+
+            var movingNodes = selectedNodes
+                .Where(node => !ReferenceEquals(node.Parent, target))
+                .ToList();
+            if (movingNodes.Count == 0)
+                return false;
+
+            var destinationNames = new HashSet<string>(
+                target.Children
+                    .Where(child => !movingNodes.Contains(child))
+                    .Select(child => child.Name),
+                StringComparer.OrdinalIgnoreCase);
+            return movingNodes.All(node =>
+                destinationNames.Add(node.Name));
+        }
+
+        public void Move(
+            IReadOnlyList<TreeNode> nodes,
+            TreeNode target)
+        {
+            var selectedNodes = Normalize(nodes)
+                .Where(node => !ReferenceEquals(node.Parent, target))
+                .ToList();
+            if (!CanMove(selectedNodes, target))
+                return;
+
+            var destinationPath = target.GetFullPath();
+            using (new WaitCursor())
+            {
+                foreach (var node in selectedNodes)
+                {
+                    if (node.NodeType == NodeType.File)
+                    {
+                        _packFileService.MoveFile(
+                            node.FileOwner,
+                            node.Item!,
+                            destinationPath);
+                    }
+                    else
+                    {
+                        _packFileService.MoveFolder(
+                            node.FileOwner,
+                            node.GetFullPath(),
+                            destinationPath);
+                    }
+                }
+            }
+        }
+
+        public static IReadOnlyList<TreeNode> Normalize(
+            IEnumerable<TreeNode> nodes)
+        {
+            var selected = nodes
+                .Where(node => node.NodeType != NodeType.Root)
+                .Distinct()
+                .ToList();
+            var selectedSet = selected.ToHashSet();
+            return selected
+                .Where(node => !HasSelectedAncestor(node, selectedSet))
+                .ToList();
+        }
+
+        private static bool HasSelectedAncestor(
+            TreeNode node,
+            HashSet<TreeNode> selected)
+        {
+            var parent = node.Parent;
+            while (parent != null)
+            {
+                if (selected.Contains(parent))
+                    return true;
+                parent = parent.Parent;
+            }
+            return false;
+        }
+
+        private static bool IsNodeOrDescendant(
+            TreeNode ancestor,
+            TreeNode node)
+        {
+            TreeNode? current = node;
+            while (current != null)
+            {
+                if (ReferenceEquals(ancestor, current))
+                    return true;
+                current = current.Parent;
+            }
+            return false;
+        }
+
+        private static PackFileTreeClipboardSelection
+            CreateClipboardSelection(TreeNode node)
+        {
+            if (node.NodeType == NodeType.File)
+            {
+                return new PackFileTreeClipboardSelection(
+                    node.Name,
+                    [
+                        new PackFileTreeClipboardEntry(
+                            node.Name,
+                            false,
+                            node.Item!.DataSource.ReadData()),
+                    ]);
+            }
+
+            var sourcePath = node.GetFullPath();
+            var entries = new List<PackFileTreeClipboardEntry>();
+            node.ForeachNode(current =>
+            {
+                var relativePath = node.Name +
+                    current.GetFullPath()[sourcePath.Length..];
+                entries.Add(new PackFileTreeClipboardEntry(
+                    relativePath,
+                    current.NodeType == NodeType.Directory,
+                    current.Item?.DataSource.ReadData()));
+            });
+            return new PackFileTreeClipboardSelection(
+                node.Name,
+                entries);
+        }
+
+        private void PasteSelection(
+            TreeNode target,
+            PackFileTreeClipboardSelection selection,
+            string destinationName)
+        {
+            var targetPath = target.GetFullPath();
+            var writes = new List<NewPackFileEntry>();
+            foreach (var entry in selection.Entries.Where(
+                         item => !item.IsDirectory))
+            {
+                var relativePath = ReplaceRootName(
+                    entry.RelativePath,
+                    selection.RootName,
+                    destinationName);
+                var fullPath = Path.Combine(targetPath, relativePath);
+                writes.Add(new NewPackFileEntry(
+                    Path.GetDirectoryName(fullPath) ?? "",
+                    new PackFile(
+                        Path.GetFileName(fullPath),
+                        new MemorySource(entry.Data!))));
+            }
+
+            if (writes.Count != 0)
+            {
+                _packFileService.AddFilesToPack(
+                    target.FileOwner,
+                    writes,
+                    overwriteExisting: false);
+            }
+
+            foreach (var entry in selection.Entries
+                         .Where(item => item.IsDirectory)
+                         .OrderBy(item => item.RelativePath.Length))
+            {
+                var relativePath = ReplaceRootName(
+                    entry.RelativePath,
+                    selection.RootName,
+                    destinationName);
+                var fullPath = Path.Combine(targetPath, relativePath);
+                if (!target.FileOwner.FileList.Keys.Any(path =>
+                        path.StartsWith(
+                            fullPath + "\\",
+                            StringComparison.OrdinalIgnoreCase)))
+                {
+                    _packFileService.CreateFolder(
+                        target.FileOwner,
+                        fullPath);
+                }
+            }
+        }
+
+        private static string ReplaceRootName(
+            string relativePath,
+            string sourceName,
+            string destinationName) =>
+            destinationName + relativePath[sourceName.Length..];
+
+        private static string CreateUniqueName(
+            string sourceName,
+            HashSet<string> occupiedNames)
+        {
+            if (!occupiedNames.Contains(sourceName))
+                return sourceName;
+
+            var extension = Path.GetExtension(sourceName);
+            var baseName = Path.GetFileNameWithoutExtension(sourceName);
+            if (string.IsNullOrEmpty(extension))
+                baseName = sourceName;
+            var candidate = $"{baseName}_copy{extension}";
+            var suffix = 2;
+            while (occupiedNames.Contains(candidate))
+            {
+                candidate = $"{baseName}_copy_{suffix}{extension}";
+                suffix++;
+            }
+            return candidate;
+        }
+
+        private static bool ShowDeleteConfirmation() =>
+            UiMessageBoxBridge.Show(
+                LocalizationManager.Instance.Get("Msg.DeleteFile"),
+                "",
+                UiMessageBoxButtonSet.YesNo,
+                UiMessageBoxIcon.Question) == UiMessageBoxResult.Yes;
+    }
+}

--- a/Shared/SharedUI/BaseDialogs/PackFileTree/PackFileTreeViewFactory.cs
+++ b/Shared/SharedUI/BaseDialogs/PackFileTree/PackFileTreeViewFactory.cs
@@ -13,20 +13,22 @@ namespace Shared.Ui.BaseDialogs.PackFileTree
         private readonly IEventHub _eventHub;
         private readonly ContextMenuFactory _contextMenuFactory;
         private readonly IFolderProjectHistoryService? _historyService;
+        private readonly PackFileTreeOperations? _operations;
 
-        public PackFileTreeViewFactory(ApplicationSettingsService applicationSettingsService, IPackFileService packFileService, IEventHub eventHub, ContextMenuFactory contextMenuFactory, IFolderProjectHistoryService? historyService = null)
+        public PackFileTreeViewFactory(ApplicationSettingsService applicationSettingsService, IPackFileService packFileService, IEventHub eventHub, ContextMenuFactory contextMenuFactory, IFolderProjectHistoryService? historyService = null, PackFileTreeOperations? operations = null)
         {
             _applicationSettingsService = applicationSettingsService;
             _packFileService = packFileService;
             _eventHub = eventHub;
             _contextMenuFactory = contextMenuFactory;
+            _operations = operations;
             _historyService = historyService;
         }
 
         public PackFileBrowserViewModel Create(ContextMenuType contextMenu, bool showCaFiles, bool showFoldersOnly)
         {
             var contextMenuBuilder = _contextMenuFactory.GetContextMenu(contextMenu);
-            var fileTree = new PackFileBrowserViewModel(_applicationSettingsService, contextMenuBuilder, _packFileService, _eventHub, showCaFiles, showFoldersOnly, _historyService);
+            var fileTree = new PackFileBrowserViewModel(_applicationSettingsService, contextMenuBuilder, _packFileService, _eventHub, showCaFiles, showFoldersOnly, _historyService, _operations);
             return fileTree;
         }
     }

--- a/Shared/SharedUI/DependencyInjectionContainer.cs
+++ b/Shared/SharedUI/DependencyInjectionContainer.cs
@@ -25,6 +25,8 @@ namespace Shared.Ui
             services.AddTransient<IToolSelectorUiProvider, ToolSelectorUiProvider>();
 
             services.AddScoped<PackFileTreeViewFactory>();
+            services.AddSingleton<PackFileTreeClipboard>();
+            services.AddScoped<PackFileTreeOperations>();
 
             // Context menu
             services.AddScoped<ContextMenuFactory>();
@@ -42,6 +44,8 @@ namespace Shared.Ui
             services.AddScoped<CollapseNodeCommand>();
             services.AddScoped<DuplicateFileCommand>();
             services.AddScoped<DeleteNodeCommand>();
+            services.AddScoped<CopyTreeNodesCommand>();
+            services.AddScoped<PasteTreeNodesCommand>();
             services.AddScoped<ExportToDirectoryCommand>();
             services.AddScoped<ExpandNodeCommand>();
             services.AddScoped<ImportDirectoryCommand>();

--- a/Testing/AssetEditorTests/FolderProjectGitOperationCoordinatorTests.cs
+++ b/Testing/AssetEditorTests/FolderProjectGitOperationCoordinatorTests.cs
@@ -1644,6 +1644,12 @@ public class FolderProjectGitOperationCoordinatorTests
             string newFolderPath) =>
             throw new NotSupportedException();
 
+        public void MoveFolder(
+            PackFileContainer container,
+            string folderPath,
+            string newParentPath) =>
+            throw new NotSupportedException();
+
         public void RenameDirectory(
             PackFileContainer container,
             string currentNodeName,

--- a/Testing/AssetEditorTests/FolderProjectTreeStateTests.cs
+++ b/Testing/AssetEditorTests/FolderProjectTreeStateTests.cs
@@ -1,7 +1,8 @@
-using System.Collections.ObjectModel;
-using System.Threading;
+﻿using System.Collections.ObjectModel;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Input;
 using Moq;
 using NUnit.Framework;
 using NUnitAssert = NUnit.Framework.Assert;
@@ -17,6 +18,169 @@ namespace AssetEditorTests;
 
 public class FolderProjectTreeStateTests
 {
+    [Test]
+    public void CtrlAndShiftSelection_UpdatesAllVisibleSelectedNodes()
+    {
+        var pack = new PackFileContainer("Pack");
+        pack.FileList["a.bin"] = PackFile.CreateFromBytes("a.bin", [1]);
+        pack.FileList["b.bin"] = PackFile.CreateFromBytes("b.bin", [2]);
+        pack.FileList["c.bin"] = PackFile.CreateFromBytes("c.bin", [3]);
+        using var harness = CreateViewModel(pack);
+        var root = harness.ViewModel.Files.Single();
+        root.IsNodeExpanded = true;
+        var first = FindNode(root, "a.bin");
+        var middle = FindNode(root, "b.bin");
+        var last = FindNode(root, "c.bin");
+
+        harness.ViewModel.SelectNode(
+            first,
+            PackFileTreeSelectionMode.Replace);
+        harness.ViewModel.SelectNode(
+            last,
+            PackFileTreeSelectionMode.Range);
+
+        NUnitAssert.That(
+            harness.ViewModel.SelectedItems.Select(node => node.Name),
+            Is.EqualTo(new[] { "a.bin", "b.bin", "c.bin" }));
+
+        harness.ViewModel.SelectNode(
+            middle,
+            PackFileTreeSelectionMode.Toggle);
+
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(
+                harness.ViewModel.SelectedItems.Select(node => node.Name),
+                Is.EqualTo(new[] { "a.bin", "c.bin" }));
+            NUnitAssert.That(first.IsSelected, Is.True);
+            NUnitAssert.That(middle.IsSelected, Is.False);
+            NUnitAssert.That(last.IsSelected, Is.True);
+        });
+    }
+
+    [Test]
+    public void SavingExistingMetaFile_PreservesExpandedResourceTree()
+    {
+        using var projectRoot = new TemporaryDirectory();
+        projectRoot.Write(@"animations\folder\selected.meta", [1]);
+        using var project = FolderProjectContainer.Create(
+            projectRoot.Path,
+            new FolderProjectSettings { Name = "工程" });
+        var eventHub = new TestEventHub();
+        var service = new PackFileService(eventHub);
+        service.AddEditableFolderProject(project);
+        var contextMenu = new Mock<IContextMenuBuilder>();
+        contextMenu.Setup(builder => builder.Build(It.IsAny<TreeNode?>()))
+            .Returns(new ObservableCollection<ContextMenuItem2>());
+        using var viewModel = new PackFileBrowserViewModel(
+            new ApplicationSettingsService(GameTypeEnum.Warhammer3),
+            contextMenu.Object,
+            service,
+            eventHub,
+            true,
+            false);
+        var root = viewModel.Files.Single();
+        root.IsNodeExpanded = true;
+        FindNode(root, "animations").IsNodeExpanded = true;
+        FindNode(root, @"animations\folder").IsNodeExpanded = true;
+        var selected = FindNode(
+            root,
+            @"animations\folder\selected.meta");
+        viewModel.SelectedItem = selected;
+
+        service.SaveFile(selected.Item!, [2]);
+
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(viewModel.Files.Single(), Is.SameAs(root));
+            NUnitAssert.That(root.IsNodeExpanded, Is.True);
+            NUnitAssert.That(
+                FindNode(root, "animations").IsNodeExpanded,
+                Is.True);
+            NUnitAssert.That(
+                FindNode(root, @"animations\folder").IsNodeExpanded,
+                Is.True);
+            NUnitAssert.That(viewModel.SelectedItem, Is.SameAs(selected));
+        });
+    }
+
+    [Test]
+    public void LegacyUpdatedEvent_DoesNotRebuildExpandedFolderProjectTree()
+    {
+        using var projectRoot = new TemporaryDirectory();
+        projectRoot.Write(@"animations\folder\selected.meta", [1]);
+        using var project = FolderProjectContainer.Create(
+            projectRoot.Path,
+            new FolderProjectSettings { Name = "工程" });
+        using var harness = CreateViewModel(project);
+        var root = harness.ViewModel.Files.Single();
+        root.IsNodeExpanded = true;
+        var animations = FindNode(root, "animations");
+        animations.IsNodeExpanded = true;
+        var folder = FindNode(root, @"animations\folder");
+        folder.IsNodeExpanded = true;
+        var selected = FindNode(
+            root,
+            @"animations\folder\selected.meta");
+        harness.ViewModel.SelectedItem = selected;
+
+        harness.EventHub.Publish(new PackFileContainerFilesUpdatedEvent(
+            project,
+            [selected.Item!]));
+
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(harness.ViewModel.Files.Single(), Is.SameAs(root));
+            NUnitAssert.That(root.IsNodeExpanded, Is.True);
+            NUnitAssert.That(animations.IsNodeExpanded, Is.True);
+            NUnitAssert.That(folder.IsNodeExpanded, Is.True);
+            NUnitAssert.That(harness.ViewModel.SelectedItem, Is.SameAs(selected));
+        });
+    }
+
+    [Test]
+    public void LegacyFolderRemoval_PreservesOtherSelectionAndHighlightsFallback()
+    {
+        using var projectRoot = new TemporaryDirectory();
+        projectRoot.Write("keep.bin", [1]);
+        Directory.CreateDirectory(Path.Combine(
+            projectRoot.Path,
+            "folder",
+            "child"));
+        using var project = FolderProjectContainer.Create(
+            projectRoot.Path,
+            new FolderProjectSettings { Name = "工程" });
+        using var harness = CreateViewModel(project);
+        var root = harness.ViewModel.Files.Single();
+        var keep = FindNode(root, "keep.bin");
+        var removed = FindNode(root, @"folder\child");
+        harness.ViewModel.SelectNode(
+            keep,
+            PackFileTreeSelectionMode.Replace);
+        harness.ViewModel.SelectNode(
+            removed,
+            PackFileTreeSelectionMode.Toggle);
+
+        project.DeleteFolderFromDisk(@"folder\child");
+        harness.EventHub.Publish(new PackFileContainerFolderRemovedEvent(
+            project,
+            @"folder\child"));
+
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(
+                harness.ViewModel.SelectedItem.GetFullPath(),
+                Is.EqualTo("folder").IgnoreCase);
+            NUnitAssert.That(
+                harness.ViewModel.SelectedItems.Select(node =>
+                    node.GetFullPath()),
+                Is.EquivalentTo(new[] { "keep.bin", "folder" }));
+            NUnitAssert.That(
+                harness.ViewModel.SelectedItems.All(node => node.IsSelected),
+                Is.True);
+        });
+    }
+
     [Test]
     public async Task CaWemSettingChanged_RefreshesCaPackAndPreservesSelection()
     {
@@ -984,23 +1148,157 @@ public class FolderProjectTreeStateTests
     }
 
     [Test]
-    [Apartment(ApartmentState.STA)]
-    public void TreeNodeSelection_BindsToTreeViewItem()
+    [NonParallelizable]
+    public void MultiSelectionHighlight_UsesTreeNodeSelectionState()
     {
-        var pack = new PackFileContainer("Pack");
-        var node = new TreeNode("node.bin", NodeType.File, pack, null);
-        var item = new TreeViewItem { DataContext = node };
-        BindingOperations.SetBinding(
-            item,
-            TreeViewItem.IsSelectedProperty,
-            new Binding(nameof(TreeNode.IsSelected))
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () =>
             {
-                Mode = BindingMode.TwoWay,
+                var view = new PackFileBrowserView();
+                var tree = (TreeView)view.FindName("tvParameters");
+                var selectionTrigger = tree.ItemContainerStyle.Triggers
+                    .OfType<DataTrigger>()
+                    .Single(trigger =>
+                        trigger.Binding is Binding binding &&
+                        binding.Path.Path == nameof(TreeNode.IsSelected));
+
+                NUnitAssert.That(
+                    selectionTrigger.Setters
+                        .OfType<Setter>()
+                        .Any(setter =>
+                            setter.Property == Control.BackgroundProperty),
+                    Is.True);
             });
+    }
 
-        node.IsSelected = true;
+    [TestCase("folder")]
+    [TestCase(@"folder\file.bin")]
+    [NonParallelizable]
+    public void RightClickingNestedNode_ActivatesClickedNode(string path)
+    {
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () =>
+            {
+                var pack = new PackFileContainer("Pack");
+                pack.FileList[@"folder\file.bin"] =
+                    PackFile.CreateFromBytes("file.bin", [1]);
+                using var harness = CreateViewModel(pack);
+                var root = harness.ViewModel.Files.Single();
+                root.IsNodeExpanded = true;
+                FindNode(root, "folder").IsNodeExpanded = true;
+                var target = FindNode(root, path);
+                var view = new PackFileBrowserView
+                {
+                    DataContext = harness.ViewModel,
+                };
+                var window = new Window
+                {
+                    Content = view,
+                    ShowActivated = false,
+                    ShowInTaskbar = false,
+                    Width = 400,
+                    Height = 500,
+                };
 
-        NUnitAssert.That(item.IsSelected, Is.True);
+                try
+                {
+                    window.Show();
+                    view.UpdateLayout();
+                    var tree = (TreeView)view.FindName("tvParameters");
+                    var targetItem = FindTreeViewItem(tree, target);
+
+                    targetItem.RaiseEvent(new MouseButtonEventArgs(
+                        Mouse.PrimaryDevice,
+                        Environment.TickCount,
+                        MouseButton.Right)
+                    {
+                        RoutedEvent = UIElement.MouseRightButtonDownEvent,
+                        Source = targetItem,
+                    });
+
+                    NUnitAssert.That(
+                        harness.ViewModel.SelectedItem,
+                        Is.SameAs(target));
+                }
+                finally
+                {
+                    window.Close();
+                }
+            });
+    }
+
+    [Test]
+    [NonParallelizable]
+    public void PreviewLeftClickOnNestedSelection_DoesNotActivateAncestor()
+    {
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () =>
+            {
+                var pack = new PackFileContainer("Pack");
+                pack.FileList[@"folder\first.bin"] =
+                    PackFile.CreateFromBytes("first.bin", [1]);
+                pack.FileList[@"folder\second.bin"] =
+                    PackFile.CreateFromBytes("second.bin", [2]);
+                using var harness = CreateViewModel(pack);
+                var root = harness.ViewModel.Files.Single();
+                root.IsNodeExpanded = true;
+                FindNode(root, "folder").IsNodeExpanded = true;
+                var first = FindNode(root, @"folder\first.bin");
+                var second = FindNode(root, @"folder\second.bin");
+                harness.ViewModel.SelectNode(
+                    first,
+                    PackFileTreeSelectionMode.Replace);
+                harness.ViewModel.SelectNode(
+                    second,
+                    PackFileTreeSelectionMode.Toggle);
+                var view = new PackFileBrowserView
+                {
+                    DataContext = harness.ViewModel,
+                };
+                var window = new Window
+                {
+                    Content = view,
+                    ShowActivated = false,
+                    ShowInTaskbar = false,
+                    Width = 400,
+                    Height = 500,
+                };
+
+                try
+                {
+                    window.Show();
+                    view.UpdateLayout();
+                    var tree = (TreeView)view.FindName("tvParameters");
+                    var rootItem = FindTreeViewItem(tree, root);
+                    var clickedItem = FindTreeViewItem(tree, second);
+
+                    rootItem.RaiseEvent(new MouseButtonEventArgs(
+                        Mouse.PrimaryDevice,
+                        Environment.TickCount,
+                        MouseButton.Left)
+                    {
+                        RoutedEvent = UIElement.PreviewMouseLeftButtonDownEvent,
+                        Source = clickedItem,
+                    });
+
+                    NUnitAssert.Multiple(() =>
+                    {
+                        NUnitAssert.That(
+                            harness.ViewModel.SelectedItem,
+                            Is.SameAs(second));
+                        NUnitAssert.That(
+                            harness.ViewModel.SelectedItems,
+                            Is.EquivalentTo(new[] { first, second }));
+                    });
+                }
+                finally
+                {
+                    window.Close();
+                }
+            });
     }
 
     private static TreeNode FindNode(TreeNode root, string path)
@@ -1019,6 +1317,37 @@ public class FolderProjectTreeStateTests
             foreach (var descendant in GetAllNodes(child))
                 yield return descendant;
         }
+    }
+
+    private static TreeViewItem FindTreeViewItem(
+        ItemsControl parent,
+        TreeNode target)
+    {
+        parent.ApplyTemplate();
+        parent.UpdateLayout();
+        foreach (var node in parent.Items.OfType<TreeNode>())
+        {
+            var item = parent.ItemContainerGenerator.ContainerFromItem(node)
+                as TreeViewItem;
+            if (item == null)
+                continue;
+            if (ReferenceEquals(node, target))
+                return item;
+
+            item.IsExpanded = true;
+            item.ApplyTemplate();
+            item.UpdateLayout();
+            try
+            {
+                return FindTreeViewItem(item, target);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not find the tree item for '{target.GetFullPath()}'.");
     }
 
     private static TreeHarness CreateViewModel(

--- a/Testing/AssetEditorTests/PackFileTreeOperationsTests.cs
+++ b/Testing/AssetEditorTests/PackFileTreeOperationsTests.cs
@@ -1,0 +1,255 @@
+﻿using System.Collections.ObjectModel;
+using Moq;
+using NUnit.Framework;
+using NUnitAssert = NUnit.Framework.Assert;
+using Shared.Core.Events.Global;
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Services;
+using Shared.Core.Settings;
+using Shared.Ui.BaseDialogs.PackFileTree;
+using Shared.Ui.BaseDialogs.PackFileTree.ContextMenu;
+
+namespace AssetEditorTests;
+
+[NonParallelizable]
+public class PackFileTreeOperationsTests
+{
+    [SetUp]
+    public void SetUp() => new LocalizationManager().LoadLanguage();
+
+    [Test]
+    public void CopyPaste_MultipleFileAndDirectory_PreservesContentsAndEmptyFolders()
+    {
+        RunOnWpfThread(() =>
+        {
+            using var projectRoot = new TemporaryDirectory();
+            projectRoot.Write(@"source\a.bin", [1]);
+            projectRoot.Write(@"source\nested\b.bin", [2]);
+            projectRoot.CreateDirectory(@"source\empty");
+            projectRoot.Write("loose.bin", [3]);
+            projectRoot.Write(@"target\existing.bin", [9]);
+            using var project = FolderProjectContainer.Create(
+                projectRoot.Path,
+                new FolderProjectSettings
+                {
+                    Name = "工程",
+                    EmptyDirectories = [@"source\empty"],
+                });
+            using var harness = CreateHarness(project);
+            var root = harness.ViewModel.Files.Single();
+            var source = FindNode(root, "source");
+            var loose = FindNode(root, "loose.bin");
+            var target = FindNode(root, "target");
+
+            harness.Operations.Copy([source, loose]);
+            harness.Operations.Paste(target);
+            harness.Operations.Paste(target);
+
+            NUnitAssert.Multiple(() =>
+            {
+                NUnitAssert.That(
+                    File.ReadAllBytes(projectRoot.Resolve(@"target\source\a.bin")),
+                    Is.EqualTo(new byte[] { 1 }));
+                NUnitAssert.That(
+                    File.ReadAllBytes(projectRoot.Resolve(@"target\source\nested\b.bin")),
+                    Is.EqualTo(new byte[] { 2 }));
+                NUnitAssert.That(
+                    Directory.Exists(projectRoot.Resolve(@"target\source\empty")),
+                    Is.True);
+                NUnitAssert.That(
+                    File.ReadAllBytes(projectRoot.Resolve(@"target\loose.bin")),
+                    Is.EqualTo(new byte[] { 3 }));
+                NUnitAssert.That(
+                    File.Exists(projectRoot.Resolve(@"target\source_copy\a.bin")),
+                    Is.True);
+                NUnitAssert.That(
+                    File.Exists(projectRoot.Resolve(@"target\loose_copy.bin")),
+                    Is.True);
+            });
+        });
+    }
+
+    [Test]
+    public void Move_MultipleFileAndDirectory_UpdatesDiskAndTree()
+    {
+        RunOnWpfThread(() =>
+        {
+            using var projectRoot = new TemporaryDirectory();
+            projectRoot.Write(@"from\moving.bin", [1]);
+            projectRoot.Write(@"folder-to-move\nested\child.bin", [2]);
+            projectRoot.CreateDirectory(@"folder-to-move\empty");
+            projectRoot.Write(@"target\keep.bin", [3]);
+            using var project = FolderProjectContainer.Create(
+                projectRoot.Path,
+                new FolderProjectSettings { Name = "工程" });
+            using var harness = CreateHarness(project);
+            var root = harness.ViewModel.Files.Single();
+            var movingFile = FindNode(root, @"from\moving.bin");
+            var movingFolder = FindNode(root, "folder-to-move");
+            var target = FindNode(root, "target");
+
+            NUnitAssert.That(
+                harness.Operations.CanMove([movingFile, movingFolder], target),
+                Is.True);
+            harness.Operations.Move([movingFile, movingFolder], target);
+
+            NUnitAssert.Multiple(() =>
+            {
+                NUnitAssert.That(
+                    File.Exists(projectRoot.Resolve(@"from\moving.bin")),
+                    Is.False);
+                NUnitAssert.That(
+                    File.Exists(projectRoot.Resolve(@"target\moving.bin")),
+                    Is.True);
+                NUnitAssert.That(
+                    Directory.Exists(projectRoot.Resolve("folder-to-move")),
+                    Is.False);
+                NUnitAssert.That(
+                    File.Exists(projectRoot.Resolve(
+                        @"target\folder-to-move\nested\child.bin")),
+                    Is.True);
+                NUnitAssert.That(
+                    Directory.Exists(projectRoot.Resolve(
+                        @"target\folder-to-move\empty")),
+                    Is.True);
+                NUnitAssert.That(
+                    project.EmptyDirectories.Any(path => path.Equals(
+                        @"target\folder-to-move\empty",
+                        StringComparison.OrdinalIgnoreCase)),
+                    Is.True);
+                NUnitAssert.That(
+                    movingFile.GetFullPath(),
+                    Is.EqualTo(@"target\moving.bin").IgnoreCase);
+                NUnitAssert.That(
+                    movingFolder.GetFullPath(),
+                    Is.EqualTo(@"target\folder-to-move").IgnoreCase);
+            });
+        });
+    }
+
+    [Test]
+    public void Delete_ParentAndChildSelected_DeletesTheTreeOnlyOnce()
+    {
+        RunOnWpfThread(() =>
+        {
+            using var projectRoot = new TemporaryDirectory();
+            projectRoot.Write(@"source\nested\child.bin", [1]);
+            using var project = FolderProjectContainer.Create(
+                projectRoot.Path,
+                new FolderProjectSettings { Name = "工程" });
+            using var harness = CreateHarness(project, confirmDelete: true);
+            var root = harness.ViewModel.Files.Single();
+            var source = FindNode(root, "source");
+            var child = FindNode(root, @"source\nested\child.bin");
+
+            harness.Operations.Delete([source, child]);
+
+            NUnitAssert.Multiple(() =>
+            {
+                NUnitAssert.That(
+                    Directory.Exists(projectRoot.Resolve("source")),
+                    Is.False);
+                NUnitAssert.That(
+                    project.FileList.Keys.Any(path => path.StartsWith(
+                        "source\\",
+                        StringComparison.OrdinalIgnoreCase)),
+                    Is.False);
+            });
+            NUnitAssert.That(harness.GetConfirmationCount(), Is.EqualTo(1));
+        });
+    }
+
+    private static void RunOnWpfThread(Action action) =>
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            action);
+
+    private static OperationHarness CreateHarness(
+        FolderProjectContainer project,
+        bool confirmDelete = false)
+    {
+        var eventHub = new TestEventHub();
+        var service = new PackFileService(eventHub);
+        service.AddEditableFolderProject(project);
+        var confirmationCount = 0;
+        var operations = new PackFileTreeOperations(
+            service,
+            new PackFileTreeClipboard(),
+            () =>
+            {
+                confirmationCount++;
+                return confirmDelete;
+            });
+        var contextMenu = new Mock<IContextMenuBuilder>();
+        contextMenu.Setup(builder => builder.Build(It.IsAny<TreeNode?>()))
+            .Returns(new ObservableCollection<ContextMenuItem2>());
+        contextMenu.Setup(builder => builder.Build(
+                It.IsAny<IReadOnlyList<TreeNode>>()))
+            .Returns(new ObservableCollection<ContextMenuItem2>());
+        var viewModel = new PackFileBrowserViewModel(
+            new ApplicationSettingsService(GameTypeEnum.Warhammer3),
+            contextMenu.Object,
+            service,
+            eventHub,
+            true,
+            false,
+            operations: operations);
+        return new OperationHarness(
+            operations,
+            viewModel,
+            () => confirmationCount);
+    }
+
+    private static TreeNode FindNode(TreeNode root, string path)
+    {
+        TreeNode? found = null;
+        root.ForeachNode(node =>
+        {
+            if (node.GetFullPath().Equals(
+                    path,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                found = node;
+            }
+        });
+        return found ?? throw new InvalidOperationException(
+            $"Tree node not found: {path}");
+    }
+
+    private sealed record OperationHarness(
+        PackFileTreeOperations Operations,
+        PackFileBrowserViewModel ViewModel,
+        Func<int> GetConfirmationCount) : IDisposable
+    {
+        public void Dispose() => ViewModel.Dispose();
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            $"ae-tree-operations-{Guid.NewGuid():N}");
+
+        public TemporaryDirectory() => Directory.CreateDirectory(Path);
+
+        public string Resolve(string relativePath) =>
+            System.IO.Path.Combine(Path, relativePath);
+
+        public void CreateDirectory(string relativePath) =>
+            Directory.CreateDirectory(Resolve(relativePath));
+
+        public void Write(string relativePath, byte[] bytes)
+        {
+            var path = Resolve(relativePath);
+            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path)!);
+            File.WriteAllBytes(path, bytes);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, true);
+        }
+    }
+}

--- a/Testing/E2EVerification/PackFileBrowser.cs
+++ b/Testing/E2EVerification/PackFileBrowser.cs
@@ -10,21 +10,27 @@ namespace Test.E2EVerification
         private readonly string _inputPackFileKarl = PathHelper.GetDataFolder("Data\\Karl_and_celestialgeneral_Pack");
 
         [Test]
+        [Apartment(ApartmentState.STA)]
         public void DragAndDrop()
         {
             // Arrange
             var runner = new AssetEditorTestRunner();
             runner.CreateCaContainer();
-            var outputPackFile = runner.LoadFolderPackFile(_inputPackFileKarl);
+            var outputPackFile = runner.LoadFolderPackFile(_inputPackFileKarl) ??
+                throw new InvalidOperationException("Unable to load the editable test pack.");
+            runner.PackFileService.SetEditablePack(outputPackFile);
 
             var mainApplicationView = runner.ServiceProvider.GetRequiredService<MainViewModel>();
             var treeView = mainApplicationView.FileTree;
             var packRootNode = treeView.Files[1];
 
             // Act
-            var fileToMove = treeView.GetFromPath(packRootNode, @"animations\battle\humanoid01\2handed_hammer\stand\hu1_2hh_stand_idle_01.anim");
-            var destinationNode = treeView.GetFromPath(packRootNode, @"animations");
-            treeView.Drop(fileToMove, destinationNode);
+            var fileToMove = treeView.GetFromPath(packRootNode, @"animations\battle\humanoid01\2handed_hammer\stand\hu1_2hh_stand_idle_01.anim") ??
+                throw new InvalidOperationException("Unable to find the file to move.");
+            var destinationNode = treeView.GetFromPath(packRootNode, @"animations") ??
+                throw new InvalidOperationException("Unable to find the move destination.");
+            Assert.That(treeView.AllowDrop(fileToMove, destinationNode), Is.True);
+            Assert.That(treeView.Drop(fileToMove, destinationNode), Is.True);
 
             // Assert
             // Get file in packfileservice

--- a/Testing/GameWorld.Core.Test/Rendering/Materials/CapabilityMaterialFactoryTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/Materials/CapabilityMaterialFactoryTests.cs
@@ -41,6 +41,44 @@ namespace GameWorld.Core.Test.Rendering.Materials
         }
 
         [Test]
+        public void Create_FromLegacyRmv_Wh3_MapsLegacyTextureNames()
+        {
+            var rmvMaterial = RmvMaterialHelper
+                .Create(ModelMaterialEnum.weighted)
+                .AssignMaterials([TextureType.Diffuse, TextureType.Specular, TextureType.Normal]);
+            rmvMaterial.SetTexture(
+                TextureType.Diffuse,
+                @"rigidmodels\buildings\textures\building_diffuse.dds");
+            rmvMaterial.SetTexture(
+                TextureType.Specular,
+                @"rigidmodels\buildings\textures\building_specular.dds");
+            rmvMaterial.SetTexture(
+                TextureType.Normal,
+                @"rigidmodels\buildings\textures\building_normal.dds");
+
+            var appSettings = new ApplicationSettingsService(GameTypeEnum.Warhammer3);
+            var materialFactory = new CapabilityMaterialFactory(appSettings, null);
+            var material = materialFactory.Create(rmvMaterial, null);
+
+            var capability = material.GetCapability<MetalRoughCapability>();
+            Assert.Multiple(() =>
+            {
+                Assert.That(capability.BaseColour.UseTexture, Is.True);
+                Assert.That(
+                    capability.BaseColour.TexturePath,
+                    Is.EqualTo(@"rigidmodels\buildings\textures\building_base_colour.dds"));
+                Assert.That(capability.MaterialMap.UseTexture, Is.True);
+                Assert.That(
+                    capability.MaterialMap.TexturePath,
+                    Is.EqualTo(@"rigidmodels\buildings\textures\building_material_map.dds"));
+                Assert.That(capability.NormalMap.UseTexture, Is.True);
+                Assert.That(
+                    capability.NormalMap.TexturePath,
+                    Is.EqualTo(@"rigidmodels\buildings\textures\building_normal.dds"));
+            });
+        }
+
+        [Test]
         public void Create_FromWs_Wh3_Default()
         {
             var rmvMaterial = RmvMaterialHelper
@@ -140,7 +178,7 @@ namespace GameWorld.Core.Test.Rendering.Materials
                 .SetAlpha(true)
                 .SetDecalAndDirt(true, true)
                 .AssignMaterials([TextureType.Diffuse, TextureType.Decal_dirtmap, TextureType.Decal_mask, TextureType.Decal_dirtmask]);
-            
+
             var appSettings = new ApplicationSettingsService(GameTypeEnum.Rome2);
             var abstractMaterialFactory = new CapabilityMaterialFactory(appSettings, null);
             var material = abstractMaterialFactory.Create(rmvMaterial, null);


### PR DESCRIPTION
## 摘要

- 支持资源树 Ctrl/Shift 多选，并让复制、粘贴、删除和拖放移动按多选集合工作
- 保留 META 保存后的资源树展开、选择和历史状态，避免保存时整棵树收起
- 兼容建筑与 rigidmodels 材质中的 Diffuse/Specular 语义贴图，映射到当前着色器参数
- 修复子文件/文件夹右键菜单命中，以及左键关闭多选菜单时短暂闪出单选菜单的问题

## 验证

- `dotnet restore AssetEditor.CN.sln`
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore`
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal`
- 资源树拖放端到端回归测试通过