### PR TITLE
Fix rigid model textures and grid selection outline

### DIFF
--- a/Editors/Kitbashing/Test.KitbashEditor/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
@@ -357,6 +357,122 @@ public class RenderEngineSelectionMaskOffscreenTests
     }
 
     [Test]
+    public void GridBeforeSelectedGeometry_DoesNotCreateInternalSelectionOutline()
+    {
+        const int size = 64;
+        var game = new WpfGameMock();
+        var device = game.GraphicsDevice;
+        var deviceResolver = new Mock<IDeviceResolver>();
+        deviceResolver
+            .SetupGet(resolver => resolver.Device)
+            .Returns(device);
+        var camera = new ArcBallCamera(
+            deviceResolver.Object,
+            Mock.Of<IKeyboardComponent>(),
+            Mock.Of<IMouseComponent>())
+        {
+            ViewMatrixOverride = Matrix.CreateLookAt(
+                new Vector3(0, 10, 0),
+                Vector3.Zero,
+                Vector3.Forward),
+            ProjectionMatrixOverride = Matrix.CreateOrthographic(
+                100,
+                100,
+                0.1f,
+                100)
+        };
+        camera.Initialize();
+        var resources = new ResourceLibrary(
+            Mock.Of<IPackFileService>());
+        resources.Initialize(device, game.Content);
+        using var grid = new GridComponent(
+            camera,
+            resources,
+            deviceResolver.Object)
+        {
+            ShowGrid = true
+        };
+        grid.Initialize();
+        var renderEngine = new RenderEngineComponent(
+            game,
+            resources,
+            camera,
+            deviceResolver.Object,
+            new ApplicationSettingsService(),
+            new SceneRenderParametersStore(),
+            Mock.Of<IEventHub>(),
+            grid);
+        renderEngine.Initialize();
+        renderEngine.AddRenderItem(
+            RenderBuckedId.Normal,
+            new SelectionMaskRenderItem(
+                game.Content.Load<Effect>(
+                    "Shaders\\Pbr\\SpecGloss\\SpecGloss_main"),
+                device));
+        using var sceneTarget = new RenderTarget2D(
+            device,
+            size,
+            size,
+            false,
+            SurfaceFormat.Color,
+            DepthFormat.Depth24);
+        using var maskTarget = new RenderTarget2D(
+            device,
+            size,
+            size,
+            false,
+            SurfaceFormat.Color,
+            DepthFormat.None);
+        using var outlineFilter = new OutlineFilter();
+        outlineFilter.Load(
+            device,
+            resources,
+            new QuadRenderer(device));
+        var cameraPosition = new Vector3(0, 10, 0);
+        var parameters = new CommonShaderParameters(
+            camera.ViewMatrix,
+            camera.ProjectionMatrix,
+            cameraPosition,
+            Vector3.Down,
+            0,
+            0,
+            0,
+            1,
+            Vector3.One,
+            []);
+
+        device.SetRenderTargets(
+            new RenderTargetBinding(sceneTarget),
+            new RenderTargetBinding(maskTarget));
+        device.Clear(
+            ClearOptions.Target | ClearOptions.DepthBuffer,
+            Color.Transparent,
+            1,
+            0);
+        grid.RenderGrid(device, parameters);
+        device.DepthStencilState = DepthStencilState.Default;
+        device.BlendState = BlendState.Opaque;
+        InvokeRender3DObjects(renderEngine);
+        device.SetRenderTarget(null);
+
+        outlineFilter.Draw(maskTarget, size, size);
+        var outlinePixels = new Color[size * size];
+        outlineFilter.GetOutlineTarget().GetData(outlinePixels);
+
+        Assert.That(
+            CountPixels(
+                outlinePixels,
+                size,
+                8,
+                56,
+                8,
+                56,
+                IsOrange),
+            Is.EqualTo(0),
+            "The ground grid must not cut orange lines into selected geometry.");
+    }
+
+    [Test]
     public void Render3DObjects_ActiveEditElementsUseThirdVisualLayer()
     {
         const int size = 64;

--- a/GameWorld/View3D/Components/GridComponent.cs
+++ b/GameWorld/View3D/Components/GridComponent.cs
@@ -127,10 +127,10 @@ namespace GameWorld.Core.Components
             _quadVertices[2] = new VertexPositionTexture(new Vector3(cx - halfSize, 0, cz - halfSize), Vector2.Zero);
             _quadVertices[3] = new VertexPositionTexture(new Vector3(cx + halfSize, 0, cz - halfSize), Vector2.Zero);
 
-            // Set render state: no backface culling (visible from both sides), alpha blending, depth test
+            // Keep the grid from clipping geometry rendered after it.
             device.RasterizerState = RasterizerState.CullNone;
             device.BlendState = BlendState.AlphaBlend;
-            device.DepthStencilState = DepthStencilState.Default;
+            device.DepthStencilState = DepthStencilState.DepthRead;
 
             // Set shader parameters
             _worldParam.SetValue(Matrix.Identity);

--- a/GameWorld/View3D/Utility/ImageLoader.cs
+++ b/GameWorld/View3D/Utility/ImageLoader.cs
@@ -37,7 +37,10 @@ namespace GameWorld.Core.Utility
             }
             else
             {
-                var imageFile = packFileService.FindFile(fileName);
+                var imageFile = TexturePathResolver.FindTextureFile(
+                    packFileService,
+                    fileName,
+                    out _);
                 if (imageFile == null)
                     return null;
                 var imageContent = imageFile.DataSource.ReadData();

--- a/GameWorld/View3D/Utility/TexturePathResolver.cs
+++ b/GameWorld/View3D/Utility/TexturePathResolver.cs
@@ -1,0 +1,43 @@
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+
+namespace GameWorld.Core.Utility
+{
+    public static class TexturePathResolver
+    {
+        private static readonly IReadOnlyDictionary<string, string> KnownAliases =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                {
+                    @"rigidmodels\buildings\textures\flatnormal.dds",
+                    @"commontextures\flatnormal.dds"
+                },
+                {
+                    @"rigidmodels\buildings\textures\test_black.dds",
+                    @"commontextures\test_black.dds"
+                },
+            };
+
+        public static PackFile? FindTextureFile(
+            IPackFileService packFileService,
+            string path,
+            out string resolvedPath)
+        {
+            resolvedPath = path;
+            var exactFile = packFileService.FindFile(path);
+            if (exactFile != null)
+                return exactFile;
+
+            var normalizedPath = path.Replace('/', '\\');
+            if (!KnownAliases.TryGetValue(normalizedPath, out var aliasPath))
+                return null;
+
+            var aliasFile = packFileService.FindFile(aliasPath);
+            if (aliasFile == null)
+                return null;
+
+            resolvedPath = aliasPath;
+            return aliasFile;
+        }
+    }
+}

--- a/GameWorld/View3D/Utility/UserInterface/ShaderTextureViewModel.cs
+++ b/GameWorld/View3D/Utility/UserInterface/ShaderTextureViewModel.cs
@@ -42,8 +42,8 @@ namespace GameWorld.Core.Utility.UserInterface
             _resourceLibrary = resourceLibrary;
             _packFileUiProvider = packFileUiProvider;
             _propertyEditor = propertyEditor;
-            Path = _shaderTextureReference.TexturePath;
             _shouldRenderTexture = _shaderTextureReference.UseTexture;
+            Path = _shaderTextureReference.TexturePath;
         }
 
         partial void OnShouldRenderTextureChanged(bool value) 
@@ -56,6 +56,7 @@ namespace GameWorld.Core.Utility.UserInterface
                     value,
                     newValue => _shaderTextureReference.UseTexture = newValue,
                     newValue => ShouldRenderTexture = newValue);
+            ValidatePath();
         }
 
         partial void OnPathChanged(string value)
@@ -75,7 +76,15 @@ namespace GameWorld.Core.Utility.UserInterface
         void HandlePreviewTexture()
         {
             if (HasErrors == false)
-                _uiCommandFactory.Create<OpenEditorCommand>().ExecuteAsWindow(Path, 800, 900);
+            {
+                TexturePathResolver.FindTextureFile(
+                    _packFileService,
+                    Path,
+                    out var resolvedPath);
+                _uiCommandFactory
+                    .Create<OpenEditorCommand>()
+                    .ExecuteAsWindow(resolvedPath, 800, 900);
+            }
         }
 
         [RelayCommand]
@@ -109,16 +118,19 @@ namespace GameWorld.Core.Utility.UserInterface
         void ValidatePath()
         {
             _errorsByPropertyName[nameof(Path)] = new List<string>();
-            if (string.IsNullOrWhiteSpace(Path))
+            if (ShouldRenderTexture && string.IsNullOrWhiteSpace(Path))
             {
                 _errorsByPropertyName[nameof(Path)].Add(
                     GetText("Kitbash.Texture.PathRequired"));
             }
-            else
+            else if (ShouldRenderTexture)
             {
                 if (Path.Contains("test_mask.dds") == false)
                 {
-                    var isFileFound = _packFileService.FindFile(Path) != null;
+                    var isFileFound = TexturePathResolver.FindTextureFile(
+                        _packFileService,
+                        Path,
+                        out _) != null;
                     if (isFileFound == false)
                     {
                         _errorsByPropertyName[nameof(Path)].Add(

--- a/Testing/GameWorld.Core.Test/Rendering/Materials/CapabilityMaterialFactoryTests.cs
+++ b/Testing/GameWorld.Core.Test/Rendering/Materials/CapabilityMaterialFactoryTests.cs
@@ -1,5 +1,6 @@
 ﻿using GameWorld.Core.Rendering.Materials;
 using GameWorld.Core.Rendering.Materials.Capabilities;
+using GameWorld.Core.Rendering.Materials.Serialization;
 using GameWorld.Core.Test.TestUtility;
 using Shared.Core.Settings;
 using Shared.GameFormats.RigidModel;
@@ -75,6 +76,36 @@ namespace GameWorld.Core.Test.Rendering.Materials
                 Assert.That(
                     capability.NormalMap.TexturePath,
                     Is.EqualTo(@"rigidmodels\buildings\textures\building_normal.dds"));
+            });
+        }
+
+        [Test]
+        public void Create_FromLegacyDefaultRmv_Wh3_PreservesNormalPathForSerialization()
+        {
+            const string normalPath =
+                @"rigidmodels\buildings\textures\flatnormal.dds";
+            const string specularPath =
+                @"rigidmodels\buildings\textures\test_black.dds";
+            var rmvMaterial = RmvMaterialHelper.Create(ModelMaterialEnum.weighted);
+            rmvMaterial.SetTexture(TextureType.Normal, normalPath);
+            rmvMaterial.SetTexture(TextureType.Specular, specularPath);
+
+            var appSettings = new ApplicationSettingsService(GameTypeEnum.Warhammer3);
+            var materialFactory = new CapabilityMaterialFactory(appSettings, null);
+            var material = materialFactory.Create(rmvMaterial, null);
+            var capability = material.GetCapability<MetalRoughCapability>();
+
+            var serializedMaterial = new MaterialToRmvSerializer()
+                .CreateMaterialFromCapabilityMaterial(material);
+            var serializedNormal = serializedMaterial.GetTexture(TextureType.Normal);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(capability.NormalMap.TexturePath, Is.EqualTo(normalPath));
+                Assert.That(capability.NormalMap.UseTexture, Is.True);
+                Assert.That(capability.MaterialMap.UseTexture, Is.False);
+                Assert.That(serializedNormal, Is.Not.Null);
+                Assert.That(serializedNormal!.Value.Path, Is.EqualTo(normalPath));
             });
         }
 

--- a/Testing/GameWorld.Core.Test/Utility/TexturePathResolverTests.cs
+++ b/Testing/GameWorld.Core.Test/Utility/TexturePathResolverTests.cs
@@ -1,0 +1,123 @@
+using GameWorld.Core.Utility;
+using Moq;
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+
+namespace GameWorld.Core.Test.Utility
+{
+    internal class TexturePathResolverTests
+    {
+        [Test]
+        public void FindTextureFile_MissingLegacyFlatNormal_UsesCommonTexture()
+        {
+            const string legacyPath =
+                @"rigidmodels\buildings\textures\flatnormal.dds";
+            const string commonPath = @"commontextures\flatnormal.dds";
+            var commonTexture = PackFile.CreateFromBytes(
+                "flatnormal.dds",
+                [1, 2, 3]);
+            var packFileService = new Mock<IPackFileService>();
+            packFileService
+                .Setup(service => service.FindFile(legacyPath, null))
+                .Returns((PackFile)null);
+            packFileService
+                .Setup(service => service.FindFile(commonPath, null))
+                .Returns(commonTexture);
+
+            var result = TexturePathResolver.FindTextureFile(
+                packFileService.Object,
+                legacyPath,
+                out var resolvedPath);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.SameAs(commonTexture));
+                Assert.That(resolvedPath, Is.EqualTo(commonPath));
+            });
+        }
+
+        [Test]
+        public void FindTextureFile_ExactLegacyPathExists_PrefersExactFile()
+        {
+            const string legacyPath =
+                @"rigidmodels\buildings\textures\flatnormal.dds";
+            const string commonPath = @"commontextures\flatnormal.dds";
+            var exactTexture = PackFile.CreateFromBytes(
+                "flatnormal.dds",
+                [4, 5, 6]);
+            var packFileService = new Mock<IPackFileService>();
+            packFileService
+                .Setup(service => service.FindFile(legacyPath, null))
+                .Returns(exactTexture);
+
+            var result = TexturePathResolver.FindTextureFile(
+                packFileService.Object,
+                legacyPath,
+                out var resolvedPath);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.SameAs(exactTexture));
+                Assert.That(resolvedPath, Is.EqualTo(legacyPath));
+            });
+            packFileService.Verify(
+                service => service.FindFile(commonPath, null),
+                Times.Never);
+        }
+
+        [Test]
+        public void FindTextureFile_UnrelatedMissingPath_DoesNotTryAlias()
+        {
+            const string missingPath = @"rigidmodels\buildings\textures\missing.dds";
+            var packFileService = new Mock<IPackFileService>();
+            packFileService
+                .Setup(service => service.FindFile(missingPath, null))
+                .Returns((PackFile)null);
+
+            var result = TexturePathResolver.FindTextureFile(
+                packFileService.Object,
+                missingPath,
+                out var resolvedPath);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Null);
+                Assert.That(resolvedPath, Is.EqualTo(missingPath));
+            });
+            packFileService.Verify(
+                service => service.FindFile(
+                    It.Is<string>(path => path.StartsWith("commontextures")),
+                    null),
+                Times.Never);
+        }
+
+        [Test]
+        public void FindTextureFile_MissingLegacyTestBlack_UsesCommonTexture()
+        {
+            const string legacyPath =
+                @"RIGIDMODELS/BUILDINGS/TEXTURES/TEST_BLACK.DDS";
+            const string commonPath = @"commontextures\test_black.dds";
+            var commonTexture = PackFile.CreateFromBytes(
+                "test_black.dds",
+                [7, 8, 9]);
+            var packFileService = new Mock<IPackFileService>();
+            packFileService
+                .Setup(service => service.FindFile(legacyPath, null))
+                .Returns((PackFile)null);
+            packFileService
+                .Setup(service => service.FindFile(commonPath, null))
+                .Returns(commonTexture);
+
+            var result = TexturePathResolver.FindTextureFile(
+                packFileService.Object,
+                legacyPath,
+                out var resolvedPath);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.SameAs(commonTexture));
+                Assert.That(resolvedPath, Is.EqualTo(commonPath));
+            });
+        }
+    }
+}

--- a/Testing/GameWorld.Core.Test/Utility/UserInterface/ShaderTextureViewModelTests.cs
+++ b/Testing/GameWorld.Core.Test/Utility/UserInterface/ShaderTextureViewModelTests.cs
@@ -1,0 +1,80 @@
+using GameWorld.Core.Commands;
+using GameWorld.Core.Services;
+using GameWorld.Core.Utility.UserInterface;
+using Moq;
+using Shared.Core.Events;
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Services;
+using Shared.GameFormats.RigidModel.Types;
+
+namespace GameWorld.Core.Test.Utility.UserInterface
+{
+    internal class ShaderTextureViewModelTests
+    {
+        [Test]
+        public void DisabledTexture_DoesNotRequirePath_AndReenabledRestoresValidation()
+        {
+            var textureInput = new GameWorld.Core.Rendering.Materials.Capabilities.Utility.TextureInput(
+                TextureType.MaterialMap)
+            {
+                TexturePath = string.Empty,
+                UseTexture = false,
+            };
+            var viewModel = new ShaderTextureViewModel(
+                textureInput,
+                Mock.Of<IPackFileService>(),
+                Mock.Of<IUiCommandFactory>(),
+                Mock.Of<IScopedResourceLibrary>(),
+                Mock.Of<IStandardDialogs>());
+
+            Assert.That(viewModel.HasErrors, Is.False);
+
+            viewModel.ShouldRenderTexture = true;
+
+            Assert.That(viewModel.HasErrors, Is.True);
+
+            viewModel.ShouldRenderTexture = false;
+
+            Assert.That(viewModel.HasErrors, Is.False);
+        }
+
+        [Test]
+        public void LegacyDefaultTexture_WithCommonAlias_IsValidWithoutChangingPath()
+        {
+            const string legacyPath =
+                @"rigidmodels\buildings\textures\flatnormal.dds";
+            const string commonPath = @"commontextures\flatnormal.dds";
+            var textureInput = new GameWorld.Core.Rendering.Materials.Capabilities.Utility.TextureInput(
+                TextureType.Normal)
+            {
+                TexturePath = legacyPath,
+                UseTexture = true,
+            };
+            var commonTexture = PackFile.CreateFromBytes(
+                "flatnormal.dds",
+                [1, 2, 3]);
+            var packFileService = new Mock<IPackFileService>();
+            packFileService
+                .Setup(service => service.FindFile(legacyPath, null))
+                .Returns((PackFile)null);
+            packFileService
+                .Setup(service => service.FindFile(commonPath, null))
+                .Returns(commonTexture);
+
+            var viewModel = new ShaderTextureViewModel(
+                textureInput,
+                packFileService.Object,
+                Mock.Of<IUiCommandFactory>(),
+                Mock.Of<IScopedResourceLibrary>(),
+                Mock.Of<IStandardDialogs>());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(viewModel.HasErrors, Is.False);
+                Assert.That(viewModel.Path, Is.EqualTo(legacyPath));
+                Assert.That(textureInput.TexturePath, Is.EqualTo(legacyPath));
+            });
+        }
+    }
+}


### PR DESCRIPTION
Summary: resolve legacy rigid-model default texture aliases without rewriting stored material paths; keep disabled texture slots valid; prevent the ground grid depth pass from cutting orange lines into selected-model outlines. Validation: GameWorld.Core Release tests 432/432 passed; selection-outline and render-target tests 17/17 passed; grid, mask, and outline tests 9/9 passed; Release build completed with 0 warnings and 0 errors; git diff checks passed.