### PR TITLE
Fix tree expanders collapsing on first click

### DIFF
--- a/AssetEditor/Themes/DesignSystem/Controls/Collections.xaml
+++ b/AssetEditor/Themes/DesignSystem/Controls/Collections.xaml
@@ -93,6 +93,7 @@
                                         x:Name="Expander"
                                         Background="Transparent"
                                         BorderThickness="0"
+                                        ClickMode="Press"
                                         Focusable="False"
                                         IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
                                         <ToggleButton.Template>

--- a/Editors/Kitbashing/KitbasherEditor/KitbashUiStyles.xaml
+++ b/Editors/Kitbashing/KitbasherEditor/KitbashUiStyles.xaml
@@ -224,6 +224,7 @@
                                         x:Name="Expander"
                                         Background="Transparent"
                                         BorderThickness="0"
+                                        ClickMode="Press"
                                         Focusable="False"
                                         IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}">
                                         <ToggleButton.Template>

--- a/Testing/AssetEditorTests/AudioFilesExplorerInteractionTests.cs
+++ b/Testing/AssetEditorTests/AudioFilesExplorerInteractionTests.cs
@@ -1,0 +1,160 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Threading;
+using Editors.Audio.AudioEditor.Presentation.AudioFilesExplorer;
+using Editors.Audio.AudioEditor.Presentation.Shared.Controls;
+using Editors.Audio.AudioEditor.Presentation.Shared.Models;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Shared.Core.Services;
+
+using Assert = NUnit.Framework.Assert;
+
+namespace AssetEditorTests;
+
+[NonParallelizable]
+public class AudioFilesExplorerInteractionTests
+{
+    [SetUp]
+    public void SetUp() => new LocalizationManager().LoadLanguage();
+
+    [Test]
+    public void AudioFilesTreeExpander_CollapsesOnFirstMousePress_WhenChildRemainsSelected()
+    {
+        using var services = new ServiceCollection()
+            .AddSingleton(LocalizationManager.Instance)
+            .BuildServiceProvider();
+        WpfTestApplicationHost.InvokeWithThemeResources(services, () =>
+        {
+            var directory = AudioFilesTreeNode.CreateContainerNode(
+                "audio",
+                AudioFilesTreeNodeType.Directory);
+            var editedFile = AudioFilesTreeNode.CreateChildNode(
+                "edited.wav",
+                AudioFilesTreeNodeType.WavFile,
+                directory);
+            directory.Children.Add(editedFile);
+            directory.IsExpanded = true;
+            var model = new AudioFilesExplorerTestModel
+            {
+                AudioFilesTree = [directory],
+                SelectedTreeNodes = [editedFile],
+            };
+            var view = new AudioFilesExplorerView
+            {
+                DataContext = model,
+                Width = 500,
+                Height = 300,
+            };
+            var window = new Window
+            {
+                Content = view,
+                Width = 520,
+                Height = 320,
+                ShowActivated = false,
+                ShowInTaskbar = false,
+                WindowStyle = WindowStyle.None,
+                Left = -10000,
+                Top = -10000,
+            };
+
+            try
+            {
+                window.Show();
+                window.UpdateLayout();
+                var tree = (MultiSelectTreeView)view.FindName(
+                    "AudioFilesTreeView");
+                var directoryItem = FindTreeViewItem(tree, directory);
+                var editedFileItem = FindTreeViewItem(tree, editedFile);
+                editedFileItem.IsSelected = true;
+                directoryItem.BringIntoView();
+                FlushBindings(view);
+                Assert.That(editedFileItem.IsSelected, Is.True);
+
+                var expander = directoryItem.Template.FindName(
+                    "Expander",
+                    directoryItem) as ToggleButton;
+                Assert.That(expander, Is.Not.Null);
+
+                expander!.RaiseEvent(new MouseButtonEventArgs(
+                    Mouse.PrimaryDevice,
+                    Environment.TickCount,
+                    MouseButton.Left)
+                {
+                    RoutedEvent = Mouse.MouseDownEvent,
+                    Source = expander,
+                });
+                FlushBindings(view);
+
+                Assert.That(directory.IsExpanded, Is.False);
+            }
+            finally
+            {
+                window.Close();
+            }
+        });
+    }
+
+    private static TreeViewItem FindTreeViewItem(
+        ItemsControl parent,
+        AudioFilesTreeNode target)
+    {
+        var item = TryFindTreeViewItem(parent, target);
+        Assert.That(item, Is.Not.Null, target.FileName);
+        return item!;
+    }
+
+    private static TreeViewItem? TryFindTreeViewItem(
+        ItemsControl parent,
+        AudioFilesTreeNode target)
+    {
+        parent.ApplyTemplate();
+        parent.UpdateLayout();
+        foreach (var node in parent.Items.OfType<AudioFilesTreeNode>())
+        {
+            var item = parent.ItemContainerGenerator.ContainerFromItem(node)
+                as TreeViewItem;
+            if (item == null)
+                continue;
+            if (ReferenceEquals(node, target))
+                return item;
+
+            item.IsExpanded = true;
+            item.ApplyTemplate();
+            item.UpdateLayout();
+            var child = TryFindTreeViewItem(item, target);
+            if (child != null)
+                return child;
+        }
+
+        return null;
+    }
+
+    private static void FlushBindings(FrameworkElement view)
+    {
+        view.Dispatcher.Invoke(
+            () => { },
+            DispatcherPriority.DataBind);
+        view.UpdateLayout();
+    }
+
+    private sealed class AudioFilesExplorerTestModel
+    {
+        public string AudioFilesExplorerLabel { get; } = "Audio files";
+
+        public ObservableCollection<AudioFilesTreeNode> AudioFilesTree
+        {
+            get;
+            init;
+        } = [];
+
+        public ObservableCollection<AudioFilesTreeNode> SelectedTreeNodes
+        {
+            get;
+            init;
+        } = [];
+    }
+}

--- a/Testing/AssetEditorTests/UiCommonControlResourceTests.cs
+++ b/Testing/AssetEditorTests/UiCommonControlResourceTests.cs
@@ -3,6 +3,7 @@ using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
@@ -199,6 +200,34 @@ public class UiCommonControlResourceTests
                 {
                     window.Close();
                 }
+            });
+    }
+
+    [Test]
+    public void TreeChevron_CollapsesOnFirstMousePress_WhenChildRemainsSelected()
+    {
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () => AssertTreeChevronCollapsesOnFirstMousePress(
+                (Style)Application.Current.FindResource("AeTree.Item"),
+                "audio",
+                "edited.wav"));
+    }
+
+    [Test]
+    public void KitbashSceneTreeChevron_CollapsesOnFirstMousePress_WhenChildRemainsSelected()
+    {
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () =>
+            {
+                var dictionary = Load(
+                    "Editors.KitbasherEditor",
+                    "KitbashUiStyles.xaml");
+                AssertTreeChevronCollapsesOnFirstMousePress(
+                    (Style)dictionary["Kitbash.SceneTreeItem"],
+                    "scene",
+                    "edited model");
             });
     }
 
@@ -1335,6 +1364,60 @@ public class UiCommonControlResourceTests
         Source = new Uri(
             $"pack://application:,,,/{assemblyName};component/{path}"),
     };
+
+    private static void AssertTreeChevronCollapsesOnFirstMousePress(
+        Style style,
+        string directoryHeader,
+        string childHeader)
+    {
+        var child = new TreeViewItem
+        {
+            Header = childHeader,
+            IsSelected = true,
+            Style = style,
+        };
+        var directory = new TreeViewItem
+        {
+            Header = directoryHeader,
+            IsExpanded = true,
+            Style = style,
+            Items = { child },
+        };
+        var window = new Window
+        {
+            Content = directory,
+            ShowActivated = false,
+            ShowInTaskbar = false,
+        };
+
+        try
+        {
+            window.Show();
+            directory.ApplyTemplate();
+            var expander = directory.Template.FindName(
+                "Expander",
+                directory) as ToggleButton;
+            NUnitAssert.That(expander, Is.Not.Null);
+
+            expander!.RaiseEvent(new MouseButtonEventArgs(
+                Mouse.PrimaryDevice,
+                Environment.TickCount,
+                MouseButton.Left)
+            {
+                RoutedEvent = Mouse.MouseDownEvent,
+                Source = expander,
+            });
+            directory.Dispatcher.Invoke(
+                () => { },
+                DispatcherPriority.DataBind);
+
+            NUnitAssert.That(directory.IsExpanded, Is.False);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
 
     private static string FindSolutionRoot()
     {


### PR DESCRIPTION
## 修改摘要
- 让公共 `AeTree.Item` 树节点箭头在鼠标按下时立即展开或收起，避免第一次点击恢复已选中的子文件
- 对 Kitbash 场景树的独立模板应用相同行为
- 添加公共树、Kitbash 场景树和真实 `AudioFilesExplorerView` 的首次点击回归测试

## 验证
- `dotnet restore AssetEditor.CN.sln`：通过
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore`：通过，0 个错误（78 个既有警告）
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal`：通过；主测试项目 1223/1223，通过全部含测试项目
- `git diff --check`：通过

## 验收边界
- 用户随后取消了实际 AE 界面控制验收，因此未把手工 UI 操作计为通过；自动化测试已覆盖音频浏览器中“子文件保持选中时，父文件夹箭头第一次按下立即收起”的原始症状