### PR TITLE
feat(animation): add unified time and format capability contracts

### DIFF
--- a/Shared/GameFiles/Animation/AnimationFormatCapabilities.cs
+++ b/Shared/GameFiles/Animation/AnimationFormatCapabilities.cs
@@ -1,0 +1,57 @@
+﻿namespace Shared.GameFormats.Animation
+{
+    public enum AnimationFormatBlockReason
+    {
+        UnsupportedVersion,
+        VersionEightIsReadOnly,
+        MultiplePartsAreReadOnly,
+    }
+
+    public sealed class AnimationFormatCapabilities
+    {
+        private AnimationFormatCapabilities(
+            bool canRead,
+            bool canEdit,
+            bool canSave,
+            IReadOnlyList<AnimationFormatBlockReason> blockingReasons)
+        {
+            CanRead = canRead;
+            CanEdit = canEdit;
+            CanSave = canSave;
+            BlockingReasons = Array.AsReadOnly(blockingReasons.ToArray());
+        }
+
+        public bool CanRead { get; }
+
+        public bool CanEdit { get; }
+
+        public bool CanSave { get; }
+
+        public IReadOnlyList<AnimationFormatBlockReason> BlockingReasons { get; }
+
+        public static AnimationFormatCapabilities Evaluate(uint version, int partCount)
+        {
+            if (version is < 4 or > 8)
+            {
+                return new AnimationFormatCapabilities(
+                    canRead: false,
+                    canEdit: false,
+                    canSave: false,
+                    [AnimationFormatBlockReason.UnsupportedVersion]);
+            }
+
+            var blockingReasons = new List<AnimationFormatBlockReason>();
+            if (version == 8)
+                blockingReasons.Add(AnimationFormatBlockReason.VersionEightIsReadOnly);
+            if (partCount != 1)
+                blockingReasons.Add(AnimationFormatBlockReason.MultiplePartsAreReadOnly);
+
+            var canEditAndSave = blockingReasons.Count == 0;
+            return new AnimationFormatCapabilities(
+                canRead: true,
+                canEdit: canEditAndSave,
+                canSave: canEditAndSave,
+                blockingReasons);
+        }
+    }
+}

--- a/Shared/GameFiles/Animation/AnimationTimebase.cs
+++ b/Shared/GameFiles/Animation/AnimationTimebase.cs
@@ -1,0 +1,31 @@
+﻿namespace Shared.GameFormats.Animation
+{
+    public sealed class AnimationTimebase
+    {
+        public AnimationTimebase(int frameCount, TimeSpan duration)
+        {
+            if (frameCount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(frameCount));
+            if (duration <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(duration));
+
+            FrameCount = frameCount;
+            Duration = duration;
+        }
+
+        public int FrameCount { get; }
+
+        public TimeSpan Duration { get; }
+
+        public double FramesPerSecond => FrameCount / Duration.TotalSeconds;
+
+        public TimeSpan GetSampleTime(int frameIndex)
+        {
+            if (frameIndex < 0 || frameIndex >= FrameCount)
+                throw new ArgumentOutOfRangeException(nameof(frameIndex));
+
+            var sampleTicks = (long)((decimal)Duration.Ticks * frameIndex / FrameCount);
+            return TimeSpan.FromTicks(sampleTicks);
+        }
+    }
+}

--- a/Testing/GameWorld.Core.Test/Animation/AnimationFormatCapabilitiesTests.cs
+++ b/Testing/GameWorld.Core.Test/Animation/AnimationFormatCapabilitiesTests.cs
@@ -1,0 +1,86 @@
+﻿using Shared.GameFormats.Animation;
+
+namespace Testing.GameWorld.Core.Animation;
+
+[TestFixture]
+internal class AnimationFormatCapabilitiesTests
+{
+    [TestCase(4u)]
+    [TestCase(5u)]
+    [TestCase(6u)]
+    [TestCase(7u)]
+    public void Evaluate_SupportedSinglePartFormat_AllowsReadEditAndSave(uint version)
+    {
+        var capabilities = AnimationFormatCapabilities.Evaluate(version, partCount: 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(capabilities.CanRead, Is.True);
+            Assert.That(capabilities.CanEdit, Is.True);
+            Assert.That(capabilities.CanSave, Is.True);
+            Assert.That(capabilities.BlockingReasons, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void Evaluate_VersionEight_IsReadableButReadOnly()
+    {
+        var capabilities = AnimationFormatCapabilities.Evaluate(version: 8, partCount: 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(capabilities.CanRead, Is.True);
+            Assert.That(capabilities.CanEdit, Is.False);
+            Assert.That(capabilities.CanSave, Is.False);
+            Assert.That(
+                capabilities.BlockingReasons,
+                Is.EqualTo(new[] { AnimationFormatBlockReason.VersionEightIsReadOnly }));
+        });
+    }
+
+    [Test]
+    public void Evaluate_MultipleParts_AreReadableButReadOnly()
+    {
+        var capabilities = AnimationFormatCapabilities.Evaluate(version: 7, partCount: 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(capabilities.CanRead, Is.True);
+            Assert.That(capabilities.CanEdit, Is.False);
+            Assert.That(capabilities.CanSave, Is.False);
+            Assert.That(
+                capabilities.BlockingReasons,
+                Is.EqualTo(new[] { AnimationFormatBlockReason.MultiplePartsAreReadOnly }));
+        });
+    }
+
+    [Test]
+    public void Evaluate_UnsupportedVersion_RejectsAllCapabilities()
+    {
+        var capabilities = AnimationFormatCapabilities.Evaluate(version: 9, partCount: 1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(capabilities.CanRead, Is.False);
+            Assert.That(capabilities.CanEdit, Is.False);
+            Assert.That(capabilities.CanSave, Is.False);
+            Assert.That(
+                capabilities.BlockingReasons,
+                Is.EqualTo(new[] { AnimationFormatBlockReason.UnsupportedVersion }));
+        });
+    }
+
+    [Test]
+    public void Evaluate_VersionEightWithMultipleParts_ReportsBothReadOnlyReasons()
+    {
+        var capabilities = AnimationFormatCapabilities.Evaluate(version: 8, partCount: 2);
+
+        Assert.That(
+            capabilities.BlockingReasons,
+            Is.EqualTo(new[]
+            {
+                AnimationFormatBlockReason.VersionEightIsReadOnly,
+                AnimationFormatBlockReason.MultiplePartsAreReadOnly,
+            }));
+    }
+}

--- a/Testing/GameWorld.Core.Test/Animation/AnimationTimebaseTests.cs
+++ b/Testing/GameWorld.Core.Test/Animation/AnimationTimebaseTests.cs
@@ -1,0 +1,50 @@
+﻿using Shared.GameFormats.Animation;
+
+namespace Testing.GameWorld.Core.Animation;
+
+[TestFixture]
+internal class AnimationTimebaseTests
+{
+    [Test]
+    public void FrameSamples_UseHalfOpenAnimationTime()
+    {
+        var timebase = new AnimationTimebase(
+            frameCount: 5,
+            duration: TimeSpan.FromMilliseconds(250));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(timebase.FramesPerSecond, Is.EqualTo(20).Within(0.000001));
+            Assert.That(timebase.GetSampleTime(0), Is.EqualTo(TimeSpan.Zero));
+            Assert.That(timebase.GetSampleTime(1), Is.EqualTo(TimeSpan.FromMilliseconds(50)));
+            Assert.That(timebase.GetSampleTime(4), Is.EqualTo(TimeSpan.FromMilliseconds(200)));
+            Assert.That(timebase.GetSampleTime(4), Is.LessThan(timebase.Duration));
+        });
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void Constructor_RejectsNonPositiveFrameCount(int frameCount)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new AnimationTimebase(frameCount, TimeSpan.FromSeconds(1)));
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void Constructor_RejectsNonPositiveDuration(int durationTicks)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new AnimationTimebase(1, TimeSpan.FromTicks(durationTicks)));
+    }
+
+    [TestCase(-1)]
+    [TestCase(5)]
+    public void GetSampleTime_RejectsIndexOutsideHalfOpenFrameRange(int frameIndex)
+    {
+        var timebase = new AnimationTimebase(5, TimeSpan.FromSeconds(1));
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => timebase.GetSampleTime(frameIndex));
+    }
+}


### PR DESCRIPTION
## 变更摘要

- 新增统一动画时间契约，采用半开区间 [0,T)
- 从帧数和时长统一计算帧率与采样时刻
- 分离动画格式的可读、可编辑、可保存能力及稳定阻止原因
- 保持现有动画读取、播放和保存调用路径不变

## 验证

- 新增公开契约测试：15/15 通过
- 既有动画核心回归：22/22 通过
- 既有保存与创建回归：18/18 通过
- dotnet restore AssetEditor.CN.sln
- dotnet build AssetEditor.CN.sln --configuration Release --no-restore（0 错误）
- dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal（退出码 0）
- Standards/Spec 双轴审查：0 项问题

Closes #137