### PR TITLE
fix(animation): unify core timebase semantics

### DIFF
--- a/GameWorld/View3D/Animation/AnimationClip.cs
+++ b/GameWorld/View3D/Animation/AnimationClip.cs
@@ -48,6 +48,19 @@ namespace GameWorld.Core.Animation
 
         public long PlayTimeUs => _playTimeUs;
 
+        public AnimationTimebase? Timebase
+        {
+            get
+            {
+                if (DynamicFrames.Count == 0 || _playTimeUs <= 0)
+                    return null;
+
+                return new AnimationTimebase(
+                    DynamicFrames.Count,
+                    TimeSpan.FromTicks(_playTimeUs * TimeSpan.TicksPerMicrosecond));
+            }
+        }
+
         public long MicrosecondsPerFrame
         {
             get
@@ -63,18 +76,7 @@ namespace GameWorld.Core.Animation
         public float PlayTimeInSec
         {
             get => (float)_playTimeUs / MicrosecondsPerSecond;
-            set
-            {
-                if (DynamicFrames.Count == 0)
-                {
-                    _playTimeUs = (long)(value * MicrosecondsPerSecond);
-                    return;
-                }
-
-                // make sure we have whole number of microsecond per frame
-                var framePlayTimeUs = (long)Math.Ceiling(value / DynamicFrames.Count * MicrosecondsPerSecond);
-                _playTimeUs = framePlayTimeUs * DynamicFrames.Count;
-            }
+            set => _playTimeUs = (long)Math.Round(value * MicrosecondsPerSecond);
         }
 
         public int AnimationBoneCount
@@ -154,10 +156,7 @@ namespace GameWorld.Core.Animation
         {
             var output = new AnimationFile();
 
-            var fRate = (DynamicFrames.Count() - 1) / PlayTimeInSec;
-            output.Header.FrameRate = (float)Math.Round(fRate);
-            if (output.Header.FrameRate <= 0)
-                output.Header.FrameRate = 20;
+            output.Header.FrameRate = (float)(Timebase?.FramesPerSecond ?? 20);
 
             output.Header.Version = 7;
             output.Header.AnimationTotalPlayTimeInSec = PlayTimeInSec;

--- a/GameWorld/View3D/Animation/AnimationEditor.cs
+++ b/GameWorld/View3D/Animation/AnimationEditor.cs
@@ -91,13 +91,19 @@ namespace GameWorld.Core.Animation
 
         public static AnimationClip ReSample(GameSkeleton skeleton, AnimationClip newAnim, int newFrameCount, float playTime)
         {
+            if (newFrameCount < 0)
+                throw new ArgumentOutOfRangeException(nameof(newFrameCount));
+
             var output = newAnim.Clone();
             output.DynamicFrames.Clear();
+            output.PlayTimeInSec = playTime;
 
-            var fraction = 1.0f / (newFrameCount - 1);
+            if (newFrameCount == 0 || newAnim.Timebase == null)
+                return output;
+
             for (var i = 0; i < newFrameCount; i++)
             {
-                var t = i * fraction;
+                var t = (float)i / newFrameCount;
                 var keyframe = AnimationSampler.Sample(t, skeleton, newAnim);
 
                 var newKeyFrame = new KeyFrame();
@@ -113,8 +119,6 @@ namespace GameWorld.Core.Animation
 
                 output.DynamicFrames.Add(newKeyFrame);
             }
-
-            output.PlayTimeInSec = playTime;// (output.DynamicFrames.Count() - 1) / 20.0f;
 
             return output;
         }

--- a/GameWorld/View3D/Animation/AnimationPlayer.cs
+++ b/GameWorld/View3D/Animation/AnimationPlayer.cs
@@ -73,20 +73,24 @@ namespace GameWorld.Core.Animation
 
         public List<IAnimationChangeRule> AnimationRules { get; set; } = new List<IAnimationChangeRule>();
 
-        private int TimeUsToFrame(long timeUs)
+        private int TimeToFrame(TimeSpan time)
         {
-            var frame = (int)(timeUs / _animationClip.MicrosecondsPerFrame);
-            return MathUtil.EnsureRange(frame, 0, FrameCount() - 1);
+            var timebase = _animationClip?.Timebase;
+            if (timebase == null)
+                return 0;
+
+            return (int)Math.Floor(timebase.GetSamplePosition(time));
         }
 
-        private long FrameToStartTimeUs(int frame)
+        private TimeSpan FrameToStartTime(int frame)
         {
-            return _animationClip.MicrosecondsPerFrame <= 0 ? 0 : MathUtil.EnsureRange(_animationClip.MicrosecondsPerFrame * frame, 0L, GetAnimationLengthUs() - _animationClip.MicrosecondsPerFrame);
+            var timebase = _animationClip?.Timebase;
+            return timebase == null ? TimeSpan.Zero : timebase.GetSampleTime(frame);
         }
 
         public int CurrentFrame
         {
-            get => _animationClip == null ? 0 : TimeUsToFrame(_timeSinceStart.TotalMicrosecondsAsLong);
+            get => _animationClip == null ? 0 : TimeToFrame(_timeSinceStart.TimeSpan);
             set
             {
                 if (CurrentFrame == value)
@@ -95,8 +99,7 @@ namespace GameWorld.Core.Animation
                 if (_animationClip != null)
                 {
                     var frameIndex = MathUtil.EnsureRange(value, 0, FrameCount() - 1);
-                    var timeInUs = FrameToStartTimeUs(frameIndex);
-                    _timeSinceStart = TimeSpanExtension.FromMicroseconds(timeInUs);
+                    _timeSinceStart = new TimeSpanExtension(FrameToStartTime(frameIndex));
                     OnFrameChanged?.Invoke(CurrentFrame);
                 }
                 else
@@ -170,9 +173,9 @@ namespace GameWorld.Core.Animation
                 }
                 //Fix this so if crash no break
                 float sampleT = 0;
-                var animationLengthUs = GetAnimationLengthUs();
-                if (animationLengthUs != 0)
-                    sampleT = (float)_timeSinceStart.TotalMicrosecondsAsLong / animationLengthUs;
+                var timebase = _animationClip?.Timebase;
+                if (timebase != null)
+                    sampleT = (float)(_timeSinceStart.TimeSpan.TotalSeconds / timebase.Duration.TotalSeconds);
                 _currentAnimFrame = AnimationSampler.Sample(sampleT, _skeleton, _animationClip, AnimationRules, !IsPlaying);
                 _skeleton?.Update();
             }
@@ -212,13 +215,9 @@ namespace GameWorld.Core.Animation
             _skeleton?.Update();
         }
 
-        public int GetFps()
-        {
-            if (_animationClip == null)
-                return 0;
-            var fps = _animationClip.DynamicFrames.Count / _animationClip.PlayTimeInSec;
-            return (int)fps;
-        }
+        public double FramesPerSecond => _animationClip?.Timebase?.FramesPerSecond ?? 0;
+
+        public int GetFps() => (int)FramesPerSecond;
 
         /// <summary>
         /// Overrides the sampled frame until the next refresh.

--- a/GameWorld/View3D/Animation/AnimationSampler.cs
+++ b/GameWorld/View3D/Animation/AnimationSampler.cs
@@ -165,14 +165,15 @@ namespace GameWorld.Core.Animation
 
                 if (animationClip != null)
                 {
-                    var maxFrames = animationClip.DynamicFrames.Count() - 1;
-                    if (maxFrames < 0)
-                        maxFrames = 0;
-                    var frameWithLeftover = maxFrames * clampedT;
-                    var clampedFrame = (float)Math.Round(frameWithLeftover);
-
-                    frameIndex = (int)clampedFrame;
-                    frameIterpolation = frameWithLeftover - clampedFrame;
+                    var timebase = animationClip.Timebase;
+                    if (timebase != null)
+                    {
+                        var playheadTime = TimeSpan.FromTicks(
+                            (long)(timebase.Duration.Ticks * (double)clampedT));
+                        var samplePosition = timebase.GetSamplePosition(playheadTime);
+                        frameIndex = (int)Math.Floor(samplePosition);
+                        frameIterpolation = (float)(samplePosition - frameIndex);
+                    }
                 }
                 var currentTimeSeconds = animationClip == null ? 0 : clampedT * animationClip.PlayTimeInSec;
                 return Sample(frameIndex, frameIterpolation, skeleton, animationClip, animationChangeRules, freezeFrame, currentTimeSeconds);
@@ -187,12 +188,13 @@ namespace GameWorld.Core.Animation
 
         private static float GetFrameTimeSeconds(float frame, AnimationClip animationClip)
         {
-            if (animationClip == null || animationClip.DynamicFrames.Count <= 1)
+            var timebase = animationClip?.Timebase;
+            if (timebase == null)
                 return 0;
 
-            var lastFrame = animationClip.DynamicFrames.Count - 1;
+            var lastFrame = timebase.FrameCount - 1;
             var clampedFrame = MathUtil.EnsureRange(frame, 0, lastFrame);
-            return clampedFrame / lastFrame * animationClip.PlayTimeInSec;
+            return (float)timebase.GetSampleTime(clampedFrame).TotalSeconds;
         }
 
         static AnimationClip.KeyFrame GetKeyFrameFromIndex(List<AnimationClip.KeyFrame> keyframes, int frameIndex)

--- a/Shared/GameFiles/Animation/AnimationTimebase.cs
+++ b/Shared/GameFiles/Animation/AnimationTimebase.cs
@@ -24,8 +24,48 @@
             if (frameIndex < 0 || frameIndex >= FrameCount)
                 throw new ArgumentOutOfRangeException(nameof(frameIndex));
 
-            var sampleTicks = (long)((decimal)Duration.Ticks * frameIndex / FrameCount);
+            return GetSampleTime((double)frameIndex);
+        }
+
+        public TimeSpan GetSampleTime(double samplePosition)
+        {
+            if (double.IsFinite(samplePosition) == false ||
+                samplePosition < 0 ||
+                samplePosition >= FrameCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(samplePosition));
+            }
+
+            var sampleTicks = (long)((decimal)Duration.Ticks * (decimal)samplePosition / FrameCount);
             return TimeSpan.FromTicks(sampleTicks);
+        }
+
+        public double GetSamplePosition(TimeSpan playheadTime)
+        {
+            if (playheadTime < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(playheadTime));
+            if (FrameCount == 1)
+                return 0;
+            if (playheadTime >= Duration)
+                return FrameCount - 1;
+
+            var frameIndexUpperBoundExclusive =
+                (decimal)(playheadTime.Ticks + 1) * FrameCount / Duration.Ticks;
+            var frameIndex = Math.Clamp(
+                (int)Math.Ceiling(frameIndexUpperBoundExclusive) - 1,
+                0,
+                FrameCount - 1);
+            if (frameIndex == FrameCount - 1)
+                return frameIndex;
+
+            var frameStartTicks = GetSampleTime(frameIndex).Ticks;
+            var nextFrameStartTicks = GetSampleTime(frameIndex + 1).Ticks;
+            if (nextFrameStartTicks == frameStartTicks)
+                return frameIndex;
+
+            return frameIndex +
+                (double)(playheadTime.Ticks - frameStartTicks) /
+                (nextFrameStartTicks - frameStartTicks);
         }
     }
 }

--- a/Testing/GameWorld.Core.Test/Animation/AnimationCoreTimeContractTests.cs
+++ b/Testing/GameWorld.Core.Test/Animation/AnimationCoreTimeContractTests.cs
@@ -1,0 +1,227 @@
+using GameWorld.Core.Animation;
+using Microsoft.Xna.Framework;
+using Shared.ByteParsing;
+using Shared.GameFormats.Animation;
+using Shared.GameFormats.RigidModel.Transforms;
+
+namespace Testing.GameWorld.Core.Animation;
+
+[TestFixture]
+internal class AnimationCoreTimeContractTests
+{
+    [Test]
+    public void Clip_NonIntegerFrameRate_UsesUnifiedTimebase()
+    {
+        var clip = CreateClip(frameCount: 7, durationSeconds: 0.3f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(clip.Timebase, Is.Not.Null);
+            Assert.That(clip.Timebase!.FrameCount, Is.EqualTo(7));
+            Assert.That(clip.Timebase.Duration, Is.EqualTo(TimeSpan.FromMilliseconds(300)));
+            Assert.That(clip.Timebase.FramesPerSecond, Is.EqualTo(70.0 / 3.0).Within(0.000001));
+            Assert.That(clip.Timebase.GetSampleTime(6), Is.LessThan(clip.Timebase.Duration));
+        });
+    }
+
+    [Test]
+    public void Player_AtDuration_UsesTimebaseForLoopAndStopFrames()
+    {
+        var player = new AnimationPlayer();
+        var skeleton = CreateSkeleton(player);
+        var clip = CreateClip(frameCount: 7, durationSeconds: 0.3f);
+        player.SetAnimation(clip, skeleton);
+        player.Play();
+
+        player.Update(new GameTime(
+            TimeSpan.FromSeconds(0.3),
+            TimeSpan.FromSeconds(0.3)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(player.FramesPerSecond, Is.EqualTo(70.0 / 3.0).Within(0.000001));
+            Assert.That(player.CurrentFrame, Is.Zero);
+            Assert.That(player.GetTimeUs(), Is.Zero);
+        });
+
+        player.LoopAnimation = false;
+        player.Play();
+        player.Update(new GameTime(
+            TimeSpan.FromSeconds(0.6),
+            TimeSpan.FromSeconds(0.3)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(player.CurrentFrame, Is.EqualTo(6));
+            Assert.That(player.GetTimeUs(), Is.EqualTo(300_000));
+            Assert.That(player.IsPlaying, Is.False);
+        });
+    }
+
+    [Test]
+    public void Player_SetFrameAtNonIntegerRate_RoundTripsFrameIndex()
+    {
+        var player = new AnimationPlayer();
+        var skeleton = CreateSkeleton(player);
+        var clip = CreateClip(frameCount: 7, durationSeconds: 0.3f);
+        player.SetAnimation(clip, skeleton);
+
+        player.CurrentFrame = 1;
+
+        Assert.That(player.CurrentFrame, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Sampler_NormalizedTime_UsesHalfOpenSamplePosition()
+    {
+        var player = new AnimationPlayer();
+        var skeleton = CreateSkeleton(player);
+        var clip = CreateClip(frameCount: 4, durationSeconds: 1);
+
+        var sampledFrame = AnimationSampler.Sample(0.25f, skeleton, clip);
+
+        Assert.That(
+            sampledFrame.BoneTransforms[0].Translation.X,
+            Is.EqualTo(1).Within(0.000001f));
+    }
+
+    [Test]
+    public void Resample_ToSingleFrame_UsesFirstSampleAndRequestedDuration()
+    {
+        var player = new AnimationPlayer();
+        var skeleton = CreateSkeleton(player);
+        var clip = CreateClip(frameCount: 4, durationSeconds: 1);
+
+        var result = global::GameWorld.Core.Animation.AnimationEditor.ReSample(
+            skeleton,
+            clip,
+            newFrameCount: 1,
+            playTime: 0.3f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.DynamicFrames, Has.Count.EqualTo(1));
+            Assert.That(result.DynamicFrames[0].Position[0].X, Is.Zero);
+            Assert.That(result.Timebase, Is.Not.Null);
+            Assert.That(result.Timebase!.Duration, Is.EqualTo(TimeSpan.FromMilliseconds(300)));
+            Assert.That(result.Timebase.FramesPerSecond, Is.EqualTo(10.0 / 3.0).Within(0.000001));
+            Assert.That(
+                result.Timebase.GetSamplePosition(TimeSpan.FromMilliseconds(150)),
+                Is.Zero);
+        });
+    }
+
+    [Test]
+    public void Resample_EmptySource_RemainsEmpty()
+    {
+        var player = new AnimationPlayer();
+        var skeleton = CreateSkeleton(player);
+        var clip = new AnimationClip { PlayTimeInSec = 1 };
+
+        var result = global::GameWorld.Core.Animation.AnimationEditor.ReSample(
+            skeleton,
+            clip,
+            newFrameCount: 4,
+            playTime: 0.3f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.DynamicFrames, Is.Empty);
+            Assert.That(result.PlayTimeInSec, Is.EqualTo(0.3f));
+            Assert.That(result.Timebase, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Resample_UsesHalfOpenTargetSampleTimes()
+    {
+        var player = new AnimationPlayer();
+        var skeleton = CreateSkeleton(player);
+        var clip = CreateClip(frameCount: 4, durationSeconds: 1);
+
+        var result = global::GameWorld.Core.Animation.AnimationEditor.ReSample(
+            skeleton,
+            clip,
+            newFrameCount: 4,
+            playTime: 1);
+
+        Assert.That(
+            result.DynamicFrames.Select(frame => frame.Position[0].X),
+            Is.EqualTo(new[] { 0, 1, 2, 3 }));
+    }
+
+    [Test]
+    public void AnimationFile_RoundTrip_PreservesUnifiedTimebase()
+    {
+        var player = new AnimationPlayer();
+        var skeleton = CreateSkeleton(player);
+        var clip = CreateClip(frameCount: 7, durationSeconds: 0.3f);
+
+        var animationFile = clip.ConvertToFileFormat(skeleton);
+        var bytes = AnimationFile.ConvertToBytes(animationFile);
+        var reloadedFile = AnimationFile.Create(new ByteChunk(bytes));
+        var reloadedClip = new AnimationClip(reloadedFile, skeleton);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(animationFile.Header.FrameRate, Is.EqualTo(70.0 / 3.0).Within(0.000001));
+            Assert.That(reloadedFile.Header.FrameRate, Is.EqualTo(animationFile.Header.FrameRate));
+            Assert.That(reloadedClip.Timebase, Is.Not.Null);
+            Assert.That(reloadedClip.Timebase!.FrameCount, Is.EqualTo(clip.Timebase!.FrameCount));
+            Assert.That(reloadedClip.Timebase.Duration, Is.EqualTo(clip.Timebase.Duration));
+            Assert.That(reloadedClip.Timebase.FramesPerSecond, Is.EqualTo(clip.Timebase.FramesPerSecond).Within(0.000001));
+            Assert.That(
+                Enumerable.Range(0, clip.Timebase.FrameCount)
+                    .Select(clip.Timebase.GetSampleTime),
+                Is.EqualTo(
+                    Enumerable.Range(0, reloadedClip.Timebase.FrameCount)
+                        .Select(reloadedClip.Timebase.GetSampleTime)));
+        });
+    }
+
+    private static AnimationClip CreateClip(int frameCount, float durationSeconds)
+    {
+        var clip = new AnimationClip();
+        for (var frameIndex = 0; frameIndex < frameCount; frameIndex++)
+        {
+            clip.DynamicFrames.Add(new AnimationClip.KeyFrame
+            {
+                Position = [new Vector3(frameIndex, 0, 0)],
+                Rotation = [Quaternion.Identity],
+                Scale = [Vector3.One],
+            });
+        }
+
+        clip.PlayTimeInSec = durationSeconds;
+        return clip;
+    }
+
+    private static GameSkeleton CreateSkeleton(AnimationPlayer player)
+    {
+        var animation = new AnimationFile
+        {
+            Header = new AnimationFile.AnimationHeader { SkeletonName = "test" },
+            Bones =
+            [
+                new AnimationFile.BoneInfo
+                {
+                    Id = 0,
+                    Name = "root",
+                    ParentId = -1,
+                },
+            ],
+        };
+
+        var frame = new AnimationFile.Frame();
+        frame.Transforms.Add(new RmvVector3());
+        frame.Quaternion.Add(new RmvVector4(0, 0, 0, 1));
+
+        var part = new AnimationFile.AnimationPart();
+        part.TranslationMappings.Add(new AnimationFile.AnimationBoneMapping(0));
+        part.RotationMappings.Add(new AnimationFile.AnimationBoneMapping(0));
+        part.DynamicFrames.Add(frame);
+        animation.AnimationParts.Add(part);
+
+        return GameSkeleton.CreateFromAnimationFile(animation, player);
+    }
+}


### PR DESCRIPTION
## 摘要

- 让动画片段、播放器、采样器和重采样统一使用 AnimationTimebase
- 明确空动画、单帧、循环末端和非整数帧率的行为
- 保证动画文件写入读取往返不会产生端点或帧率漂移

## 验证

- dotnet restore AssetEditor.CN.sln
- dotnet build AssetEditor.CN.sln --configuration Release --no-restore
- dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal（1223/1223 通过）
- 双轴代码审查：Standards 0 项，Spec 0 项

Closes #138