### PR TITLE
[动画工作台] 迁移调用方到统一时间契约

### DIFF
--- a/AssetEditor/Language_Cn.json
+++ b/AssetEditor/Language_Cn.json
@@ -751,6 +751,7 @@
   "GltfImporter.Error.MissingCaHumanoidSkeleton": "当前加载的原版 CA Pack 中找不到 animations\\skeletons\\humanoid01.anim，无法计算游戏标准人形尺寸。",
   "GltfImporter.Error.AutoScaleRequiresWarhammer3": "自动人形缩放当前只支持《全面战争：战锤3》。请选择战锤3，或关闭自动人形缩放。",
   "RmvToGltfExporter.Error.AnimationSkeletonMismatch": "动画“{0}”属于骨架“{1}”，与当前导出骨架“{2}”不一致，已停止导出。",
+  "RmvToGltfExporter.Error.InvalidAnimationDuration": "动画“{0}”的时长无效。",
   "GltfImporter.ScaleSkeleton.Source": "源骨架",
   "GltfImporter.ScaleAnchor.Head": "头部",
   "GltfImporter.ScaleAnchor.LeftFoot": "左脚",
@@ -905,6 +906,7 @@
   "AnimReTarget.Warning.SparseMapping.Title": "骨骼映射过少",
   "AnimReTarget.Warning.SparseMapping": "当前只映射了 1 根骨骼。继续重定向通常会导致身体大部分骨骼保持目标骨架原姿势。是否仍要继续？",
   "AnimReTarget.Error.EmptySourceAnimation": "源动画不包含任何帧，无法进行重定向。",
+  "AnimReTarget.Error.InvalidSourceDuration": "源动画时长必须大于 0。",
   "AnimReTarget.Error.SkeletonSelectionRequired": "请先选择源骨架和目标骨架。",
   "AnimReTarget.Error.GeneratedAnimationRequired": "尚未生成可保存的动画，请先应用设置。",
 

--- a/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationKeyframeEditorViewModel.cs
+++ b/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationKeyframeEditorViewModel.cs
@@ -280,7 +280,7 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
            // if (newValue != null)
            // {
            //     _originalClip = newValue.Clone();
-           //     FramesDurationInSeconds = _originalClip.PlayTimeInSec.ToString();
+           //     FramesDurationInSeconds = _originalClip.Duration.TotalSeconds.ToString();
            //     SetFrameLengthMax();
            // }
            //
@@ -529,8 +529,8 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
 
         public void ResetDuration()
         {
-            FramesDurationInSeconds = _originalClip.PlayTimeInSec.ToString();
-            _rider.AnimationClip.PlayTimeInSec = _originalClip.PlayTimeInSec;
+            FramesDurationInSeconds = _originalClip.Duration.TotalSeconds.ToString();
+            _rider.AnimationClip.Duration = _originalClip.Duration;
         }
 
 
@@ -540,11 +540,11 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
             if (!validSeconds)
             {
                 MessageBox.Show(LocalizationManager.Instance.Get("Msg.InvalidDecimalInput"), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButtons.OK, MessageBoxIcon.Error);
-                FramesDurationInSeconds = _rider.AnimationClip.PlayTimeInSec.ToString();
+                FramesDurationInSeconds = _rider.AnimationClip.Duration.TotalSeconds.ToString();
                 return;
             }
 
-            _rider.AnimationClip.PlayTimeInSec = seconds;
+            _rider.AnimationClip.Duration = TimeSpan.FromSeconds(seconds);
             IsDirty.Value = true;
         }
 

--- a/Editors/AnimationEditor/MountAnimationCreator/Services/MountAnimationGeneratorService.cs
+++ b/Editors/AnimationEditor/MountAnimationCreator/Services/MountAnimationGeneratorService.cs
@@ -48,7 +48,7 @@ namespace AnimationEditor.MountAnimationCreator.Services
 
             // Resample
             if (_animationSettings.FitAnimation)
-                newRiderAnim = GameWorld.Core.Animation.AnimationEditor.ReSample(_riderSkeleton, newRiderAnim, mountAnimation.DynamicFrames.Count, mountAnimation.PlayTimeInSec);
+                newRiderAnim = GameWorld.Core.Animation.AnimationEditor.ReSample(_riderSkeleton, newRiderAnim, mountAnimation.DynamicFrames.Count, mountAnimation.Duration);
 
             var maxFrameCount = Math.Min(mountAnimation.DynamicFrames.Count, newRiderAnim.DynamicFrames.Count);
             for (int i = 0; i < maxFrameCount; i++)

--- a/Editors/AnimationMeta/Test.AnimationMeta/MetaDataBuilderMissingResourceTests.cs
+++ b/Editors/AnimationMeta/Test.AnimationMeta/MetaDataBuilderMissingResourceTests.cs
@@ -358,7 +358,7 @@ namespace Test.AnimationMeta
             var clip = new AnimationClip();
             for (var frameIndex = 0; frameIndex < 30; frameIndex++)
                 clip.DynamicFrames.Add(new AnimationClip.KeyFrame());
-            clip.PlayTimeInSec = 1;
+            clip.Duration = TimeSpan.FromSeconds(1);
             player.SetAnimation(clip, null!);
 
             var instances = builder.Build(

--- a/Editors/AnimationMeta/Test.AnimationMeta/MetaDataEditorViewModelTests.cs
+++ b/Editors/AnimationMeta/Test.AnimationMeta/MetaDataEditorViewModelTests.cs
@@ -635,8 +635,8 @@ namespace Test.AnimationMeta
                 Assert.Multiple(() =>
                 {
                     Assert.That(
-                        superView.SceneObjects.Single().Data.Player.GetTimeUs(),
-                        Is.EqualTo(1_250_000));
+                        superView.SceneObjects.Single().Data.Player.CurrentTime,
+                        Is.EqualTo(TimeSpan.FromMilliseconds(1250)));
                     Assert.That(
                         superView.SelectedMetaDataIsActive,
                         Is.True);
@@ -644,8 +644,8 @@ namespace Test.AnimationMeta
 
                 superView.JumpToSelectedMetaDataEndAction();
                 Assert.That(
-                    superView.SceneObjects.Single().Data.Player.GetTimeUs(),
-                    Is.EqualTo(2_500_000));
+                    superView.SceneObjects.Single().Data.Player.CurrentTime,
+                    Is.EqualTo(TimeSpan.FromMilliseconds(2500)));
 
                 superView.MetaEditor.SelectedTag = effectTag;
                 Assert.That(superView.IsEffectMetaDataSelected, Is.True);
@@ -1618,8 +1618,8 @@ namespace Test.AnimationMeta
                         superView.PersistentMetaEditor.SelectedAttribute,
                         Is.SameAs(persistentMarker.Item.Source));
                     Assert.That(
-                        sceneObject.Data.Player.GetTimeUs(),
-                        Is.EqualTo(1_000_000));
+                        sceneObject.Data.Player.CurrentTime,
+                        Is.EqualTo(TimeSpan.FromSeconds(1)));
                     Assert.That(
                         sceneObject.Data.MetaDataItems,
                         Is.EqualTo(originalPreviews));
@@ -1737,8 +1737,8 @@ namespace Test.AnimationMeta
                         superView.PersistentMetaEditor.SelectedAttribute,
                         Is.SameAs(persistentItem.Source));
                     Assert.That(
-                        sceneObject.Data.Player.GetTimeUs(),
-                        Is.Zero);
+                        sceneObject.Data.Player.CurrentTime,
+                        Is.EqualTo(TimeSpan.Zero));
                     Assert.That(selectedTimelineMarker.IsSelected, Is.True);
                     Assert.That(superView.CanEditSelectedMetaData3D, Is.True);
                     Assert.That(
@@ -1912,8 +1912,8 @@ namespace Test.AnimationMeta
                         superView.PersistentMetaEditor.SelectedAttribute,
                         Is.SameAs(problem.Source));
                     Assert.That(
-                        sceneObject.Data.Player.GetTimeUs(),
-                        Is.EqualTo(1_000_000));
+                        sceneObject.Data.Player.CurrentTime,
+                        Is.EqualTo(TimeSpan.FromSeconds(1)));
                     Assert.That(camera.LookAt, Is.EqualTo(position));
                     Assert.That(
                         sceneObject.Data.MetaDataItems.Single(),

--- a/Editors/AnimationMeta/Test.AnimationMeta/MetaDataPreviewTimeTests.cs
+++ b/Editors/AnimationMeta/Test.AnimationMeta/MetaDataPreviewTimeTests.cs
@@ -134,6 +134,41 @@ internal class MetaDataPreviewTimeTests
         });
     }
 
+    [Test]
+    public void ZeroZeroSplashPreview_UsesPlayerTimebaseSampleDuration()
+    {
+        var player = new AnimationPlayer();
+        var skeleton = CreateSkeleton(player);
+        var clip = new AnimationClip
+        {
+            Duration = TimeSpan.FromMilliseconds(300),
+        };
+        for (var frameIndex = 0; frameIndex < 7; frameIndex++)
+            clip.DynamicFrames.Add(CreateFrame(Quaternion.Identity));
+        player.SetAnimation(clip, skeleton);
+        var node = new SimpleDrawableNode("splash");
+        var source = new SplashAttack_v10
+        {
+            StartTime = 0,
+            EndTime = 0,
+        };
+        var instance = new CombatMetaDataInstance(
+            source,
+            CombatMetaDataPreviewCategory.Splash,
+            Vector3.Zero,
+            node,
+            false,
+            _ => { },
+            player,
+            new MetaDataTimeRange(0, 0));
+
+        instance.Update(0.04f);
+        Assert.That(node.IsVisible, Is.True);
+
+        instance.Update(0.05f);
+        Assert.That(node.IsVisible, Is.False);
+    }
+
     [TestCaseSource(nameof(WholeAnimationZeroRangeTags))]
     public void ZeroZeroStateTag_IsActiveForTheWholeAnimation(
         ParsedMetadataAttribute source)
@@ -156,7 +191,7 @@ internal class MetaDataPreviewTimeTests
 
         player.SeekToTimeSeconds(1.25f);
 
-        Assert.That(player.GetTimeUs(), Is.EqualTo(1_250_000));
+        Assert.That(player.CurrentTime, Is.EqualTo(TimeSpan.FromMilliseconds(1250)));
     }
 
     [Test]
@@ -222,7 +257,7 @@ internal class MetaDataPreviewTimeTests
     {
         var propPlayer = new AnimationPlayer();
         var propSkeleton = CreateSkeleton(propPlayer, includeChild: true);
-        var clip = new AnimationClip { PlayTimeInSec = 1 };
+        var clip = new AnimationClip { Duration = TimeSpan.FromSeconds(1) };
         clip.DynamicFrames.Add(CreateFrame(Quaternion.Identity));
         var expectedRotation = Quaternion.CreateFromAxisAngle(
             Vector3.Up,

--- a/Editors/AnimationReTarget/Editors.AnimatioReTarget/Editor/AnimationRemapperService.cs
+++ b/Editors/AnimationReTarget/Editors.AnimatioReTarget/Editor/AnimationRemapperService.cs
@@ -53,10 +53,14 @@ namespace Editors.AnimatioReTarget.Editor
                     "AnimReTarget.Error.EmptySourceAnimation",
                     "Source animation must contain at least one frame."));
             }
-            var newFrameCount = originalFrameCount <= 1
-                ? originalFrameCount
-                : Math.Max(2, (int)MathF.Round((originalFrameCount - 1) / speedMultiplier) + 1);
-            var newPlayTime = animationToCopy.PlayTimeInSec / speedMultiplier;
+            var sourceTimebase = animationToCopy.Timebase ??
+                throw new InvalidDataException(
+                    GetLocalizedText(
+                        "AnimReTarget.Error.InvalidSourceDuration",
+                        "Source animation must have a positive duration."));
+            var targetTimebase = sourceTimebase.WithPlaybackSpeed(
+                speedMultiplier);
+            var newFrameCount = targetTimebase.FrameCount;
 
             //animationToCopy.RemoveOptimizations(copyFromSkeleton);
             var resampledAnimationToCopy = originalFrameCount == 1
@@ -65,8 +69,8 @@ namespace Editors.AnimatioReTarget.Editor
                     copyFromSkeleton,
                     animationToCopy,
                     newFrameCount,
-                    newPlayTime);
-            resampledAnimationToCopy.PlayTimeInSec = newPlayTime;
+                    targetTimebase.Duration);
+            resampledAnimationToCopy.Duration = targetTimebase.Duration;
             var newAnimation = CreateNewAnimation(copyToSkeleton, resampledAnimationToCopy);
 
             if (!HaveEquivalentSkeletonDefinitions(
@@ -539,7 +543,7 @@ namespace Editors.AnimatioReTarget.Editor
             var frameCount = animationToCopy.DynamicFrames.Count;
 
             var newAnimation = new AnimationClip();
-            newAnimation.PlayTimeInSec = animationToCopy.PlayTimeInSec;
+            newAnimation.Duration = animationToCopy.Duration;
             for (var frameIndex = 0; frameIndex < frameCount; frameIndex++)
             {
                 newAnimation.DynamicFrames.Add(new AnimationClip.KeyFrame());

--- a/Editors/AnimationReTarget/Editors.AnimatioReTarget/Editor/ExportHelper.cs
+++ b/Editors/AnimationReTarget/Editors.AnimatioReTarget/Editor/ExportHelper.cs
@@ -58,7 +58,6 @@ namespace Editors.AnimatioReTarget.Editor
             //var scaleAnimClip = new AnimationClip();
             //scaleAnimClip.DynamicFrames.Add(new AnimationClip.KeyFrame());
             //scaleAnimClip.DynamicFrames.Add(new AnimationClip.KeyFrame());
-            //scaleAnimClip.PlayTimeInSec = 2.0f / 20.0f;
             //for (int i = 0; i < Generated.Skeleton.BoneCount; i++)
             //{
             //    scaleAnimClip.DynamicFrames[0].Position.Add(Generated.Skeleton.Translation[i]);

--- a/Editors/AnimationReTarget/Test.AnimatioReTarget/AnimationRemapperServiceTests.cs
+++ b/Editors/AnimationReTarget/Test.AnimatioReTarget/AnimationRemapperServiceTests.cs
@@ -1007,7 +1007,7 @@ public class AnimationRemapperServiceTests
     public void ReMapAnimation_SpeedMultiplierTwo_HalvesDurationAndPreservesSamplingRate()
     {
         var skeleton = CreateSkeleton("shared", 1);
-        var animation = CreateAnimation(21, 1, 1.0f);
+        var animation = CreateAnimation(20, 1, 1.0f);
         var bone = new SkeletonBoneNode_new("root", 0, -1)
         {
             HasMapping = true,
@@ -1023,8 +1023,8 @@ public class AnimationRemapperServiceTests
 
         var result = service.ReMapAnimation(skeleton, skeleton, animation);
 
-        Assert.That(result.PlayTimeInSec, Is.EqualTo(0.5f).Within(0.0001f));
-        Assert.That(result.DynamicFrames, Has.Count.EqualTo(11));
+        Assert.That(result.Duration, Is.EqualTo(TimeSpan.FromSeconds(0.5)));
+        Assert.That(result.DynamicFrames, Has.Count.EqualTo(10));
     }
 
     [Test]
@@ -1096,7 +1096,7 @@ public class AnimationRemapperServiceTests
             Assert.That(result.DynamicFrames, Has.Count.EqualTo(1));
             Assert.That(result.DynamicFrames[0].Position[0],
                 Is.EqualTo(new Vector3(1, 2, 3)));
-            Assert.That(float.IsFinite(result.PlayTimeInSec), Is.True);
+            Assert.That(result.Duration, Is.GreaterThan(TimeSpan.Zero));
         });
     }
 
@@ -1304,7 +1304,7 @@ public class AnimationRemapperServiceTests
             animation.DynamicFrames.Add(frame);
         }
 
-        animation.PlayTimeInSec = playTime;
+        animation.Duration = TimeSpan.FromSeconds(playTime);
         return animation;
     }
 

--- a/Editors/CscEditor/Editors.CscEditor/Services/CscAnimationComponent.cs
+++ b/Editors/CscEditor/Editors.CscEditor/Services/CscAnimationComponent.cs
@@ -427,8 +427,6 @@ namespace Editors.CscEditor.Services
             foreach (var binding in ordered)
             {
                 var animElement = binding.Element;
-                if (binding.FrameCount <= 0 || binding.ClipLengthSeconds <= 0)
-                    continue;
                 if (sceneTime < animElement.NormalizedBegin)
                     continue;
 
@@ -550,8 +548,6 @@ namespace Editors.CscEditor.Services
             foreach (var binding in spliceBindings.OrderBy(b => b.Element.NormalizedBegin))
             {
                 var animElement = binding.Element;
-                if (binding.FrameCount <= 0 || binding.ClipLengthSeconds <= 0)
-                    continue;
                 if (sceneTime < animElement.NormalizedBegin)
                     continue;
 
@@ -663,11 +659,10 @@ namespace Editors.CscEditor.Services
         /// tail end of the clip first" instead of freezing on frame 0 until elapsed time catches up
         /// to |offset|.
         /// <para/>
-        /// <see cref="Frame"/>/<see cref="FrameInterpolation"/> are deliberately computed the same
-        /// way <see cref="AnimationSampler.Sample(float, GameSkeleton, AnimationClip, List{IAnimationChangeRule}, bool)"/>
-        /// does (round to the nearest frame, keep the leftover as the blend factor toward its
-        /// neighbour) rather than truncating <paramref name="normalized"/> straight to an integer
-        /// frame index with no fractional remainder - the previous version discarded that remainder
+        /// <see cref="Frame"/>/<see cref="FrameInterpolation"/> are derived from the clip's shared
+        /// half-open timebase, keeping the leftover as the blend factor toward the next sample,
+        /// rather than truncating <paramref name="normalized"/> straight to an integer frame index
+        /// with no fractional remainder - the previous version discarded that remainder
         /// entirely (passed a hardcoded interpolation of 0 into <see cref="AnimationSampler.Sample(int, float, GameSkeleton, AnimationClip, List{IAnimationChangeRule}, bool)"/>),
         /// so playback only ever showed whichever whole frame the current time landed on with no
         /// blend toward the next - correct, but visibly stepped ("slideshow-y"), worst at a heavily
@@ -683,15 +678,15 @@ namespace Editors.CscEditor.Services
             var speed = animElement.PeriodSpeedMultiplier != 0 ? animElement.PeriodSpeedMultiplier : 1;
             var animTime = (clampedTime - begin) * speed + animElement.PeriodTimeOffset;
 
-            var passes = animTime / binding.ClipLengthSeconds;
+            var clipLengthSeconds = (float)binding.Timebase.Duration.TotalSeconds;
+            var passes = animTime / clipLengthSeconds;
             var completedLoops = (int)MathF.Floor(passes);
             var normalized = passes - completedLoops; // always in [0,1), even for negative animTime
 
-            var maxFrameIndex = MathF.Max(binding.FrameCount - 1, 0);
-            var frameWithLeftover = normalized * maxFrameIndex;
-            var frame = (int)MathF.Round(frameWithLeftover);
-            var frameInterpolation = frameWithLeftover - frame;
-            frame = Math.Clamp(frame, 0, binding.FrameCount - 1);
+            var frameWithLeftover = binding.Timebase.GetSamplePosition(
+                TimeSpan.FromSeconds(normalized * clipLengthSeconds));
+            var frame = (int)Math.Floor(frameWithLeftover);
+            var frameInterpolation = (float)(frameWithLeftover - frame);
 
             return (frame, frameInterpolation, completedLoops);
         }

--- a/Editors/CscEditor/Editors.CscEditor/Services/CscSceneGraphBuilder.cs
+++ b/Editors/CscEditor/Editors.CscEditor/Services/CscSceneGraphBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Editors.CscEditor.Data;
 using GameWorld.Core.Animation;
@@ -22,8 +23,7 @@ namespace Editors.CscEditor.Services
         public required CscElement Element { get; init; }
         public required AnimationClip Clip { get; init; }
         public required GameSkeleton Skeleton { get; init; }
-        public float ClipLengthSeconds { get; init; }
-        public int FrameCount { get; init; }
+        public required AnimationTimebase Timebase { get; init; }
 
         /// <summary>Model-space transform the animroot bone accumulates over one full clip pass
         /// (identity when the clip ends where it started). Walk cycles and travelling idles put
@@ -255,13 +255,15 @@ namespace Editors.CscEditor.Services
                             : GameSkeleton.CreateFromAnimationFile(animFile, content.Player);
 
                         var clip = new AnimationClip(animFile, skeleton);
+                        var timebase = clip.Timebase ??
+                            throw new InvalidDataException(
+                                "动画时长必须大于 0，且至少包含一帧。");
                         content.Bindings.Add(new CscAnimationBinding
                         {
                             Element = animationElement,
                             Clip = clip,
                             Skeleton = skeleton,
-                            ClipLengthSeconds = clip.PlayTimeInSec,
-                            FrameCount = clip.DynamicFrames.Count,
+                            Timebase = timebase,
                             LoopRootMotion = ComputeLoopRootMotion(skeleton, clip),
                         });
                     }

--- a/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfAnimationBuilder.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Exporters/RmvToGltf/Helpers/GltfAnimationBuilder.cs
@@ -77,10 +77,11 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
             var animationClip = new AnimationClip(animationToExport, gameSkeleton);
             if (animationClip.DynamicFrames.Count == 0)
                 throw new InvalidDataException($"动画“{animationName}”不包含任何动态帧。");
-            if (!float.IsFinite(animationToExport.Header.FrameRate) || animationToExport.Header.FrameRate <= 0)
-                throw new InvalidDataException($"动画“{animationName}”的帧率无效。");
-
-            var secondsPerFrame = 1.0f / animationToExport.Header.FrameRate;
+            var timebase = animationClip.Timebase ??
+                throw new InvalidDataException(
+                    LocalizationManager.Instance.GetFormat(
+                        "RmvToGltfExporter.Error.InvalidAnimationDuration",
+                        animationName));
 
             var gltfAnimation = modelRoot.CreateAnimation(animationName);
 
@@ -93,16 +94,19 @@ namespace Editors.ImportExport.Exporting.Exporters.RmvToGltf.Helpers
                 // populate the bone track containers with the key frames from the .ANIM animation file
                 for (var frameIndex = 0; frameIndex < animationClip.DynamicFrames.Count; frameIndex++)
                 {
-                    translationKeyFrames.Add(secondsPerFrame * (float)frameIndex, VecConv.GetSys(GlobalSceneTransforms.FlipVector(animationClip.DynamicFrames[frameIndex].Position[boneIndex], doMirror)));
+                    var keyTime = (float)timebase
+                        .GetSampleTime(frameIndex)
+                        .TotalSeconds;
+                    translationKeyFrames.Add(keyTime, VecConv.GetSys(GlobalSceneTransforms.FlipVector(animationClip.DynamicFrames[frameIndex].Position[boneIndex], doMirror)));
                     var rotation = Microsoft.Xna.Framework.Quaternion.Normalize(
                         GlobalSceneTransforms.FlipQuaternion(
                             animationClip.DynamicFrames[frameIndex]
                                 .Rotation[boneIndex],
                             doMirror));
                     rotationKeyFrames.Add(
-                        secondsPerFrame * (float)frameIndex,
+                        keyTime,
                         VecConv.GetSys(rotation));
-                    scaleKeyFrames.Add(secondsPerFrame * (float)frameIndex, new SysNum.Vector3(1, 1, 1));
+                    scaleKeyFrames.Add(keyTime, new SysNum.Vector3(1, 1, 1));
                 }
 
                 // add the transformations

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/AnimationBuilder.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/AnimationBuilder.cs
@@ -50,7 +50,6 @@ public class AnimationBuilder
         var keysPerSecond = settings.AutoDetectKeysPerSecond
             ? DetectSamplingRate(settings.ModelRoot, animation) ?? settings.KeysPerSecond
             : settings.KeysPerSecond;
-        var keyInterval = 1.0f / keysPerSecond;
         var roundedIntervalCount = Math.Round(
             (double)animation.Duration * keysPerSecond,
             MidpointRounding.AwayFromZero);
@@ -64,6 +63,9 @@ public class AnimationBuilder
 
         var intervalCount = Math.Max(0, (int)roundedIntervalCount);
         var keyCount = intervalCount + 1;
+        var timebase = AnimationTimebase.FromFramesPerSecond(
+            keyCount,
+            keysPerSecond);
         if ((long)keyCount * skeletonAnimFile.Bones.Length >
             MaxAnimationTransformSamples)
         {
@@ -79,7 +81,8 @@ public class AnimationBuilder
                 Version = 7,
                 FrameRate = keysPerSecond,
                 SkeletonName = settings.SkeletonName,
-                AnimationTotalPlayTimeInSec = keyCount * keyInterval,
+                AnimationTotalPlayTimeInSec =
+                    (float)timebase.Duration.TotalSeconds,
             },
             Bones = skeletonAnimFile.Bones,
             AnimationParts = [new AnimationPart()],
@@ -97,7 +100,9 @@ public class AnimationBuilder
         for (var keyIndex = 0; keyIndex < keyCount; keyIndex++)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var keyTime = keyIndex * keyInterval;
+            var keyTime = (float)timebase
+                .GetSampleTime(keyIndex)
+                .TotalSeconds;
             var frame = new Frame();
             FillFrame(
                 settings.ModelRoot,

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/AnimationRoundTripTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/AnimationRoundTripTests.cs
@@ -290,6 +290,56 @@ public class AnimationRoundTripTests
     }
 
     [Test]
+    public void ExportAnimation_ConflictingHeaderRate_UsesClipTimebase()
+    {
+        var packFileService = PackFileSerivceTestHelper.Create(
+            PathHelper.GetDataFolder("Data\\Karl_and_celestialgeneral_Pack"));
+        var skeleton = CreateSingleBoneAnimation(1.0f);
+        var animation = CreateSingleBoneAnimation(1.0f);
+        var sourceFrame = animation.AnimationParts[0].DynamicFrames[0];
+        animation.AnimationParts[0].DynamicFrames = Enumerable
+            .Range(0, 7)
+            .Select(_ => new AnimationFile.Frame
+            {
+                Transforms = [sourceFrame.Transforms[0]],
+                Quaternion = [sourceFrame.Quaternion[0]],
+            })
+            .ToList();
+        animation.Header.FrameRate = 20;
+        animation.Header.AnimationTotalPlayTimeInSec = 0.3f;
+        var animationPackFile = new PackFile(
+            "non_integer_rate.anim",
+            new MemorySource(AnimationFile.ConvertToBytes(animation)));
+        var modelRoot = ModelRoot.CreateModel();
+        var exportSettings = new RmvToGltfExporterSettings(
+            new PackFile("model.rigid_model_v2", new MemorySource([])),
+            [animationPackFile],
+            "roundtrip.gltf",
+            false,
+            false,
+            false,
+            true,
+            true);
+        var gltfSkeleton = new GltfSkeletonBuilder(packFileService)
+            .CreateSkeleton(skeleton, modelRoot, exportSettings);
+
+        new GltfAnimationBuilder(packFileService).Build(
+            skeleton,
+            exportSettings,
+            gltfSkeleton,
+            modelRoot);
+
+        var node = gltfSkeleton.Data[0].Item1;
+        var keyTimes = modelRoot.LogicalAnimations.Single()
+            .FindTranslationChannel(node)!
+            .GetTranslationSampler()
+            .GetLinearKeys()
+            .Select(key => key.Key)
+            .ToArray();
+        Assert.That(keyTimes[^1], Is.EqualTo(6.0 * 0.3 / 7.0).Within(0.000001));
+    }
+
+    [Test]
     public void ExportThenImport_NonUnitBindQuaternion_DoesNotCreateBoneScale()
     {
         var packFileService = PackFileSerivceTestHelper.Create(

--- a/Editors/Kitbashing/KitbasherEditor/Core/Animation/AnimationControllerViewModel.cs
+++ b/Editors/Kitbashing/KitbasherEditor/Core/Animation/AnimationControllerViewModel.cs
@@ -155,7 +155,7 @@ namespace Editors.KitbasherEditor.ViewModels
         void OnLastFrame()
         {
             _player.Pause();
-            _player.CurrentFrame = _player.FrameCount();
+            _player.CurrentFrame = _player.FrameCount;
             UpdatePlayingState();
         }
 
@@ -219,7 +219,7 @@ namespace Editors.KitbasherEditor.ViewModels
                 if (_player.IsPlaying && _player.IsEnabled)
                     _player.Play();
 
-                MaxFrames = _player.FrameCount();
+                MaxFrames = _player.FrameCount;
                 CurrentFrame = 0;
                 RefreshPlaybackPosition();
                 UpdatePlayingState();
@@ -266,9 +266,9 @@ namespace Editors.KitbasherEditor.ViewModels
             try
             {
                 PlaybackPositionSeconds =
-                    (float)_player.GetTimeUs() / 1_000_000;
+                    (float)_player.CurrentTime.TotalSeconds;
                 MaxTimeSeconds =
-                    (float)_player.GetAnimationLengthUs() / 1_000_000;
+                    (float)_player.Duration.TotalSeconds;
             }
             finally
             {

--- a/Editors/Kitbashing/Test.KitbashEditor/Animation/AnimationControllerViewModelTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/Animation/AnimationControllerViewModelTests.cs
@@ -53,7 +53,7 @@ namespace Test.KitbashEditor.Animation
                 });
             }
 
-            clip.PlayTimeInSec = seconds;
+            clip.Duration = TimeSpan.FromSeconds(seconds);
             return clip;
         }
 
@@ -229,7 +229,7 @@ namespace Test.KitbashEditor.Animation
 
             Assert.Multiple(() =>
             {
-                Assert.That(scene.Player.GetTimeUs(), Is.EqualTo(400_000));
+                Assert.That(scene.Player.CurrentTime, Is.EqualTo(TimeSpan.FromMilliseconds(400)));
                 Assert.That(scene.Player.IsPlaying, Is.False);
                 Assert.That(vm.MaxTimeSeconds, Is.EqualTo(1));
             });
@@ -237,14 +237,14 @@ namespace Test.KitbashEditor.Animation
             vm.PausePlayCommand.Execute(null);
             Assert.Multiple(() =>
             {
-                Assert.That(scene.Player.GetTimeUs(), Is.EqualTo(400_000));
+                Assert.That(scene.Player.CurrentTime, Is.EqualTo(TimeSpan.FromMilliseconds(400)));
                 Assert.That(scene.Player.IsPlaying, Is.True);
             });
 
             vm.PlaybackPositionSeconds = 0.6f;
             Assert.Multiple(() =>
             {
-                Assert.That(scene.Player.GetTimeUs(), Is.EqualTo(600_000));
+                Assert.That(scene.Player.CurrentTime, Is.EqualTo(TimeSpan.FromMilliseconds(600)));
                 Assert.That(scene.Player.IsPlaying, Is.True);
             });
         }

--- a/Editors/Kitbashing/Test.KitbashEditor/Components/Gizmo/TransformGestureTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/Components/Gizmo/TransformGestureTests.cs
@@ -1685,7 +1685,7 @@ namespace Testing.GameWorld.Core.Components.Gizmo
 
             var clip = new AnimationClip();
             clip.DynamicFrames.Add(initialFrame.Clone());
-            clip.PlayTimeInSec = 1;
+            clip.Duration = TimeSpan.FromSeconds(1);
             player.SetAnimation(clip, skeleton);
             player.IsEnabled = true;
             player.Pause();

--- a/Editors/Kitbashing/Test.KitbashEditor/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/Rendering/RenderEngineSelectionMaskOffscreenTests.cs
@@ -1491,7 +1491,7 @@ public class RenderEngineSelectionMaskOffscreenTests
                 Rotation = [Quaternion.Identity],
                 Scale = [Vector3.One]
             });
-        clip.PlayTimeInSec = 1;
+        clip.Duration = TimeSpan.FromSeconds(1);
         player.SetAnimation(clip, skeleton);
         player.IsEnabled = true;
         player.Pause();

--- a/Editors/Kitbashing/Test.KitbashEditor/TransformToolViewModelTests.cs
+++ b/Editors/Kitbashing/Test.KitbashEditor/TransformToolViewModelTests.cs
@@ -219,7 +219,7 @@ public class TransformToolViewModelTests
             Rotation = [Quaternion.Identity],
             Scale = [Vector3.One]
         });
-        clip.PlayTimeInSec = 1;
+        clip.Duration = TimeSpan.FromSeconds(1);
         player.SetAnimation(clip, skeleton);
         player.IsEnabled = true;
         player.Pause();

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/SuperViewViewModel.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/SuperViewViewModel.cs
@@ -277,8 +277,8 @@ namespace Editors.AnimationMeta.SuperView
                 : 0;
         public bool SelectedMetaDataIsActive =>
             TryGetSelectedMetaDataTimeRange(out var timeRange) &&
-            timeRange.Contains((float)_asset.Data.Player.GetTimeUs() /
-                1_000_000);
+            timeRange.Contains(
+                (float)_asset.Data.Player.CurrentTime.TotalSeconds);
         public bool SelectedMetaDataUsesZeroRangeConvention =>
             TryGetSelectedMetaDataTimeRange(out var timeRange) &&
             timeRange.IsWholeAnimationRange;
@@ -1129,7 +1129,7 @@ namespace Editors.AnimationMeta.SuperView
             if (change.Kind == CombatMetaDataEditChangeKind.Preview)
             {
                 var currentTimeSeconds =
-                    _asset.Data.Player.GetTimeUs() / 1_000_000f;
+                    (float)_asset.Data.Player.CurrentTime.TotalSeconds;
                 _asset.Data.MetaDataItems
                     .FirstOrDefault(item =>
                         item is IMetaDataPreview preview &&

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/Instances/AnimatedPropInstance.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/Instances/AnimatedPropInstance.cs
@@ -132,12 +132,11 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
 
         private float GetPlayerTime(float mainAnimationTime)
         {
-            var animationLengthUs = Player.GetAnimationLengthUs();
-            if (!Player.LoopAnimation || animationLengthUs <= 0)
+            var animationDuration = Player.Duration;
+            if (!Player.LoopAnimation || animationDuration <= TimeSpan.Zero)
                 return mainAnimationTime;
 
-            var animationLengthSeconds = animationLengthUs / 1_000_000f;
-            return mainAnimationTime % animationLengthSeconds;
+            return mainAnimationTime % (float)animationDuration.TotalSeconds;
         }
 
         private void ApplyVisibility() =>

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/Instances/CombatMetaDataInstance.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/Instances/CombatMetaDataInstance.cs
@@ -200,11 +200,8 @@ namespace Editors.AnimationMeta.SuperView.Visualisation.Instances
 
         private float GetFrameDurationSeconds()
         {
-            var microsecondsPerFrame =
-                Player.AnimationClip?.MicrosecondsPerFrame ?? 0;
-            return microsecondsPerFrame > 0
-                ? microsecondsPerFrame / 1_000_000f
-                : 0;
+            return (float)(Player.AnimationClip?.Timebase?
+                .SampleDuration.TotalSeconds ?? 0);
         }
 
         private Matrix GetParentWorldTransform()

--- a/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataBuilder.cs
+++ b/Editors/MetaDataEditor/AnimationMeta/SuperView/Visualisation/MetaDataBuilder.cs
@@ -858,7 +858,7 @@ namespace Editors.AnimationMeta.SuperView.Visualisation
                             }
                         });
                     animatedProp.Update(
-                        rootPlayer.GetTimeUs() / 1_000_000f);
+                        (float)rootPlayer.CurrentTime.TotalSeconds);
                     return animatedProp;
                 }
 

--- a/Editors/Shared/Editors.Shared.Core/Common/AnimationPlayer/AnimationPlayerView.xaml
+++ b/Editors/Shared/Editors.Shared.Core/Common/AnimationPlayer/AnimationPlayerView.xaml
@@ -127,7 +127,7 @@
                     Margin="12,0,0,0"
                     VerticalAlignment="Center"
                     Visibility="{Binding PlayerControlsVisibility.Value, Mode=OneWay}">
-                    <Run Text="{Binding SelectedAnimationFps.Value}" />
+                    <Run Text="{Binding SelectedAnimationFps.Value, StringFormat=N2}" />
                     <Run Text="{loc:Loc SharedAnimPlayer.Fps}" />
                 </TextBlock>
                 <CheckBox

--- a/Editors/Shared/Editors.Shared.Core/Common/AnimationPlayer/AnimationPlayerViewModel.cs
+++ b/Editors/Shared/Editors.Shared.Core/Common/AnimationPlayer/AnimationPlayerViewModel.cs
@@ -15,7 +15,7 @@ namespace Editors.Shared.Core.Common.AnimationPlayer
 
         public NotifyAttr<float> SelectedAnimationCurrentTime { get; private set; } = new();
         public NotifyAttr<float> SelectedAnimationMaxTime { get; private set; } = new();
-        public NotifyAttr<int> SelectedAnimationFps { get; private set; } = new();
+        public NotifyAttr<double> SelectedAnimationFps { get; private set; } = new();
         public NotifyAttr<int> SelectedAnimationCurrentFrame { get; private set; } = new();
         public NotifyAttr<int> SelectedAnimationFrameCount { get; private set; } = new();
         public NotifyAttr<bool> IsEnabled { get; set; } = new();
@@ -59,10 +59,11 @@ namespace Editors.Shared.Core.Common.AnimationPlayer
 
             SelectedAnimationFrameCount.Value = mainAnimation.MaxFrames.Value;
             SelectedAnimationCurrentTime.Value =
-                (float)mainAnimation.Asset.Player.GetTimeUs() / 1_000_000;
+                (float)mainAnimation.Asset.Player.CurrentTime.TotalSeconds;
             SelectedAnimationMaxTime.Value =
-                (float)mainAnimation.Asset.Player.GetAnimationLengthUs() /
-                1_000_000;
+                (float)mainAnimation.Asset.Player.Duration.TotalSeconds;
+            SelectedAnimationFps.Value =
+                mainAnimation.Asset.Player.FramesPerSecond;
             SetPlaybackPositionFromPlayer(
                 SelectedAnimationCurrentTime.Value);
             mainAnimation.Asset.Player.OnFrameChanged += OnAnimationFrameChanged;
@@ -86,7 +87,7 @@ namespace Editors.Shared.Core.Common.AnimationPlayer
         {
             playerItem.AnimationName.Value = asset.AnimationName.Value;
             playerItem.SlotName.Value = asset.Description;
-            playerItem.MaxFrames.Value = asset.Player.FrameCount();
+            playerItem.MaxFrames.Value = asset.Player.FrameCount;
         }
 
         public void ToggleAnimationPausePlay()
@@ -126,21 +127,24 @@ namespace Editors.Shared.Core.Common.AnimationPlayer
         {
             LoopAnimation.Value = false;
             foreach (var item in _assetList)
-                SetFrame(item, SelectedMainAnimation.Asset.Player.FrameCount());
+                SetFrame(item, SelectedMainAnimation.Asset.Player.FrameCount);
             UpdatePlayingState();
         }
 
         private void OnAnimationFrameChanged(int currentFrame)
         {
-            SelectedAnimationFrameCount.Value = SelectedMainAnimation.Asset.Player.FrameCount();
+            SelectedAnimationFrameCount.Value = SelectedMainAnimation.Asset.Player.FrameCount;
             SelectedAnimationCurrentFrame.Value = currentFrame;
-            SelectedAnimationCurrentTime.Value = (float)SelectedMainAnimation.Asset.Player.GetTimeUs() / 1_000_000;
-            SelectedAnimationMaxTime.Value = (float)SelectedMainAnimation.Asset.Player.GetAnimationLengthUs() / 1_000_000;
-            SelectedAnimationFps.Value = SelectedMainAnimation.Asset.Player.GetFps();
+            SelectedAnimationCurrentTime.Value =
+                (float)SelectedMainAnimation.Asset.Player.CurrentTime.TotalSeconds;
+            SelectedAnimationMaxTime.Value =
+                (float)SelectedMainAnimation.Asset.Player.Duration.TotalSeconds;
+            SelectedAnimationFps.Value =
+                SelectedMainAnimation.Asset.Player.FramesPerSecond;
             SetPlaybackPositionFromPlayer(
                 SelectedAnimationCurrentTime.Value);
 
-            if (SelectedAnimationCurrentFrame.Value + 1 == SelectedMainAnimation.Asset.Player.FrameCount())
+            if (SelectedAnimationCurrentFrame.Value + 1 == SelectedMainAnimation.Asset.Player.FrameCount)
             {
                 if (LoopAnimation.Value)
                 {

--- a/Editors/Shared/Editors.Shared.Core/Common/SceneObject.cs
+++ b/Editors/Shared/Editors.Shared.Core/Common/SceneObject.cs
@@ -95,7 +95,7 @@ namespace Editors.Shared.Core.Common
         {
             ParentNode.ModelMatrix = Matrix.Multiply(Offset, Matrix.Identity);
 
-            var currentTimeSeconds = (float)Player.GetTimeUs() / 1_000_000;
+            var currentTimeSeconds = (float)Player.CurrentTime.TotalSeconds;
             foreach (var item in MetaDataItems)
                 item.Update(currentTimeSeconds);
         }

--- a/Editors/Shared/Test.Editors.Shared.Core/AnimationPlayerViewModelTests.cs
+++ b/Editors/Shared/Test.Editors.Shared.Core/AnimationPlayerViewModelTests.cs
@@ -77,13 +77,26 @@ public class AnimationPlayerViewModelTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(first.Player.GetTimeUs(), Is.EqualTo(400_000));
-            Assert.That(second.Player.GetTimeUs(), Is.EqualTo(400_000));
-            Assert.That(metadataPlayer.GetTimeUs(), Is.EqualTo(400_000));
+            Assert.That(first.Player.CurrentTime, Is.EqualTo(TimeSpan.FromMilliseconds(400)));
+            Assert.That(second.Player.CurrentTime, Is.EqualTo(TimeSpan.FromMilliseconds(400)));
+            Assert.That(metadataPlayer.CurrentTime, Is.EqualTo(TimeSpan.FromMilliseconds(400)));
             Assert.That(first.Player.IsPlaying, Is.False);
             Assert.That(second.Player.IsPlaying, Is.False);
             Assert.That(metadataPlayer.IsPlaying, Is.False);
         });
+    }
+
+    [Test]
+    public void RegisterAsset_ReportsExactNonIntegerFrameRate()
+    {
+        var sceneObject = CreateSceneObject("main", 7, 0.3f);
+        var viewModel = new AnimationPlayerViewModel();
+
+        viewModel.RegisterAsset(sceneObject);
+
+        Assert.That(
+            viewModel.SelectedAnimationFps.Value,
+            Is.EqualTo(70.0 / 3.0).Within(0.000001));
     }
 
     [Test]
@@ -138,7 +151,7 @@ public class AnimationPlayerViewModelTests
             });
         }
 
-        clip.PlayTimeInSec = seconds;
+        clip.Duration = TimeSpan.FromSeconds(seconds);
         return clip;
     }
 

--- a/GameWorld/View3D/Animation/AnimationClip.cs
+++ b/GameWorld/View3D/Animation/AnimationClip.cs
@@ -40,43 +40,21 @@ namespace GameWorld.Core.Animation
             }
         }
 
-        private const long MicrosecondsPerSecond = 1_000_000;
-
-        private long _playTimeUs = -1 * MicrosecondsPerSecond;
-
         public List<KeyFrame> DynamicFrames = new List<KeyFrame>();
 
-        public long PlayTimeUs => _playTimeUs;
+        public TimeSpan Duration { get; set; }
 
         public AnimationTimebase? Timebase
         {
             get
             {
-                if (DynamicFrames.Count == 0 || _playTimeUs <= 0)
+                if (DynamicFrames.Count == 0 || Duration <= TimeSpan.Zero)
                     return null;
 
                 return new AnimationTimebase(
                     DynamicFrames.Count,
-                    TimeSpan.FromTicks(_playTimeUs * TimeSpan.TicksPerMicrosecond));
+                    Duration);
             }
-        }
-
-        public long MicrosecondsPerFrame
-        {
-            get
-            {
-                if (DynamicFrames.Count == 0)
-                {
-                    return -1;
-                }
-                return _playTimeUs / DynamicFrames.Count;
-            }
-        }
-
-        public float PlayTimeInSec
-        {
-            get => (float)_playTimeUs / MicrosecondsPerSecond;
-            set => _playTimeUs = (long)Math.Round(value * MicrosecondsPerSecond);
         }
 
         public int AnimationBoneCount
@@ -101,7 +79,8 @@ namespace GameWorld.Core.Animation
                 DynamicFrames.AddRange(frames);
             }
 
-            PlayTimeInSec = file.Header.AnimationTotalPlayTimeInSec;
+            Duration = TimeSpan.FromSeconds(
+                file.Header.AnimationTotalPlayTimeInSec);
         }
 
 
@@ -159,7 +138,8 @@ namespace GameWorld.Core.Animation
             output.Header.FrameRate = (float)(Timebase?.FramesPerSecond ?? 20);
 
             output.Header.Version = 7;
-            output.Header.AnimationTotalPlayTimeInSec = PlayTimeInSec;
+            output.Header.AnimationTotalPlayTimeInSec =
+                (float)Duration.TotalSeconds;
             output.Header.SkeletonName = skeleton.SkeletonName;
             output.AnimationParts.Add(new AnimationPart());
 
@@ -216,7 +196,7 @@ namespace GameWorld.Core.Animation
             var copy = new AnimationClip();
             foreach (var item in DynamicFrames)
                 copy.DynamicFrames.Add(item.Clone());
-            copy.PlayTimeInSec = PlayTimeInSec;
+            copy.Duration = Duration;
 
             return copy;
         }
@@ -237,7 +217,7 @@ namespace GameWorld.Core.Animation
             clip.DynamicFrames.Add(frame.Clone());
             clip.DynamicFrames.Add(frame.Clone());
 
-            clip.PlayTimeInSec = 0.1f;
+            clip.Duration = TimeSpan.FromSeconds(0.1);
             return clip;
         }
 

--- a/GameWorld/View3D/Animation/AnimationEditor.cs
+++ b/GameWorld/View3D/Animation/AnimationEditor.cs
@@ -89,14 +89,18 @@ namespace GameWorld.Core.Animation
             }
         }
 
-        public static AnimationClip ReSample(GameSkeleton skeleton, AnimationClip newAnim, int newFrameCount, float playTime)
+        public static AnimationClip ReSample(
+            GameSkeleton skeleton,
+            AnimationClip newAnim,
+            int newFrameCount,
+            TimeSpan duration)
         {
             if (newFrameCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(newFrameCount));
 
             var output = newAnim.Clone();
             output.DynamicFrames.Clear();
-            output.PlayTimeInSec = playTime;
+            output.Duration = duration;
 
             if (newFrameCount == 0 || newAnim.Timebase == null)
                 return output;

--- a/GameWorld/View3D/Animation/AnimationPlayer.cs
+++ b/GameWorld/View3D/Animation/AnimationPlayer.cs
@@ -98,7 +98,14 @@ namespace GameWorld.Core.Animation
 
                 if (_animationClip != null)
                 {
-                    var frameIndex = MathUtil.EnsureRange(value, 0, FrameCount() - 1);
+                    if (FrameCount == 0)
+                    {
+                        OnFrameChanged?.Invoke(0);
+                        Refresh();
+                        return;
+                    }
+
+                    var frameIndex = MathUtil.EnsureRange(value, 0, FrameCount - 1);
                     _timeSinceStart = new TimeSpanExtension(FrameToStartTime(frameIndex));
                     OnFrameChanged?.Invoke(CurrentFrame);
                 }
@@ -139,11 +146,11 @@ namespace GameWorld.Core.Animation
             if (!IsPlaying && !RefreshWhilePaused)
                 return;
 
-            var animationLengthUs = GetAnimationLengthUs();
-            if (animationLengthUs != 0 && IsPlaying)
+            var animationDuration = Duration;
+            if (animationDuration > TimeSpan.Zero && IsPlaying)
             {
                 _timeSinceStart.TimeSpan += gameTime.ElapsedGameTime;
-                if (_timeSinceStart.TotalMicrosecondsAsLong >= animationLengthUs)
+                if (_timeSinceStart.TimeSpan >= animationDuration)
                 {
                     if (LoopAnimation)
                     {
@@ -151,7 +158,7 @@ namespace GameWorld.Core.Animation
                     }
                     else
                     {
-                        _timeSinceStart = TimeSpanExtension.FromMicroseconds(animationLengthUs);
+                        _timeSinceStart = new TimeSpanExtension(animationDuration);
                         IsPlaying = false;
                     }
                 }
@@ -195,14 +202,12 @@ namespace GameWorld.Core.Animation
             if (float.IsFinite(timeSeconds) == false)
                 throw new ArgumentOutOfRangeException(nameof(timeSeconds));
 
-            var requestedTimeUs = (long)Math.Round(
-                Math.Max(0, timeSeconds) * 1_000_000d);
-            var animationLengthUs = GetAnimationLengthUs();
-            if (animationLengthUs > 0)
-                requestedTimeUs = Math.Min(requestedTimeUs, animationLengthUs);
+            var requestedTime = TimeSpan.FromSeconds(
+                Math.Max(0, timeSeconds));
+            if (Duration > TimeSpan.Zero && requestedTime > Duration)
+                requestedTime = Duration;
 
-            _timeSinceStart = TimeSpanExtension.FromMicroseconds(
-                requestedTimeUs);
+            _timeSinceStart = new TimeSpanExtension(requestedTime);
             OnFrameChanged?.Invoke(CurrentFrame);
             Refresh();
         }
@@ -215,9 +220,13 @@ namespace GameWorld.Core.Animation
             _skeleton?.Update();
         }
 
-        public double FramesPerSecond => _animationClip?.Timebase?.FramesPerSecond ?? 0;
+        public TimeSpan CurrentTime => _timeSinceStart.TimeSpan;
 
-        public int GetFps() => (int)FramesPerSecond;
+        public TimeSpan Duration => _animationClip?.Timebase?.Duration ?? TimeSpan.Zero;
+
+        public int FrameCount => _animationClip?.Timebase?.FrameCount ?? 0;
+
+        public double FramesPerSecond => _animationClip?.Timebase?.FramesPerSecond ?? 0;
 
         /// <summary>
         /// Overrides the sampled frame until the next refresh.
@@ -225,8 +234,5 @@ namespace GameWorld.Core.Animation
         public void SetManualFrame(AnimationFrame frame) => _currentAnimFrame = frame;
 
         public AnimationFrame GetCurrentAnimationFrame() => _currentAnimFrame;
-        public int FrameCount() => _animationClip != null ? _animationClip.DynamicFrames.Count() : 0;
-        public long GetAnimationLengthUs() => _animationClip?.PlayTimeUs ?? 0;
-        public long GetTimeUs() => _timeSinceStart.TotalMicrosecondsAsLong;
     }
 }

--- a/GameWorld/View3D/Animation/AnimationSampler.cs
+++ b/GameWorld/View3D/Animation/AnimationSampler.cs
@@ -175,7 +175,9 @@ namespace GameWorld.Core.Animation
                         frameIterpolation = (float)(samplePosition - frameIndex);
                     }
                 }
-                var currentTimeSeconds = animationClip == null ? 0 : clampedT * animationClip.PlayTimeInSec;
+                var currentTimeSeconds = animationClip == null
+                    ? 0
+                    : clampedT * (float)animationClip.Duration.TotalSeconds;
                 return Sample(frameIndex, frameIterpolation, skeleton, animationClip, animationChangeRules, freezeFrame, currentTimeSeconds);
             }
             catch (Exception e)

--- a/Shared/GameFiles/Animation/AnimationTimebase.cs
+++ b/Shared/GameFiles/Animation/AnimationTimebase.cs
@@ -19,6 +19,62 @@
 
         public double FramesPerSecond => FrameCount / Duration.TotalSeconds;
 
+        public TimeSpan SampleDuration => TimeSpan.FromTicks(
+            Math.Max(1, Duration.Ticks / FrameCount));
+
+        public static AnimationTimebase FromFramesPerSecond(
+            int frameCount,
+            double framesPerSecond)
+        {
+            if (frameCount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(frameCount));
+            if (!double.IsFinite(framesPerSecond) || framesPerSecond <= 0)
+                throw new ArgumentOutOfRangeException(nameof(framesPerSecond));
+
+            var durationTicks = frameCount *
+                (double)TimeSpan.TicksPerSecond / framesPerSecond;
+            if (!double.IsFinite(durationTicks) ||
+                durationTicks < 1 ||
+                durationTicks > TimeSpan.MaxValue.Ticks)
+            {
+                throw new ArgumentOutOfRangeException(nameof(framesPerSecond));
+            }
+
+            return new AnimationTimebase(
+                frameCount,
+                TimeSpan.FromTicks((long)Math.Round(
+                    durationTicks,
+                    MidpointRounding.AwayFromZero)));
+        }
+
+        public AnimationTimebase WithPlaybackSpeed(double playbackSpeed)
+        {
+            if (!double.IsFinite(playbackSpeed) || playbackSpeed <= 0)
+                throw new ArgumentOutOfRangeException(nameof(playbackSpeed));
+
+            var scaledTicks = Duration.Ticks / playbackSpeed;
+            if (!double.IsFinite(scaledTicks) ||
+                scaledTicks < 1 ||
+                scaledTicks > TimeSpan.MaxValue.Ticks)
+            {
+                throw new ArgumentOutOfRangeException(nameof(playbackSpeed));
+            }
+
+            var scaledDuration = TimeSpan.FromTicks((long)Math.Round(
+                scaledTicks,
+                MidpointRounding.AwayFromZero));
+            var scaledFrameCount = (decimal)FrameCount *
+                scaledDuration.Ticks / Duration.Ticks;
+            if (scaledFrameCount > int.MaxValue)
+                throw new ArgumentOutOfRangeException(nameof(playbackSpeed));
+
+            return new AnimationTimebase(
+                Math.Max(1, (int)Math.Round(
+                    scaledFrameCount,
+                    MidpointRounding.AwayFromZero)),
+                scaledDuration);
+        }
+
         public TimeSpan GetSampleTime(int frameIndex)
         {
             if (frameIndex < 0 || frameIndex >= FrameCount)

--- a/Testing/AssetEditorTests/AnimationKeyframeEditorSaveTests.cs
+++ b/Testing/AssetEditorTests/AnimationKeyframeEditorSaveTests.cs
@@ -118,7 +118,7 @@ namespace AssetEditorTests
 
             var clip = new AnimationClip();
             clip.DynamicFrames.Add(frame);
-            clip.PlayTimeInSec = 0.05f;
+            clip.Duration = TimeSpan.FromSeconds(0.05);
             return clip;
         }
 

--- a/Testing/AssetEditorTests/CampaignAnimationCreatorCommandTests.cs
+++ b/Testing/AssetEditorTests/CampaignAnimationCreatorCommandTests.cs
@@ -171,7 +171,7 @@ namespace AssetEditorTests
             Assert.IsTrue(result);
             Assert.IsNotNull(convertedAnimation);
             Assert.AreNotSame(sourceAnimation, convertedAnimation);
-            Assert.AreEqual(sourceAnimation.PlayTimeInSec, convertedAnimation.PlayTimeInSec);
+            Assert.AreEqual(sourceAnimation.Duration, convertedAnimation.Duration);
             Assert.AreEqual(sourceAnimation.DynamicFrames.Count, convertedAnimation.DynamicFrames.Count);
             dialogs.Verify(x => x.ShowDialogBox(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
@@ -296,7 +296,7 @@ namespace AssetEditorTests
             CollectionAssert.AreEqual(skeleton.BoneNames, savedAnimation.Bones.Select(x => x.Name).ToList());
             Assert.AreEqual(animationClip.DynamicFrames.Count, savedAnimation.AnimationParts[0].DynamicFrames.Count);
             Assert.AreEqual(
-                animationClip.PlayTimeInSec,
+                (float)animationClip.Duration.TotalSeconds,
                 savedAnimation.Header.AnimationTotalPlayTimeInSec,
                 0.001f);
 
@@ -351,7 +351,7 @@ namespace AssetEditorTests
 
         private static AnimationClip CreateAnimationClip(int boneCount = 2, int frameCount = 2)
         {
-            var clip = new AnimationClip { PlayTimeInSec = 0.2f };
+            var clip = new AnimationClip { Duration = TimeSpan.FromSeconds(0.2) };
             for (var frameIndex = 0; frameIndex < frameCount; frameIndex++)
             {
                 var frame = new AnimationClip.KeyFrame();

--- a/Testing/GameWorld.Core.Test/Animation/AnimationCoreTimeContractTests.cs
+++ b/Testing/GameWorld.Core.Test/Animation/AnimationCoreTimeContractTests.cs
@@ -41,7 +41,7 @@ internal class AnimationCoreTimeContractTests
         {
             Assert.That(player.FramesPerSecond, Is.EqualTo(70.0 / 3.0).Within(0.000001));
             Assert.That(player.CurrentFrame, Is.Zero);
-            Assert.That(player.GetTimeUs(), Is.Zero);
+            Assert.That(player.CurrentTime, Is.EqualTo(TimeSpan.Zero));
         });
 
         player.LoopAnimation = false;
@@ -53,7 +53,7 @@ internal class AnimationCoreTimeContractTests
         Assert.Multiple(() =>
         {
             Assert.That(player.CurrentFrame, Is.EqualTo(6));
-            Assert.That(player.GetTimeUs(), Is.EqualTo(300_000));
+            Assert.That(player.CurrentTime, Is.EqualTo(TimeSpan.FromMilliseconds(300)));
             Assert.That(player.IsPlaying, Is.False);
         });
     }
@@ -69,6 +69,40 @@ internal class AnimationCoreTimeContractTests
         player.CurrentFrame = 1;
 
         Assert.That(player.CurrentFrame, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Timebase_FromFramesPerSecond_PreservesHalfOpenDuration()
+    {
+        var timebase = AnimationTimebase.FromFramesPerSecond(
+            7,
+            70.0 / 3.0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(timebase.Duration, Is.EqualTo(TimeSpan.FromMilliseconds(300)));
+            Assert.That(timebase.SampleDuration, Is.EqualTo(TimeSpan.FromTicks(428_571)));
+            Assert.That(timebase.GetSampleTime(6), Is.LessThan(timebase.Duration));
+        });
+    }
+
+    [Test]
+    public void Player_ExposesUnifiedTimebaseState()
+    {
+        var player = new AnimationPlayer();
+        var skeleton = CreateSkeleton(player);
+        var clip = CreateClip(frameCount: 7, durationSeconds: 0.3f);
+        player.SetAnimation(clip, skeleton);
+
+        player.SeekToTimeSeconds(0.15f);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(player.CurrentTime, Is.EqualTo(TimeSpan.FromMilliseconds(150)));
+            Assert.That(player.Duration, Is.EqualTo(TimeSpan.FromMilliseconds(300)));
+            Assert.That(player.FrameCount, Is.EqualTo(7));
+            Assert.That(player.FramesPerSecond, Is.EqualTo(70.0 / 3.0).Within(0.000001));
+        });
     }
 
     [Test]
@@ -96,7 +130,7 @@ internal class AnimationCoreTimeContractTests
             skeleton,
             clip,
             newFrameCount: 1,
-            playTime: 0.3f);
+            duration: TimeSpan.FromSeconds(0.3));
 
         Assert.Multiple(() =>
         {
@@ -116,18 +150,18 @@ internal class AnimationCoreTimeContractTests
     {
         var player = new AnimationPlayer();
         var skeleton = CreateSkeleton(player);
-        var clip = new AnimationClip { PlayTimeInSec = 1 };
+        var clip = new AnimationClip { Duration = TimeSpan.FromSeconds(1) };
 
         var result = global::GameWorld.Core.Animation.AnimationEditor.ReSample(
             skeleton,
             clip,
             newFrameCount: 4,
-            playTime: 0.3f);
+            duration: TimeSpan.FromSeconds(0.3));
 
         Assert.Multiple(() =>
         {
             Assert.That(result.DynamicFrames, Is.Empty);
-            Assert.That(result.PlayTimeInSec, Is.EqualTo(0.3f));
+            Assert.That(result.Duration, Is.EqualTo(TimeSpan.FromSeconds(0.3)));
             Assert.That(result.Timebase, Is.Null);
         });
     }
@@ -143,7 +177,7 @@ internal class AnimationCoreTimeContractTests
             skeleton,
             clip,
             newFrameCount: 4,
-            playTime: 1);
+            duration: TimeSpan.FromSeconds(1));
 
         Assert.That(
             result.DynamicFrames.Select(frame => frame.Position[0].X),
@@ -192,7 +226,7 @@ internal class AnimationCoreTimeContractTests
             });
         }
 
-        clip.PlayTimeInSec = durationSeconds;
+        clip.Duration = TimeSpan.FromSeconds(durationSeconds);
         return clip;
     }
 

--- a/Testing/GameWorld.Core.Test/Animation/AnimationSamplerRuleTimeTests.cs
+++ b/Testing/GameWorld.Core.Test/Animation/AnimationSamplerRuleTimeTests.cs
@@ -13,7 +13,7 @@ internal class AnimationSamplerRuleTimeTests
     {
         var skeleton = CreateSkeleton();
         var clip = AnimationClip.CreateSkeletonAnimation(skeleton);
-        clip.PlayTimeInSec = 2;
+        clip.Duration = TimeSpan.FromSeconds(2);
         var rule = new RecordingWorldSpaceRule();
 
         AnimationSampler.Sample(0.25f, skeleton, clip, [rule]);

--- a/Testing/GameWorld.Core.Test/Animation/MeshPoseSnapshotTests.cs
+++ b/Testing/GameWorld.Core.Test/Animation/MeshPoseSnapshotTests.cs
@@ -798,7 +798,7 @@ public class MeshPoseSnapshotTests
                 Rotation = [Quaternion.Identity],
                 Scale = [Vector3.One]
             });
-        clip.PlayTimeInSec = 1;
+        clip.Duration = TimeSpan.FromSeconds(1);
         player.SetAnimation(clip, skeleton);
         player.IsEnabled = true;
         player.Pause();

--- a/Testing/GameWorld.Core.Test/Services/FocusSelectableObjectServiceTests.cs
+++ b/Testing/GameWorld.Core.Test/Services/FocusSelectableObjectServiceTests.cs
@@ -111,7 +111,7 @@ public class FocusSelectableObjectServiceTests
             Rotation = [Quaternion.Identity],
             Scale = [Vector3.One]
         });
-        animation.PlayTimeInSec = 1;
+        animation.Duration = TimeSpan.FromSeconds(1);
         player.SetAnimation(animation, skeleton);
         player.IsEnabled = true;
         player.Pause();

--- a/Testing/GameWorld.Core.Test/Utility/SkeletonBoneAnimationResolverTests.cs
+++ b/Testing/GameWorld.Core.Test/Utility/SkeletonBoneAnimationResolverTests.cs
@@ -203,7 +203,7 @@ namespace Testing.GameWorld.Core.Utility
                     animatedChildScale
                 ]
             });
-            clip.PlayTimeInSec = 1;
+            clip.Duration = TimeSpan.FromSeconds(1);
 
             player.SetAnimation(clip, skeleton);
             if (isPlaying)

--- a/docs/superview.md
+++ b/docs/superview.md
@@ -153,7 +153,7 @@
 
 `SceneObject.Update` 以主播放器的当前秒数调用每个 `IMetaDataInstance.Update(currentTimeSeconds)`。动画 Prop 的附属播放器也必须与主时间同步；主播放器暂停时仍要在显式 seek 后刷新附属 pose。
 
-时间单位是秒。不要在 UI、元数据或动画播放器之间隐式混用微秒、帧序号和秒；只有动画 clip 的 `MicrosecondsPerFrame` 在边界处换算。
+时间单位是秒。不要在 UI、元数据或动画播放器之间隐式混用微秒、帧序号和秒；播放器通过 `CurrentTime` / `Duration` 暴露时间，逐帧窗口通过动画 clip 的 `Timebase.SampleDuration` 取得。
 
 ## 7. 预览构建原理
 


### PR DESCRIPTION
## 改动摘要

- 将动画播放、预览、重采样、导入导出、重定向和 META 调用方统一到 AnimationTimebase / TimeSpan 契约
- 删除运行时旧微秒时间接口和冲突帧率公式，文件格式字段仅保留在序列化边界
- 补充非整数帧率、冲突头帧率、变速重采样与 META 瞬时可见性的回归测试
- 修正相关中文错误提示和 SuperView 时间契约文档

## 验证

- dotnet restore AssetEditor.CN.sln --verbosity quiet
- dotnet build AssetEditor.CN.sln --configuration Release --no-restore --verbosity quiet：0 错误
- dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal：1223/1223 通过
- git diff --check 23f39a44020519128c19529dc877d45b1ed4968b...HEAD
- Standards / Spec 双轴审查：0 个未解决问题

Closes #139