### PR TITLE
[动画工作台] 建立工作台文档与安全预览壳

### DIFF
--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchDocument.cs
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchDocument.cs
@@ -1,0 +1,373 @@
+﻿using GameWorld.Core.Animation;
+using Shared.Core.Settings;
+
+namespace Editors.AnimationVisualEditors.AnimationWorkbench;
+
+public enum AnimationWorkbenchPreviewKind
+{
+    AnimationA,
+    AnimationB,
+    Result,
+}
+
+public enum AnimationWorkbenchSourceSlot
+{
+    AnimationA,
+    AnimationB,
+}
+
+public enum AnimationWorkbenchDiagnosticSeverity
+{
+    Information,
+    Warning,
+    Error,
+}
+
+public enum AnimationWorkbenchDiagnosticCode
+{
+    AnimationAMissing,
+    SourceSkeletonBoneCountMismatch,
+    TargetGameMissing,
+    TargetGameUnsupported,
+    TargetSkeletonMissing,
+}
+
+public sealed record AnimationWorkbenchSourceInput(
+    string Name,
+    AnimationClip Animation,
+    GameSkeleton Skeleton);
+
+public sealed record AnimationWorkbenchLoadRequest(
+    AnimationWorkbenchSourceInput? AnimationA,
+    AnimationWorkbenchSourceInput? AnimationB,
+    GameTypeEnum? TargetGame,
+    GameSkeleton? TargetSkeleton);
+
+public sealed record AnimationWorkbenchSourceSummary(
+    string Name,
+    int FrameCount,
+    TimeSpan Duration,
+    string SkeletonName,
+    int BoneCount);
+
+public sealed record AnimationWorkbenchSkeletonSummary(
+    string Name,
+    int BoneCount);
+
+public sealed record AnimationWorkbenchDiagnostic(
+    AnimationWorkbenchDiagnosticCode Code,
+    AnimationWorkbenchDiagnosticSeverity Severity,
+    AnimationWorkbenchSourceSlot? Source = null,
+    int? ExpectedValue = null,
+    int? ActualValue = null);
+
+public interface IAnimationWorkbenchPreviewHost : IDisposable
+{
+    void Show(
+        AnimationWorkbenchPreviewSnapshot preview,
+        CancellationToken cancellationToken);
+
+    void Clear();
+}
+
+public sealed class AnimationWorkbenchPreviewSnapshot
+{
+    internal AnimationWorkbenchPreviewSnapshot(
+        AnimationWorkbenchPreviewKind kind,
+        string name,
+        AnimationClip animation,
+        GameSkeleton skeleton)
+    {
+        Kind = kind;
+        Name = name;
+        Animation = animation;
+        Skeleton = skeleton;
+    }
+
+    public AnimationWorkbenchPreviewKind Kind { get; }
+
+    public string Name { get; }
+
+    public AnimationClip Animation { get; }
+
+    public GameSkeleton Skeleton { get; }
+}
+
+public sealed record AnimationWorkbenchDocumentState(
+    AnimationWorkbenchSourceSummary? AnimationA,
+    AnimationWorkbenchSourceSummary? AnimationB,
+    AnimationWorkbenchSourceSummary? Result,
+    GameTypeEnum? TargetGame,
+    AnimationWorkbenchSkeletonSummary? TargetSkeleton,
+    AnimationWorkbenchPreviewKind? SelectedPreview,
+    AnimationWorkbenchPreviewSnapshot? CurrentPreview,
+    IReadOnlyList<AnimationWorkbenchDiagnostic> Diagnostics,
+    bool IsClosed);
+
+public sealed class AnimationWorkbenchDocument : IDisposable
+{
+    private readonly IAnimationWorkbenchPreviewHost _previewHost;
+    private SourceSnapshot? _animationA;
+    private SourceSnapshot? _animationB;
+    private SourceSnapshot? _result;
+    private GameTypeEnum? _targetGame;
+    private GameSkeleton? _targetSkeleton;
+    private AnimationWorkbenchPreviewKind? _selectedPreview;
+    private CancellationTokenSource? _previewCancellationSource;
+    private bool _isClosed;
+
+    public AnimationWorkbenchDocument(
+        IAnimationWorkbenchPreviewHost? previewHost = null)
+    {
+        _previewHost = previewHost ?? new EmptyPreviewHost();
+    }
+
+    public AnimationWorkbenchDocumentState Load(
+        AnimationWorkbenchLoadRequest request)
+    {
+        ObjectDisposedException.ThrowIf(_isClosed, this);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var animationA = SourceSnapshot.Create(request.AnimationA);
+        var animationB = SourceSnapshot.Create(request.AnimationB);
+        var result = animationA?.Clone();
+        var targetSkeleton = request.TargetSkeleton?.Clone(
+            new AnimationPlayer());
+        AnimationWorkbenchPreviewKind? selectedPreview = animationA == null
+            ? null
+            : AnimationWorkbenchPreviewKind.AnimationA;
+
+        ReleasePreview();
+        _animationA = animationA;
+        _animationB = animationB;
+        _result = result;
+        _targetGame = request.TargetGame;
+        _targetSkeleton = targetSkeleton;
+        _selectedPreview = selectedPreview;
+
+        ShowCurrentPreview();
+
+        return CreateState();
+    }
+
+    public AnimationWorkbenchDocumentState SelectPreview(
+        AnimationWorkbenchPreviewKind kind)
+    {
+        ObjectDisposedException.ThrowIf(_isClosed, this);
+        if (GetSource(kind) != null)
+        {
+            ReleasePreview();
+            _selectedPreview = kind;
+            ShowCurrentPreview();
+        }
+
+        return CreateState();
+    }
+
+    public AnimationWorkbenchDocumentState Close()
+    {
+        if (_isClosed)
+            return CreateState();
+
+        ReleasePreview();
+        _previewHost.Dispose();
+        _animationA = null;
+        _animationB = null;
+        _result = null;
+        _targetGame = null;
+        _targetSkeleton = null;
+        _selectedPreview = null;
+        _isClosed = true;
+
+        return CreateState();
+    }
+
+    public void Dispose() => Close();
+
+    private AnimationWorkbenchDocumentState CreateState()
+    {
+        return new AnimationWorkbenchDocumentState(
+            _animationA?.CreateSummary(),
+            _animationB?.CreateSummary(),
+            _result?.CreateSummary(),
+            _targetGame,
+            _targetSkeleton == null
+                ? null
+                : new AnimationWorkbenchSkeletonSummary(
+                    _targetSkeleton.SkeletonName,
+                    _targetSkeleton.BoneCount),
+            _selectedPreview,
+            CreatePreview(_selectedPreview),
+            CreateDiagnostics(),
+            _isClosed);
+    }
+
+    private IReadOnlyList<AnimationWorkbenchDiagnostic> CreateDiagnostics()
+    {
+        if (_isClosed)
+            return Array.Empty<AnimationWorkbenchDiagnostic>();
+
+        var diagnostics = new List<AnimationWorkbenchDiagnostic>();
+        if (_animationA == null)
+        {
+            diagnostics.Add(new AnimationWorkbenchDiagnostic(
+                AnimationWorkbenchDiagnosticCode.AnimationAMissing,
+                AnimationWorkbenchDiagnosticSeverity.Warning));
+        }
+        else
+        {
+            AddSourceDiagnostics(
+                diagnostics,
+                _animationA,
+                AnimationWorkbenchSourceSlot.AnimationA);
+        }
+
+        if (_animationB != null)
+        {
+            AddSourceDiagnostics(
+                diagnostics,
+                _animationB,
+                AnimationWorkbenchSourceSlot.AnimationB);
+        }
+
+        if (_targetGame == null)
+        {
+            diagnostics.Add(new AnimationWorkbenchDiagnostic(
+                AnimationWorkbenchDiagnosticCode.TargetGameMissing,
+                AnimationWorkbenchDiagnosticSeverity.Warning));
+        }
+        else if (_targetGame != GameTypeEnum.Warhammer3 &&
+                 _targetGame != GameTypeEnum.ThreeKingdoms)
+        {
+            diagnostics.Add(new AnimationWorkbenchDiagnostic(
+                AnimationWorkbenchDiagnosticCode.TargetGameUnsupported,
+                AnimationWorkbenchDiagnosticSeverity.Error));
+        }
+
+        if (_targetSkeleton == null)
+        {
+            diagnostics.Add(new AnimationWorkbenchDiagnostic(
+                AnimationWorkbenchDiagnosticCode.TargetSkeletonMissing,
+                AnimationWorkbenchDiagnosticSeverity.Warning));
+        }
+
+        return diagnostics;
+    }
+
+    private static void AddSourceDiagnostics(
+        ICollection<AnimationWorkbenchDiagnostic> diagnostics,
+        SourceSnapshot source,
+        AnimationWorkbenchSourceSlot slot)
+    {
+        if (source.AnimationBoneCount == source.SkeletonBoneCount)
+            return;
+
+        diagnostics.Add(new AnimationWorkbenchDiagnostic(
+            AnimationWorkbenchDiagnosticCode.SourceSkeletonBoneCountMismatch,
+            AnimationWorkbenchDiagnosticSeverity.Error,
+            slot,
+            source.SkeletonBoneCount,
+            source.AnimationBoneCount));
+    }
+
+    private AnimationWorkbenchPreviewSnapshot? CreatePreview(
+        AnimationWorkbenchPreviewKind? kind)
+    {
+        var source = kind == null ? null : GetSource(kind.Value);
+
+        return source?.CreatePreview(kind!.Value);
+    }
+
+    private SourceSnapshot? GetSource(AnimationWorkbenchPreviewKind kind) =>
+        kind switch
+        {
+            AnimationWorkbenchPreviewKind.AnimationA => _animationA,
+            AnimationWorkbenchPreviewKind.AnimationB => _animationB,
+            AnimationWorkbenchPreviewKind.Result => _result,
+            _ => null,
+        };
+
+    private void ShowCurrentPreview()
+    {
+        var preview = CreatePreview(_selectedPreview);
+        if (preview == null)
+            return;
+
+        _previewCancellationSource = new CancellationTokenSource();
+        _previewHost.Show(
+            preview,
+            _previewCancellationSource.Token);
+    }
+
+    private void ReleasePreview()
+    {
+        var cancellationSource = Interlocked.Exchange(
+            ref _previewCancellationSource,
+            null);
+        cancellationSource?.Cancel();
+        cancellationSource?.Dispose();
+        _previewHost.Clear();
+    }
+
+    private sealed class SourceSnapshot(
+        string name,
+        AnimationClip animation,
+        GameSkeleton skeleton)
+    {
+        public int AnimationBoneCount => animation.AnimationBoneCount;
+
+        public int SkeletonBoneCount => skeleton.BoneCount;
+
+        public static SourceSnapshot? Create(
+            AnimationWorkbenchSourceInput? input)
+        {
+            if (input == null)
+                return null;
+
+            ArgumentException.ThrowIfNullOrWhiteSpace(input.Name);
+            ArgumentNullException.ThrowIfNull(input.Animation);
+            ArgumentNullException.ThrowIfNull(input.Skeleton);
+
+            return new SourceSnapshot(
+                input.Name,
+                input.Animation.Clone(),
+                input.Skeleton.Clone(new AnimationPlayer()));
+        }
+
+        public SourceSnapshot Clone() => new(
+            name,
+            animation.Clone(),
+            skeleton.Clone(new AnimationPlayer()));
+
+        public AnimationWorkbenchSourceSummary CreateSummary() => new(
+            name,
+            animation.DynamicFrames.Count,
+            animation.Duration,
+            skeleton.SkeletonName,
+            skeleton.BoneCount);
+
+        public AnimationWorkbenchPreviewSnapshot CreatePreview(
+            AnimationWorkbenchPreviewKind kind) => new(
+                kind,
+                name,
+                animation.Clone(),
+                skeleton.Clone(new AnimationPlayer()));
+    }
+
+    private sealed class EmptyPreviewHost : IAnimationWorkbenchPreviewHost
+    {
+        public void Show(
+            AnimationWorkbenchPreviewSnapshot preview,
+            CancellationToken cancellationToken)
+        {
+        }
+
+        public void Clear()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchDocument.cs
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchDocument.cs
@@ -18,7 +18,6 @@ public enum AnimationWorkbenchSourceSlot
 
 public enum AnimationWorkbenchDiagnosticSeverity
 {
-    Information,
     Warning,
     Error,
 }
@@ -63,11 +62,13 @@ public sealed record AnimationWorkbenchDiagnostic(
 
 public interface IAnimationWorkbenchPreviewHost : IDisposable
 {
-    void Show(
+    /// <summary>
+    /// Creates a preview session that owns its player, scene nodes, and event
+    /// subscriptions. Disposing the session must release all of them.
+    /// </summary>
+    IDisposable Show(
         AnimationWorkbenchPreviewSnapshot preview,
         CancellationToken cancellationToken);
-
-    void Clear();
 }
 
 public sealed class AnimationWorkbenchPreviewSnapshot
@@ -114,6 +115,7 @@ public sealed class AnimationWorkbenchDocument : IDisposable
     private GameSkeleton? _targetSkeleton;
     private AnimationWorkbenchPreviewKind? _selectedPreview;
     private CancellationTokenSource? _previewCancellationSource;
+    private IDisposable? _previewSession;
     private bool _isClosed;
 
     public AnimationWorkbenchDocument(
@@ -293,10 +295,21 @@ public sealed class AnimationWorkbenchDocument : IDisposable
         if (preview == null)
             return;
 
-        _previewCancellationSource = new CancellationTokenSource();
-        _previewHost.Show(
-            preview,
-            _previewCancellationSource.Token);
+        var cancellationSource = new CancellationTokenSource();
+        try
+        {
+            var previewSession = _previewHost.Show(
+                preview,
+                cancellationSource.Token);
+            _previewCancellationSource = cancellationSource;
+            _previewSession = previewSession;
+        }
+        catch
+        {
+            cancellationSource.Cancel();
+            cancellationSource.Dispose();
+            throw;
+        }
     }
 
     private void ReleasePreview()
@@ -304,9 +317,25 @@ public sealed class AnimationWorkbenchDocument : IDisposable
         var cancellationSource = Interlocked.Exchange(
             ref _previewCancellationSource,
             null);
-        cancellationSource?.Cancel();
-        cancellationSource?.Dispose();
-        _previewHost.Clear();
+        var previewSession = Interlocked.Exchange(
+            ref _previewSession,
+            null);
+
+        try
+        {
+            cancellationSource?.Cancel();
+        }
+        finally
+        {
+            try
+            {
+                previewSession?.Dispose();
+            }
+            finally
+            {
+                cancellationSource?.Dispose();
+            }
+        }
     }
 
     private sealed class SourceSnapshot(
@@ -356,15 +385,21 @@ public sealed class AnimationWorkbenchDocument : IDisposable
 
     private sealed class EmptyPreviewHost : IAnimationWorkbenchPreviewHost
     {
-        public void Show(
+        public IDisposable Show(
             AnimationWorkbenchPreviewSnapshot preview,
             CancellationToken cancellationToken)
         {
+            return EmptyPreviewSession.Instance;
         }
 
-        public void Clear()
+        public void Dispose()
         {
         }
+    }
+
+    private sealed class EmptyPreviewSession : IDisposable
+    {
+        public static EmptyPreviewSession Instance { get; } = new();
 
         public void Dispose()
         {

--- a/GameWorld/View3D/Animation/GameSkeleton.cs
+++ b/GameWorld/View3D/Animation/GameSkeleton.cs
@@ -206,6 +206,16 @@ namespace GameWorld.Core.Animation
             return clone;
         }
 
+        public GameSkeleton Clone(AnimationPlayer animationPlayer)
+        {
+            ArgumentNullException.ThrowIfNull(animationPlayer);
+
+            var clone = Clone();
+            clone.AnimationPlayer = animationPlayer;
+            clone._frame = null;
+            return clone;
+        }
+
 
         public void Update()
         {

--- a/Testing/AssetEditorTests/AnimationWorkbenchDocumentTests.cs
+++ b/Testing/AssetEditorTests/AnimationWorkbenchDocumentTests.cs
@@ -1,0 +1,376 @@
+﻿using Editors.AnimationVisualEditors.AnimationWorkbench;
+using GameWorld.Core.Animation;
+using Microsoft.Xna.Framework;
+using Shared.Core.Settings;
+using Shared.GameFormats.Animation;
+using Shared.GameFormats.RigidModel.Transforms;
+
+namespace AssetEditorTests;
+
+[TestClass]
+public class AnimationWorkbenchDocumentTests
+{
+    [TestMethod]
+    public void Load_WithAnimationAAndCompleteTarget_ReturnsReadyPreviewState()
+    {
+        using var document = new AnimationWorkbenchDocument();
+        var sourceSkeleton = CreateSkeleton("source_skeleton", "root");
+        var targetSkeleton = CreateSkeleton("target_skeleton", "root");
+
+        var state = document.Load(new AnimationWorkbenchLoadRequest(
+            new AnimationWorkbenchSourceInput(
+                "animation_a",
+                CreateClip(new Vector3(1, 2, 3)),
+                sourceSkeleton),
+            null,
+            GameTypeEnum.Warhammer3,
+            targetSkeleton));
+
+        Assert.AreEqual("animation_a", state.AnimationA?.Name);
+        Assert.AreEqual(1, state.AnimationA?.FrameCount);
+        Assert.AreEqual(GameTypeEnum.Warhammer3, state.TargetGame);
+        Assert.AreEqual("target_skeleton", state.TargetSkeleton?.Name);
+        Assert.AreEqual(AnimationWorkbenchPreviewKind.AnimationA, state.SelectedPreview);
+        Assert.IsNotNull(state.CurrentPreview);
+        Assert.AreEqual(0, state.Diagnostics.Count);
+    }
+
+    [TestMethod]
+    public void Load_WithoutRequiredTarget_ReturnsStructuredDiagnostics()
+    {
+        using var document = new AnimationWorkbenchDocument();
+        var sourceSkeleton = CreateSkeleton("source_skeleton", "root");
+
+        var state = document.Load(new AnimationWorkbenchLoadRequest(
+            new AnimationWorkbenchSourceInput(
+                "animation_a",
+                CreateClip(Vector3.Zero),
+                sourceSkeleton),
+            null,
+            null,
+            null));
+
+        CollectionAssert.AreEquivalent(
+            new[]
+            {
+                AnimationWorkbenchDiagnosticCode.TargetGameMissing,
+                AnimationWorkbenchDiagnosticCode.TargetSkeletonMissing,
+            },
+            state.Diagnostics.Select(diagnostic => diagnostic.Code).ToArray());
+        Assert.IsTrue(state.Diagnostics.All(
+            diagnostic =>
+                diagnostic.Severity ==
+                AnimationWorkbenchDiagnosticSeverity.Warning));
+    }
+
+    [TestMethod]
+    public void Load_WithUnsupportedTargetGame_ReturnsErrorDiagnostic()
+    {
+        using var document = new AnimationWorkbenchDocument();
+        var skeleton = CreateSkeleton("source_skeleton", "root");
+
+        var state = document.Load(new AnimationWorkbenchLoadRequest(
+            new AnimationWorkbenchSourceInput(
+                "animation_a",
+                CreateClip(Vector3.Zero),
+                skeleton),
+            null,
+            GameTypeEnum.Rome2,
+            skeleton));
+
+        Assert.AreEqual(1, state.Diagnostics.Count);
+        var diagnostic = state.Diagnostics[0];
+        Assert.AreEqual(
+            AnimationWorkbenchDiagnosticCode.TargetGameUnsupported,
+            diagnostic.Code);
+        Assert.AreEqual(
+            AnimationWorkbenchDiagnosticSeverity.Error,
+            diagnostic.Severity);
+    }
+
+    [TestMethod]
+    public void Load_WithoutAnimationA_ReturnsMissingSourceDiagnostic()
+    {
+        using var document = new AnimationWorkbenchDocument();
+        var targetSkeleton = CreateSkeleton("target_skeleton", "root");
+
+        var state = document.Load(new AnimationWorkbenchLoadRequest(
+            null,
+            null,
+            GameTypeEnum.Warhammer3,
+            targetSkeleton));
+
+        Assert.AreEqual(1, state.Diagnostics.Count);
+        Assert.AreEqual(
+            AnimationWorkbenchDiagnosticCode.AnimationAMissing,
+            state.Diagnostics[0].Code);
+        Assert.AreEqual(
+            AnimationWorkbenchDiagnosticSeverity.Warning,
+            state.Diagnostics[0].Severity);
+        Assert.IsNull(state.SelectedPreview);
+        Assert.IsNull(state.CurrentPreview);
+        Assert.IsNull(state.Result);
+    }
+
+    [TestMethod]
+    public void Load_WithSourceBoneCountMismatch_ReturnsSourceErrorDiagnostic()
+    {
+        using var document = new AnimationWorkbenchDocument();
+        var skeleton = CreateSkeleton("source_skeleton", "root");
+
+        var state = document.Load(new AnimationWorkbenchLoadRequest(
+            new AnimationWorkbenchSourceInput(
+                "animation_a",
+                CreateClip(Vector3.Zero, Vector3.One),
+                skeleton),
+            null,
+            GameTypeEnum.Warhammer3,
+            skeleton));
+
+        Assert.AreEqual(1, state.Diagnostics.Count);
+        var diagnostic = state.Diagnostics[0];
+        Assert.AreEqual(
+            AnimationWorkbenchDiagnosticCode.SourceSkeletonBoneCountMismatch,
+            diagnostic.Code);
+        Assert.AreEqual(
+            AnimationWorkbenchDiagnosticSeverity.Error,
+            diagnostic.Severity);
+        Assert.AreEqual(AnimationWorkbenchSourceSlot.AnimationA, diagnostic.Source);
+        Assert.AreEqual(1, diagnostic.ExpectedValue);
+        Assert.AreEqual(2, diagnostic.ActualValue);
+    }
+
+    [TestMethod]
+    public void SelectPreview_ReturnsIndependentAnimationAAnimationBAndResult()
+    {
+        using var document = new AnimationWorkbenchDocument();
+        var skeleton = CreateSkeleton("source_skeleton", "root");
+        var animationA = CreateClip(new Vector3(10, 0, 0));
+        var animationB = CreateClip(new Vector3(20, 0, 0));
+
+        document.Load(new AnimationWorkbenchLoadRequest(
+            new AnimationWorkbenchSourceInput(
+                "animation_a",
+                animationA,
+                skeleton),
+            new AnimationWorkbenchSourceInput(
+                "animation_b",
+                animationB,
+                skeleton),
+            GameTypeEnum.ThreeKingdoms,
+            skeleton));
+
+        animationA.DynamicFrames[0].Position[0] = new Vector3(99, 0, 0);
+        skeleton.BoneNames[0] = "changed_root";
+
+        var previewA = document.SelectPreview(
+            AnimationWorkbenchPreviewKind.AnimationA).CurrentPreview!;
+        var previewB = document.SelectPreview(
+            AnimationWorkbenchPreviewKind.AnimationB).CurrentPreview!;
+        previewB.Animation.DynamicFrames[0].Position[0] =
+            new Vector3(88, 0, 0);
+        previewB.Skeleton.BoneNames[0] = "changed_preview_root";
+        var previewBAgain = document.SelectPreview(
+            AnimationWorkbenchPreviewKind.AnimationB).CurrentPreview!;
+        var result = document.SelectPreview(
+            AnimationWorkbenchPreviewKind.Result).CurrentPreview!;
+
+        Assert.AreEqual(10, previewA.Animation.DynamicFrames[0].Position[0].X);
+        Assert.AreEqual("root", previewA.Skeleton.BoneNames[0]);
+        Assert.AreNotSame(
+            skeleton.AnimationPlayer,
+            previewA.Skeleton.AnimationPlayer);
+        Assert.AreEqual(20, previewBAgain.Animation.DynamicFrames[0].Position[0].X);
+        Assert.AreEqual("root", previewBAgain.Skeleton.BoneNames[0]);
+        Assert.AreEqual(10, result.Animation.DynamicFrames[0].Position[0].X);
+        Assert.AreEqual("root", result.Skeleton.BoneNames[0]);
+        Assert.AreNotSame(
+            previewA.Skeleton.AnimationPlayer,
+            result.Skeleton.AnimationPlayer);
+    }
+
+    [TestMethod]
+    public void ReloadAndClose_CancelPendingPreviewAndReleasePreviewHost()
+    {
+        var previewHost = new RecordingPreviewHost();
+        var document = new AnimationWorkbenchDocument(previewHost);
+        var skeleton = CreateSkeleton("source_skeleton", "root");
+        var request = new AnimationWorkbenchLoadRequest(
+            new AnimationWorkbenchSourceInput(
+                "animation_a",
+                CreateClip(new Vector3(1, 0, 0)),
+                skeleton),
+            new AnimationWorkbenchSourceInput(
+                "animation_b",
+                CreateClip(new Vector3(2, 0, 0)),
+                skeleton),
+            GameTypeEnum.Warhammer3,
+            skeleton);
+
+        document.Load(request);
+        var loadToken = previewHost.CurrentCancellationToken;
+
+        document.SelectPreview(AnimationWorkbenchPreviewKind.AnimationB);
+        var selectionToken = previewHost.CurrentCancellationToken;
+
+        Assert.IsTrue(loadToken.IsCancellationRequested);
+        Assert.AreEqual(
+            AnimationWorkbenchPreviewKind.AnimationB,
+            previewHost.CurrentPreview?.Kind);
+
+        var replacementSourceSkeleton = CreateSkeleton(
+            "replacement_source_skeleton",
+            "replacement_root");
+        var replacementTargetSkeleton = CreateSkeleton(
+            "replacement_target_skeleton",
+            "replacement_root");
+        var replacementRequest = new AnimationWorkbenchLoadRequest(
+            new AnimationWorkbenchSourceInput(
+                "replacement_animation_a",
+                CreateClip(new Vector3(3, 0, 0)),
+                replacementSourceSkeleton),
+            null,
+            GameTypeEnum.ThreeKingdoms,
+            replacementTargetSkeleton);
+
+        var reloadedState = document.Load(replacementRequest);
+        var reloadToken = previewHost.CurrentCancellationToken;
+
+        Assert.IsTrue(selectionToken.IsCancellationRequested);
+        Assert.AreEqual("replacement_animation_a", reloadedState.AnimationA?.Name);
+        Assert.IsNull(reloadedState.AnimationB);
+        Assert.AreEqual(
+            GameTypeEnum.ThreeKingdoms,
+            reloadedState.TargetGame);
+        Assert.AreEqual(
+            "replacement_target_skeleton",
+            reloadedState.TargetSkeleton?.Name);
+        Assert.AreEqual(
+            "replacement_animation_a",
+            reloadedState.Result?.Name);
+        Assert.AreEqual(
+            AnimationWorkbenchPreviewKind.AnimationA,
+            previewHost.CurrentPreview?.Kind);
+
+        var closedState = document.Close();
+
+        Assert.IsTrue(reloadToken.IsCancellationRequested);
+        Assert.IsTrue(previewHost.IsDisposed);
+        Assert.IsNull(previewHost.CurrentPreview);
+        Assert.IsTrue(closedState.IsClosed);
+        Assert.IsNull(closedState.CurrentPreview);
+        Assert.AreEqual(0, closedState.Diagnostics.Count);
+    }
+
+    [TestMethod]
+    public void Load_WhenReplacementCannotBePrepared_KeepsCurrentPreviewActive()
+    {
+        var previewHost = new RecordingPreviewHost();
+        using var document = new AnimationWorkbenchDocument(previewHost);
+        var skeleton = CreateSkeleton("source_skeleton", "root");
+        document.Load(new AnimationWorkbenchLoadRequest(
+            new AnimationWorkbenchSourceInput(
+                "animation_a",
+                CreateClip(Vector3.Zero),
+                skeleton),
+            null,
+            GameTypeEnum.Warhammer3,
+            skeleton));
+        var currentToken = previewHost.CurrentCancellationToken;
+
+        Assert.ThrowsException<ArgumentException>(() =>
+            document.Load(new AnimationWorkbenchLoadRequest(
+                new AnimationWorkbenchSourceInput(
+                    " ",
+                    CreateClip(Vector3.One),
+                    skeleton),
+                null,
+                GameTypeEnum.ThreeKingdoms,
+                skeleton)));
+
+        Assert.IsFalse(currentToken.IsCancellationRequested);
+        Assert.AreEqual("animation_a", previewHost.CurrentPreview?.Name);
+        Assert.AreEqual(
+            GameTypeEnum.Warhammer3,
+            document.SelectPreview(
+                AnimationWorkbenchPreviewKind.AnimationA).TargetGame);
+    }
+
+    private static AnimationClip CreateClip(params Vector3[] positions)
+    {
+        var frame = new AnimationClip.KeyFrame();
+        foreach (var position in positions)
+        {
+            frame.Position.Add(position);
+            frame.Rotation.Add(Quaternion.Identity);
+            frame.Scale.Add(Vector3.One);
+        }
+
+        var clip = new AnimationClip
+        {
+            Duration = TimeSpan.FromSeconds(0.05),
+        };
+        clip.DynamicFrames.Add(frame);
+        return clip;
+    }
+
+    private static GameSkeleton CreateSkeleton(
+        string skeletonName,
+        string boneName)
+    {
+        var skeletonFile = new AnimationFile
+        {
+            Header = new AnimationFile.AnimationHeader
+            {
+                SkeletonName = skeletonName,
+            },
+            Bones =
+            [
+                new AnimationFile.BoneInfo
+                {
+                    Id = 0,
+                    Name = boneName,
+                    ParentId = AnimationFile.BoneIndexNoParent,
+                },
+            ],
+        };
+
+        var frame = new AnimationFile.Frame();
+        frame.Transforms.Add(new RmvVector3());
+        frame.Quaternion.Add(new RmvVector4(0, 0, 0, 1));
+
+        var part = new AnimationFile.AnimationPart();
+        part.DynamicFrames.Add(frame);
+        skeletonFile.AnimationParts.Add(part);
+
+        return new GameSkeleton(skeletonFile, new AnimationPlayer());
+    }
+
+    private sealed class RecordingPreviewHost : IAnimationWorkbenchPreviewHost
+    {
+        public AnimationWorkbenchPreviewSnapshot? CurrentPreview { get; private set; }
+
+        public CancellationToken CurrentCancellationToken { get; private set; }
+
+        public bool IsDisposed { get; private set; }
+
+        public void Show(
+            AnimationWorkbenchPreviewSnapshot preview,
+            CancellationToken cancellationToken)
+        {
+            CurrentPreview = preview;
+            CurrentCancellationToken = cancellationToken;
+        }
+
+        public void Clear()
+        {
+            CurrentPreview = null;
+        }
+
+        public void Dispose()
+        {
+            Clear();
+            IsDisposed = true;
+        }
+    }
+}

--- a/Testing/AssetEditorTests/AnimationWorkbenchDocumentTests.cs
+++ b/Testing/AssetEditorTests/AnimationWorkbenchDocumentTests.cs
@@ -209,11 +209,14 @@ public class AnimationWorkbenchDocumentTests
 
         document.Load(request);
         var loadToken = previewHost.CurrentCancellationToken;
+        var loadSession = previewHost.CurrentSession;
 
         document.SelectPreview(AnimationWorkbenchPreviewKind.AnimationB);
         var selectionToken = previewHost.CurrentCancellationToken;
+        var selectionSession = previewHost.CurrentSession;
 
         Assert.IsTrue(loadToken.IsCancellationRequested);
+        Assert.IsTrue(previewHost.IsSessionDisposed(loadSession));
         Assert.AreEqual(
             AnimationWorkbenchPreviewKind.AnimationB,
             previewHost.CurrentPreview?.Kind);
@@ -235,8 +238,10 @@ public class AnimationWorkbenchDocumentTests
 
         var reloadedState = document.Load(replacementRequest);
         var reloadToken = previewHost.CurrentCancellationToken;
+        var reloadSession = previewHost.CurrentSession;
 
         Assert.IsTrue(selectionToken.IsCancellationRequested);
+        Assert.IsTrue(previewHost.IsSessionDisposed(selectionSession));
         Assert.AreEqual("replacement_animation_a", reloadedState.AnimationA?.Name);
         Assert.IsNull(reloadedState.AnimationB);
         Assert.AreEqual(
@@ -255,6 +260,7 @@ public class AnimationWorkbenchDocumentTests
         var closedState = document.Close();
 
         Assert.IsTrue(reloadToken.IsCancellationRequested);
+        Assert.IsTrue(previewHost.IsSessionDisposed(reloadSession));
         Assert.IsTrue(previewHost.IsDisposed);
         Assert.IsNull(previewHost.CurrentPreview);
         Assert.IsTrue(closedState.IsClosed);
@@ -277,6 +283,7 @@ public class AnimationWorkbenchDocumentTests
             GameTypeEnum.Warhammer3,
             skeleton));
         var currentToken = previewHost.CurrentCancellationToken;
+        var currentSession = previewHost.CurrentSession;
 
         Assert.ThrowsException<ArgumentException>(() =>
             document.Load(new AnimationWorkbenchLoadRequest(
@@ -289,6 +296,7 @@ public class AnimationWorkbenchDocumentTests
                 skeleton)));
 
         Assert.IsFalse(currentToken.IsCancellationRequested);
+        Assert.IsFalse(previewHost.IsSessionDisposed(currentSession));
         Assert.AreEqual("animation_a", previewHost.CurrentPreview?.Name);
         Assert.AreEqual(
             GameTypeEnum.Warhammer3,
@@ -352,25 +360,44 @@ public class AnimationWorkbenchDocumentTests
 
         public CancellationToken CurrentCancellationToken { get; private set; }
 
+        public IDisposable? CurrentSession { get; private set; }
+
         public bool IsDisposed { get; private set; }
 
-        public void Show(
+        public IDisposable Show(
             AnimationWorkbenchPreviewSnapshot preview,
             CancellationToken cancellationToken)
         {
             CurrentPreview = preview;
             CurrentCancellationToken = cancellationToken;
+            CurrentSession = new RecordingPreviewSession(() =>
+            {
+                CurrentPreview = null;
+                CurrentSession = null;
+            });
+            return CurrentSession;
         }
 
-        public void Clear()
-        {
-            CurrentPreview = null;
-        }
+        public bool IsSessionDisposed(IDisposable? session) =>
+            session is RecordingPreviewSession { IsDisposed: true };
 
         public void Dispose()
         {
-            Clear();
             IsDisposed = true;
+        }
+    }
+
+    private sealed class RecordingPreviewSession(Action release) : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose()
+        {
+            if (IsDisposed)
+                return;
+
+            IsDisposed = true;
+            release();
         }
     }
 }


### PR DESCRIPTION
## 变更
- 新增动画工作台文档接缝，加载并替换动画 A、动画 B、目标游戏和目标骨架
- 通过深克隆保护来源，并为结果和每次预览提供独立快照
- 让每个预览会话显式拥有播放器、场景节点和事件订阅；切换、重载、关闭时取消并释放
- 保持旧关键帧编辑器正式入口禁用

## 验证
- `dotnet restore AssetEditor.CN.sln`
- `dotnet build AssetEditor.CN.sln --configuration Release --no-restore`（0 错误）
- `dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal`（1231/1231 通过）
- 两轴代码审查：规范 0 个问题；规格 0 个缺口/膨胀/错误

Closes #140