### PR TITLE
支持原生 V8 动画编辑与保存

### DIFF
--- a/AssetEditor/Language_Cn.json
+++ b/AssetEditor/Language_Cn.json
@@ -1033,7 +1033,6 @@
   "AnimationWorkbench.Diagnostic.TargetSkeletonMissing": "无法继续：尚未选择目标骨架。",
   "AnimationWorkbench.Diagnostic.SourceFormatUnknown": "无法保存：来源动画缺少可验证的格式信息，请重新从文件加载。",
   "AnimationWorkbench.Diagnostic.SourceFormatUnsupported": "无法保存：来源动画的文件版本不受支持。",
-  "AnimationWorkbench.Diagnostic.SourceVersionEightReadOnly": "无法保存：v8 动画目前只允许查看，不能静默转换或写回。",
   "AnimationWorkbench.Diagnostic.SourceMultiplePartsReadOnly": "无法保存：多 Part 动画目前只允许查看，不能静默合并或写回。",
   "AnimationWorkbench.Diagnostic.SourceStaticFrameReadOnly": "无法保存：包含 Static Frame 的来源动画目前只允许查看，不能静默展开为全动态帧。",
   "AnimationWorkbench.Diagnostic.TargetGameSaveUnsupported": "无法保存：当前仅开放经过验证的战锤 3 动画写入。",

--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchCandidateBuilder.cs
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchCandidateBuilder.cs
@@ -40,7 +40,8 @@ internal static class AnimationWorkbenchCandidateBuilder
 
     public static AnimationWorkbenchCandidateBuildResult Build(
         AnimationClip result,
-        GameSkeleton targetSkeleton)
+        GameSkeleton targetSkeleton,
+        AnimationWorkbenchSourceFormat sourceFormat)
     {
         if (!HasCompleteFrames(result, targetSkeleton.BoneCount))
         {
@@ -50,9 +51,14 @@ internal static class AnimationWorkbenchCandidateBuilder
         }
 
         AnimationFile candidate;
+        var outputVersion = sourceFormat.Version == 8 ? 8u : 7u;
         try
         {
-            candidate = result.ConvertToFileFormat(targetSkeleton);
+            candidate = result.ConvertToFileFormat(
+                targetSkeleton,
+                outputVersion,
+                sourceFormat.UnknownValueV8,
+                sourceFormat.FlagVariables);
         }
         catch (Exception)
         {
@@ -63,7 +69,8 @@ internal static class AnimationWorkbenchCandidateBuilder
         if (!MatchesTargetStructure(
                 candidate,
                 result,
-                targetSkeleton))
+                targetSkeleton,
+                outputVersion))
         {
             return AnimationWorkbenchCandidateBuildResult.Failure(
                 AnimationWorkbenchDiagnosticCode.CandidateRoundTripMismatch);
@@ -136,9 +143,10 @@ internal static class AnimationWorkbenchCandidateBuilder
     private static bool MatchesTargetStructure(
         AnimationFile candidate,
         AnimationClip expectedAnimation,
-        GameSkeleton targetSkeleton)
+        GameSkeleton targetSkeleton,
+        uint expectedVersion)
     {
-        if (candidate.Header.Version != 7 ||
+        if (candidate.Header.Version != expectedVersion ||
             candidate.Header.SkeletonName != targetSkeleton.SkeletonName ||
             candidate.Bones == null ||
             candidate.Bones.Length != targetSkeleton.BoneCount ||
@@ -148,9 +156,17 @@ internal static class AnimationWorkbenchCandidateBuilder
         }
 
         var part = candidate.AnimationParts[0];
-        if (part.StaticFrame != null ||
-            part.DynamicFrames.Count !=
-                expectedAnimation.DynamicFrames.Count ||
+        var dynamicTranslationCount = part.TranslationMappings.Count(
+            mapping => mapping.MappingType ==
+                AnimationFile.AnimationBoneMappingType.Dynamic);
+        var dynamicRotationCount = part.RotationMappings.Count(
+            mapping => mapping.MappingType ==
+                AnimationFile.AnimationBoneMappingType.Dynamic);
+        var expectedDynamicFrameCount =
+            dynamicTranslationCount != 0 || dynamicRotationCount != 0
+                ? expectedAnimation.DynamicFrames.Count
+                : 0;
+        if (part.DynamicFrames.Count != expectedDynamicFrameCount ||
             part.TranslationMappings.Count != targetSkeleton.BoneCount ||
             part.RotationMappings.Count != targetSkeleton.BoneCount)
         {
@@ -168,29 +184,61 @@ internal static class AnimationWorkbenchCandidateBuilder
                 bone.Name != targetSkeleton.BoneNames[boneIndex] ||
                 bone.ParentId !=
                     targetSkeleton.GetParentBoneIndex(boneIndex) ||
-                translationMapping.MappingType !=
-                    AnimationFile.AnimationBoneMappingType.Dynamic ||
-                translationMapping.Id != boneIndex ||
-                rotationMapping.MappingType !=
-                    AnimationFile.AnimationBoneMappingType.Dynamic ||
-                rotationMapping.Id != boneIndex)
+                !IsSupportedMapping(translationMapping, expectedVersion, boneIndex) ||
+                !IsSupportedMapping(rotationMapping, expectedVersion, boneIndex))
             {
                 return false;
             }
         }
 
+        var staticTranslationCount = part.TranslationMappings.Count(
+            mapping => mapping.MappingType ==
+                AnimationFile.AnimationBoneMappingType.Static);
+        var staticRotationCount = part.RotationMappings.Count(
+            mapping => mapping.MappingType ==
+                AnimationFile.AnimationBoneMappingType.Static);
+        if (expectedVersion == 7 && part.StaticFrame != null)
+            return false;
+        if (expectedVersion == 8 &&
+            ((staticTranslationCount != 0 || staticRotationCount != 0) !=
+             (part.StaticFrame != null)))
+        {
+            return false;
+        }
+        if (part.StaticFrame != null &&
+            (part.StaticFrame.Transforms.Count != staticTranslationCount ||
+             part.StaticFrame.Quaternion.Count != staticRotationCount))
+        {
+            return false;
+        }
+
         return part.DynamicFrames.All(
             frame =>
-                frame.Transforms.Count == targetSkeleton.BoneCount &&
-                frame.Quaternion.Count == targetSkeleton.BoneCount);
+                frame.Transforms.Count == dynamicTranslationCount &&
+                frame.Quaternion.Count == dynamicRotationCount);
+    }
+
+    private static bool IsSupportedMapping(
+        AnimationFile.AnimationBoneMapping mapping,
+        uint expectedVersion,
+        int boneIndex)
+    {
+        if (expectedVersion == 7)
+        {
+            return mapping.MappingType ==
+                       AnimationFile.AnimationBoneMappingType.Dynamic &&
+                   mapping.Id == boneIndex;
+        }
+
+        return mapping.MappingType !=
+            AnimationFile.AnimationBoneMappingType.None;
     }
 
     private static bool HasEquivalentFileStructure(
         AnimationFile expected,
         AnimationFile actual)
     {
-        if (expected.Header.Version != 7 ||
-            actual.Header.Version != expected.Header.Version ||
+        if (actual.Header.Version != expected.Header.Version ||
             actual.Header.SkeletonName != expected.Header.SkeletonName ||
             MathF.Abs(actual.Header.FrameRate - expected.Header.FrameRate) >
                 VectorTolerance ||
@@ -200,6 +248,7 @@ internal static class AnimationWorkbenchCandidateBuilder
                 VectorTolerance ||
             !actual.Header.FlagVariables.SequenceEqual(
                 expected.Header.FlagVariables) ||
+            actual.Header.UnknownValue_v8 != expected.Header.UnknownValue_v8 ||
             expected.AnimationParts.Count != 1 ||
             actual.AnimationParts.Count != expected.AnimationParts.Count ||
             actual.Bones.Length != expected.Bones.Length)

--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchDocument.cs
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchDocument.cs
@@ -36,7 +36,6 @@ public enum AnimationWorkbenchDiagnosticCode
     TargetSkeletonMissing,
     SourceFormatUnknown,
     SourceFormatUnsupported,
-    SourceVersionEightReadOnly,
     SourceMultiplePartsReadOnly,
     SourceStaticFrameReadOnly,
     TargetGameSaveUnsupported,
@@ -131,7 +130,9 @@ public enum AnimationWorkbenchDiagnosticCode
 public sealed record AnimationWorkbenchSourceFormat(
     uint Version,
     int PartCount,
-    bool HasStaticFrame = false)
+    bool HasStaticFrame = false,
+    uint UnknownValueV8 = 0,
+    IReadOnlyList<string>? FlagVariables = null)
 {
     public static AnimationWorkbenchSourceFormat FromFile(
         AnimationFile file)
@@ -141,7 +142,9 @@ public sealed record AnimationWorkbenchSourceFormat(
             file.Header.Version,
             file.AnimationParts.Count,
             file.AnimationParts.Any(
-                part => part.StaticFrame != null));
+                part => part.StaticFrame != null),
+            file.Header.UnknownValue_v8,
+            file.Header.FlagVariables.ToArray());
     }
 }
 
@@ -590,7 +593,8 @@ public sealed partial class AnimationWorkbenchDocument : IDisposable
 
         return AnimationWorkbenchCandidateBuilder.Build(
             _result!.Animation,
-            _targetSkeleton!);
+            _targetSkeleton!,
+            _animationA!.Format!);
     }
 
     private static void AddSaveSourceDiagnostics(
@@ -629,8 +633,6 @@ public sealed partial class AnimationWorkbenchDocument : IDisposable
                 {
                     AnimationFormatBlockReason.UnsupportedVersion =>
                         AnimationWorkbenchDiagnosticCode.SourceFormatUnsupported,
-                    AnimationFormatBlockReason.VersionEightIsReadOnly =>
-                        AnimationWorkbenchDiagnosticCode.SourceVersionEightReadOnly,
                     AnimationFormatBlockReason.MultiplePartsAreReadOnly =>
                         AnimationWorkbenchDiagnosticCode.SourceMultiplePartsReadOnly,
                     _ => throw new ArgumentOutOfRangeException(
@@ -641,7 +643,7 @@ public sealed partial class AnimationWorkbenchDocument : IDisposable
                 slot));
         }
 
-        if (source.Format.HasStaticFrame)
+        if (source.Format.HasStaticFrame && source.Format.Version != 8)
         {
             diagnostics.Add(CreateSaveDiagnostic(
                 AnimationWorkbenchDiagnosticCode.SourceStaticFrameReadOnly,

--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchViewModel.cs
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchViewModel.cs
@@ -502,14 +502,12 @@ public sealed partial class AnimationWorkbenchViewModel :
             {
                 AnimationFormatBlockReason.UnsupportedVersion =>
                     "AnimationWorkbench.Diagnostic.SourceFormatUnsupported",
-                AnimationFormatBlockReason.VersionEightIsReadOnly =>
-                    "AnimationWorkbench.Diagnostic.SourceVersionEightReadOnly",
                 AnimationFormatBlockReason.MultiplePartsAreReadOnly =>
                     "AnimationWorkbench.Diagnostic.SourceMultiplePartsReadOnly",
                 _ => throw new ArgumentOutOfRangeException(),
             }));
         }
-        if (source.Format.HasStaticFrame)
+        if (source.Format.HasStaticFrame && source.Format.Version != 8)
         {
             Diagnostics.Add(Localize(
                 "AnimationWorkbench.Diagnostic.SourceStaticFrameReadOnly"));
@@ -549,7 +547,8 @@ public sealed partial class AnimationWorkbenchViewModel :
     private static bool CanEditSource(
         AnimationWorkbenchSourceInput source)
     {
-        if (source.Format == null || source.Format.HasStaticFrame)
+        if (source.Format == null ||
+            (source.Format.HasStaticFrame && source.Format.Version != 8))
             return false;
         return AnimationFormatCapabilities.Evaluate(
             source.Format.Version,

--- a/GameWorld/View3D/Animation/AnimationClip.cs
+++ b/GameWorld/View3D/Animation/AnimationClip.cs
@@ -133,15 +133,29 @@ namespace GameWorld.Core.Animation
 
         public AnimationFile ConvertToFileFormat(GameSkeleton skeleton)
         {
+            return ConvertToFileFormat(skeleton, 7);
+        }
+
+        public AnimationFile ConvertToFileFormat(
+            GameSkeleton skeleton,
+            uint version,
+            uint unknownValueV8 = 0,
+            IReadOnlyList<string>? flagVariables = null)
+        {
+            if (version is not 7 and not 8)
+                throw new ArgumentOutOfRangeException(nameof(version));
+
             var output = new AnimationFile();
 
             output.Header.FrameRate = (float)(Timebase?.FramesPerSecond ?? 20);
 
-            output.Header.Version = 7;
+            output.Header.Version = version;
             output.Header.AnimationTotalPlayTimeInSec =
                 (float)Duration.TotalSeconds;
             output.Header.SkeletonName = skeleton.SkeletonName;
-            output.AnimationParts.Add(new AnimationPart());
+            output.Header.UnknownValue_v8 = unknownValueV8;
+            output.Header.FlagVariables = flagVariables?.ToList() ?? [];
+            output.Header.FlagCount = (uint)output.Header.FlagVariables.Count;
 
             output.Bones = new BoneInfo[skeleton.BoneCount];
             for (var i = 0; i < skeleton.BoneCount; i++)
@@ -152,16 +166,141 @@ namespace GameWorld.Core.Animation
                     Name = skeleton.BoneNames[i],
                     ParentId = skeleton.GetParentBoneIndex(i)
                 };
-
-                output.AnimationParts[0].RotationMappings.Add(new AnimationBoneMapping(i));
-                output.AnimationParts[0].TranslationMappings.Add(new AnimationBoneMapping(i));
             }
 
-
+            var frames = new List<Frame>();
             for (var i = 0; i < DynamicFrames.Count; i++)
-                output.AnimationParts[0].DynamicFrames.Add(CreateFrameFromKeyFrame(i, skeleton));
+                frames.Add(CreateFrameFromKeyFrame(i, skeleton));
+
+            output.AnimationParts.Add(version == 8
+                ? CreateVersionEightPart(frames, skeleton.BoneCount)
+                : CreateVersionSevenPart(frames, skeleton.BoneCount));
 
             return output;
+        }
+
+        private static AnimationPart CreateVersionSevenPart(
+            IReadOnlyList<Frame> frames,
+            int boneCount)
+        {
+            var part = new AnimationPart();
+            for (var boneIndex = 0; boneIndex < boneCount; boneIndex++)
+            {
+                part.RotationMappings.Add(new AnimationBoneMapping(boneIndex));
+                part.TranslationMappings.Add(new AnimationBoneMapping(boneIndex));
+            }
+
+            part.DynamicFrames.AddRange(frames);
+            return part;
+        }
+
+        private static AnimationPart CreateVersionEightPart(
+            IReadOnlyList<Frame> frames,
+            int boneCount)
+        {
+            if (frames.Count == 0)
+                throw new InvalidOperationException("Version 8 animation requires at least one frame.");
+
+            var staticTranslations = new bool[boneCount];
+            var staticRotations = new bool[boneCount];
+            for (var boneIndex = 0; boneIndex < boneCount; boneIndex++)
+            {
+                staticTranslations[boneIndex] = frames
+                    .Skip(1)
+                    .All(frame => NearlyEqual(
+                        frames[0].Transforms[boneIndex],
+                        frame.Transforms[boneIndex]));
+                staticRotations[boneIndex] = frames
+                    .Skip(1)
+                    .All(frame => NearlyEqual(
+                        frames[0].Quaternion[boneIndex],
+                        frame.Quaternion[boneIndex]));
+            }
+
+            if (frames.Count > 1 &&
+                staticTranslations.All(value => value) &&
+                staticRotations.All(value => value) &&
+                boneCount != 0)
+            {
+                staticTranslations[0] = false;
+            }
+
+            var part = new AnimationPart();
+            var hasStaticTracks = staticTranslations.Any(value => value) ||
+                                  staticRotations.Any(value => value);
+            if (hasStaticTracks)
+                part.StaticFrame = new Frame();
+
+            var hasDynamicTracks = staticTranslations.Any(value => !value) ||
+                                   staticRotations.Any(value => !value);
+            if (hasDynamicTracks)
+            {
+                for (var frameIndex = 0; frameIndex < frames.Count; frameIndex++)
+                    part.DynamicFrames.Add(new Frame());
+            }
+
+            for (var boneIndex = 0; boneIndex < boneCount; boneIndex++)
+            {
+                if (staticTranslations[boneIndex])
+                {
+                    part.TranslationMappings.Add(new AnimationBoneMapping(
+                        10000 + part.StaticFrame!.Transforms.Count));
+                    part.StaticFrame.Transforms.Add(
+                        frames[0].Transforms[boneIndex]);
+                }
+                else
+                {
+                    var mappingId = part.DynamicFrames[0].Transforms.Count;
+                    part.TranslationMappings.Add(new AnimationBoneMapping(mappingId));
+                    for (var frameIndex = 0; frameIndex < frames.Count; frameIndex++)
+                    {
+                        part.DynamicFrames[frameIndex].Transforms.Add(
+                            frames[frameIndex].Transforms[boneIndex]);
+                    }
+                }
+
+                if (staticRotations[boneIndex])
+                {
+                    part.RotationMappings.Add(new AnimationBoneMapping(
+                        10000 + part.StaticFrame!.Quaternion.Count));
+                    part.StaticFrame.Quaternion.Add(
+                        frames[0].Quaternion[boneIndex]);
+                }
+                else
+                {
+                    var mappingId = part.DynamicFrames[0].Quaternion.Count;
+                    part.RotationMappings.Add(new AnimationBoneMapping(mappingId));
+                    for (var frameIndex = 0; frameIndex < frames.Count; frameIndex++)
+                    {
+                        part.DynamicFrames[frameIndex].Quaternion.Add(
+                            frames[frameIndex].Quaternion[boneIndex]);
+                    }
+                }
+            }
+
+            return part;
+        }
+
+        private static bool NearlyEqual(RmvVector3 first, RmvVector3 second)
+        {
+            const float tolerance = 0.000001f;
+            return MathF.Abs(first.X - second.X) <= tolerance &&
+                   MathF.Abs(first.Y - second.Y) <= tolerance &&
+                   MathF.Abs(first.Z - second.Z) <= tolerance;
+        }
+
+        private static bool NearlyEqual(RmvVector4 first, RmvVector4 second)
+        {
+            const float tolerance = 0.000001f;
+            var sameSign = MathF.Abs(first.X - second.X) <= tolerance &&
+                           MathF.Abs(first.Y - second.Y) <= tolerance &&
+                           MathF.Abs(first.Z - second.Z) <= tolerance &&
+                           MathF.Abs(first.W - second.W) <= tolerance;
+            var oppositeSign = MathF.Abs(first.X + second.X) <= tolerance &&
+                               MathF.Abs(first.Y + second.Y) <= tolerance &&
+                               MathF.Abs(first.Z + second.Z) <= tolerance &&
+                               MathF.Abs(first.W + second.W) <= tolerance;
+            return sameSign || oppositeSign;
         }
 
         private Frame CreateFrameFromKeyFrame(int frameIndex, GameSkeleton skeleton)

--- a/GameWorld/View3D/Animation/AnimationClip.cs
+++ b/GameWorld/View3D/Animation/AnimationClip.cs
@@ -11,6 +11,8 @@ namespace GameWorld.Core.Animation
 {
     public class AnimationClip
     {
+        private const int StaticMappingOffset = 10000;
+
         public class KeyFrame
         {
             public List<Vector3> Position { get; set; } = new List<Vector3>();
@@ -244,7 +246,7 @@ namespace GameWorld.Core.Animation
                 if (staticTranslations[boneIndex])
                 {
                     part.TranslationMappings.Add(new AnimationBoneMapping(
-                        10000 + part.StaticFrame!.Transforms.Count));
+                        StaticMappingOffset + part.StaticFrame!.Transforms.Count));
                     part.StaticFrame.Transforms.Add(
                         frames[0].Transforms[boneIndex]);
                 }
@@ -262,7 +264,7 @@ namespace GameWorld.Core.Animation
                 if (staticRotations[boneIndex])
                 {
                     part.RotationMappings.Add(new AnimationBoneMapping(
-                        10000 + part.StaticFrame!.Quaternion.Count));
+                        StaticMappingOffset + part.StaticFrame!.Quaternion.Count));
                     part.StaticFrame.Quaternion.Add(
                         frames[0].Quaternion[boneIndex]);
                 }

--- a/Shared/GameFiles/Animation/AnimationFile.cs
+++ b/Shared/GameFiles/Animation/AnimationFile.cs
@@ -407,8 +407,8 @@ namespace Shared.GameFormats.Animation
 
         static byte[] ConvertToBytesInvernal(AnimationFile input)
         {
-            if (input.AnimationParts.Count != 1 || input.Header.Version == 8)
-                throw new Exception("Animations with multiple parts or version 8 can not be saved!");
+            if (input.Header.Version != 8 && input.AnimationParts.Count != 1)
+                throw new Exception("Animations before version 8 must contain exactly one part.");
 
             using var memoryStream = new MemoryStream();
             using var writer = new BinaryWriter(memoryStream);
@@ -421,9 +421,9 @@ namespace Shared.GameFormats.Animation
             for (var i = 0; i < input.Header.SkeletonName.Length; i++)
                 writer.Write(input.Header.SkeletonName[i]);
 
-            if (input.Header.Version == 7)
+            if (input.Header.Version > 6)
             {
-                writer.Write(input.Header.FlagCount);
+                writer.Write((uint)input.Header.FlagVariables.Count);
                 foreach (var flag in input.Header.FlagVariables)
                     writer.Write(ByteParsers.String.WriteCaString(flag));
             }
@@ -439,6 +439,12 @@ namespace Shared.GameFormats.Animation
                 for (var i = 0; i < bone.Name.Length; i++)
                     writer.Write(bone.Name[i]);
                 writer.Write(bone.ParentId);
+            }
+
+            if (input.Header.Version == 8)
+            {
+                WriteVersionEight(writer, input);
+                return memoryStream.ToArray();
             }
 
             foreach (var animationPart in input.AnimationParts)
@@ -484,6 +490,144 @@ namespace Shared.GameFormats.Animation
             }
 
             return memoryStream.ToArray();
+        }
+
+        static void WriteVersionEight(
+            BinaryWriter writer,
+            AnimationFile input)
+        {
+            writer.Write(input.Header.UnknownValue_v8);
+            writer.Write((uint)input.AnimationParts.Count);
+
+            foreach (var animationPart in input.AnimationParts)
+            {
+                ValidateVersionEightPart(animationPart, input.Bones.Length);
+
+                foreach (var mapping in animationPart.TranslationMappings)
+                {
+                    writer.Write(mapping.MappingType switch
+                    {
+                        AnimationBoneMappingType.Dynamic => (sbyte)12,
+                        AnimationBoneMappingType.Static => (sbyte)-12,
+                        AnimationBoneMappingType.None => (sbyte)0,
+                        _ => throw new ArgumentOutOfRangeException(),
+                    });
+                }
+
+                foreach (var mapping in animationPart.RotationMappings)
+                {
+                    writer.Write(mapping.MappingType switch
+                    {
+                        AnimationBoneMappingType.Dynamic => (sbyte)8,
+                        AnimationBoneMappingType.Static => (sbyte)-8,
+                        AnimationBoneMappingType.None => (sbyte)0,
+                        _ => throw new ArgumentOutOfRangeException(),
+                    });
+                }
+
+                writer.Write(0u);
+                writer.Write(0u);
+
+                var staticFrame = animationPart.StaticFrame;
+                writer.Write((uint)(staticFrame?.Transforms.Count ?? 0));
+                writer.Write((uint)(staticFrame?.Quaternion.Count ?? 0));
+                if (staticFrame != null)
+                    WriteFrame(writer, staticFrame);
+
+                var dynamicTransformCount = animationPart.TranslationMappings.Count(
+                    mapping => mapping.MappingType == AnimationBoneMappingType.Dynamic);
+                var dynamicQuaternionCount = animationPart.RotationMappings.Count(
+                    mapping => mapping.MappingType == AnimationBoneMappingType.Dynamic);
+                writer.Write((uint)dynamicTransformCount);
+                writer.Write((uint)dynamicQuaternionCount);
+                writer.Write((uint)animationPart.DynamicFrames.Count);
+                foreach (var frame in animationPart.DynamicFrames)
+                    WriteFrame(writer, frame);
+            }
+        }
+
+        static void ValidateVersionEightPart(
+            AnimationPart animationPart,
+            int boneCount)
+        {
+            if (animationPart.TranslationMappings.Count != boneCount ||
+                animationPart.RotationMappings.Count != boneCount)
+            {
+                throw new InvalidDataException(
+                    "Version 8 animation mappings must match the bone count.");
+            }
+
+            var staticTransformCount = ValidateMappingIds(
+                animationPart.TranslationMappings,
+                AnimationBoneMappingType.Static);
+            var staticQuaternionCount = ValidateMappingIds(
+                animationPart.RotationMappings,
+                AnimationBoneMappingType.Static);
+            var dynamicTransformCount = ValidateMappingIds(
+                animationPart.TranslationMappings,
+                AnimationBoneMappingType.Dynamic);
+            var dynamicQuaternionCount = ValidateMappingIds(
+                animationPart.RotationMappings,
+                AnimationBoneMappingType.Dynamic);
+
+            if ((staticTransformCount != 0 || staticQuaternionCount != 0) &&
+                animationPart.StaticFrame == null)
+            {
+                throw new InvalidDataException(
+                    "Version 8 static mappings require a static frame.");
+            }
+
+            if (animationPart.StaticFrame != null &&
+                (animationPart.StaticFrame.Transforms.Count != staticTransformCount ||
+                 animationPart.StaticFrame.Quaternion.Count != staticQuaternionCount))
+            {
+                throw new InvalidDataException(
+                    "Version 8 static frame data does not match its mappings.");
+            }
+            if (animationPart.StaticFrame != null &&
+                staticTransformCount == 0 &&
+                staticQuaternionCount == 0)
+            {
+                throw new InvalidDataException(
+                    "Version 8 static frame must contain a mapped track.");
+            }
+            if (dynamicTransformCount == 0 &&
+                dynamicQuaternionCount == 0 &&
+                animationPart.DynamicFrames.Count != 0)
+            {
+                throw new InvalidDataException(
+                    "Version 8 dynamic frames must contain a mapped track.");
+            }
+
+            foreach (var frame in animationPart.DynamicFrames)
+            {
+                if (frame.Transforms.Count != dynamicTransformCount ||
+                    frame.Quaternion.Count != dynamicQuaternionCount)
+                {
+                    throw new InvalidDataException(
+                        "Version 8 dynamic frame data does not match its mappings.");
+                }
+            }
+        }
+
+        static int ValidateMappingIds(
+            IReadOnlyList<AnimationBoneMapping> mappings,
+            AnimationBoneMappingType mappingType)
+        {
+            var expectedId = 0;
+            foreach (var mapping in mappings)
+            {
+                if (mapping.MappingType != mappingType)
+                    continue;
+                if (mapping.Id != expectedId)
+                {
+                    throw new InvalidDataException(
+                        "Version 8 animation mapping ids must follow bone order.");
+                }
+                expectedId++;
+            }
+
+            return expectedId;
         }
 
         public static byte[] ConvertToBytes(AnimationFile input)

--- a/Shared/GameFiles/Animation/AnimationFile.cs
+++ b/Shared/GameFiles/Animation/AnimationFile.cs
@@ -11,6 +11,11 @@ namespace Shared.GameFormats.Animation
     [DebuggerDisplay("AnimationFile - {Header.SkeletonName}[{DynamicFrames.Count}]")]
     public class AnimationFile
     {
+        private const sbyte VersionEightFullTranslationBitRate = 12;
+        private const sbyte VersionEightFullRotationBitRate = 8;
+        private const sbyte VersionEightStaticTranslationBitRate = -12;
+        private const sbyte VersionEightStaticRotationBitRate = -8;
+
         public const int InvalidBoneIndex = -1;
         public const int BoneIndexNoParent = InvalidBoneIndex;
 
@@ -507,8 +512,10 @@ namespace Shared.GameFormats.Animation
                 {
                     writer.Write(mapping.MappingType switch
                     {
-                        AnimationBoneMappingType.Dynamic => (sbyte)12,
-                        AnimationBoneMappingType.Static => (sbyte)-12,
+                        AnimationBoneMappingType.Dynamic =>
+                            VersionEightFullTranslationBitRate,
+                        AnimationBoneMappingType.Static =>
+                            VersionEightStaticTranslationBitRate,
                         AnimationBoneMappingType.None => (sbyte)0,
                         _ => throw new ArgumentOutOfRangeException(),
                     });
@@ -518,8 +525,10 @@ namespace Shared.GameFormats.Animation
                 {
                     writer.Write(mapping.MappingType switch
                     {
-                        AnimationBoneMappingType.Dynamic => (sbyte)8,
-                        AnimationBoneMappingType.Static => (sbyte)-8,
+                        AnimationBoneMappingType.Dynamic =>
+                            VersionEightFullRotationBitRate,
+                        AnimationBoneMappingType.Static =>
+                            VersionEightStaticRotationBitRate,
                         AnimationBoneMappingType.None => (sbyte)0,
                         _ => throw new ArgumentOutOfRangeException(),
                     });
@@ -590,6 +599,12 @@ namespace Shared.GameFormats.Animation
             {
                 throw new InvalidDataException(
                     "Version 8 static frame must contain a mapped track.");
+            }
+            if ((dynamicTransformCount != 0 || dynamicQuaternionCount != 0) &&
+                animationPart.DynamicFrames.Count == 0)
+            {
+                throw new InvalidDataException(
+                    "Version 8 dynamic mappings require at least one frame.");
             }
             if (dynamicTransformCount == 0 &&
                 dynamicQuaternionCount == 0 &&

--- a/Shared/GameFiles/Animation/AnimationFormatCapabilities.cs
+++ b/Shared/GameFiles/Animation/AnimationFormatCapabilities.cs
@@ -3,7 +3,6 @@
     public enum AnimationFormatBlockReason
     {
         UnsupportedVersion,
-        VersionEightIsReadOnly,
         MultiplePartsAreReadOnly,
     }
 
@@ -41,8 +40,6 @@
             }
 
             var blockingReasons = new List<AnimationFormatBlockReason>();
-            if (version == 8)
-                blockingReasons.Add(AnimationFormatBlockReason.VersionEightIsReadOnly);
             if (partCount != 1)
                 blockingReasons.Add(AnimationFormatBlockReason.MultiplePartsAreReadOnly);
 

--- a/Testing/AssetEditorTests/AnimationWorkbenchSaveTests.cs
+++ b/Testing/AssetEditorTests/AnimationWorkbenchSaveTests.cs
@@ -108,8 +108,57 @@ public class AnimationWorkbenchSaveTests
         packFileService.VerifyAll();
     }
 
+    [TestMethod]
+    public void SaveAsNewProjectResource_VersionEightSource_WritesVersionEightCandidate()
+    {
+        using var projectRoot = new TemporaryDirectory();
+        using var project = FolderProjectContainer.Create(
+            projectRoot.Path,
+            new FolderProjectSettings { Name = "测试工程" });
+        var packFileService = new Mock<IPackFileService>();
+        List<NewPackFileEntry>? capturedEntries = null;
+        packFileService
+            .Setup(service => service.AddFilesToPack(
+                project,
+                It.IsAny<List<NewPackFileEntry>>(),
+                false))
+            .Callback<PackFileContainer, List<NewPackFileEntry>, bool>(
+                (_, entries, _) => capturedEntries = entries);
+        using var document = CreateLoadedDocument(
+            new AnimationWorkbenchSourceFormat(
+                8,
+                1,
+                true,
+                6,
+                ["flag_a"]));
+
+        var saveResult = document.SaveAsNewProjectResource(
+            packFileService.Object,
+            project,
+            @"animations\battle\v8_candidate.anim");
+
+        Assert.IsTrue(saveResult.Succeeded);
+        Assert.IsNotNull(capturedEntries);
+        var candidate = AnimationFile.Create(new ByteChunk(
+            capturedEntries.Single().PackFile.DataSource.ReadData()));
+        Assert.AreEqual(8u, candidate.Header.Version);
+        Assert.AreEqual(6u, candidate.Header.UnknownValue_v8);
+        CollectionAssert.AreEqual(
+            new[] { "flag_a" },
+            candidate.Header.FlagVariables);
+        Assert.AreEqual(1, candidate.AnimationParts.Count);
+        Assert.IsNotNull(candidate.AnimationParts[0].StaticFrame);
+        Assert.AreEqual(2, candidate.AnimationParts[0].DynamicFrames.Count);
+        Assert.AreEqual(
+            AnimationFile.AnimationBoneMappingType.Dynamic,
+            candidate.AnimationParts[0].TranslationMappings[0].MappingType);
+        Assert.AreEqual(
+            AnimationFile.AnimationBoneMappingType.Static,
+            candidate.AnimationParts[0].RotationMappings[0].MappingType);
+        packFileService.VerifyAll();
+    }
+
     [DataTestMethod]
-    [DataRow(8, 1, false, AnimationWorkbenchDiagnosticCode.SourceVersionEightReadOnly)]
     [DataRow(7, 2, false, AnimationWorkbenchDiagnosticCode.SourceMultiplePartsReadOnly)]
     [DataRow(7, 1, true, AnimationWorkbenchDiagnosticCode.SourceStaticFrameReadOnly)]
     [DataRow(9, 1, false, AnimationWorkbenchDiagnosticCode.SourceFormatUnsupported)]

--- a/Testing/AssetEditorTests/AnimationWorkbenchShellTests.cs
+++ b/Testing/AssetEditorTests/AnimationWorkbenchShellTests.cs
@@ -195,6 +195,46 @@ public class AnimationWorkbenchShellTests
     }
 
     [Test]
+    public void Warhammer3_LoadVersionEightStaticFileEnablesEditing()
+    {
+        var animationFile = CreateVersionEightStaticAnimationFile();
+        var animation = PackFile.CreateFromBytes(
+            "idle_v8.anim",
+            AnimationFile.ConvertToBytes(animationFile));
+        var packFileService = new Mock<IPackFileService>();
+        packFileService.Setup(service => service.GetFullPath(
+                animation,
+                null))
+            .Returns("animations\\idle_v8.anim");
+        var skeletonLookup = new Mock<ISkeletonAnimationLookUpHelper>();
+        skeletonLookup.Setup(helper => helper.GetSkeletonFileFromName(
+                "test_skeleton"))
+            .Returns(CreateAnimationFile());
+        var previewSession = new Mock<IAnimationWorkbenchPreviewSession>();
+        var viewport = new Mock<IAnimationWorkbenchViewport>();
+        viewport.Setup(candidate => candidate.Show(
+                It.IsAny<AnimationWorkbenchPreviewSnapshot>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(previewSession.Object);
+        var viewModel = new AnimationWorkbenchViewModel(
+            viewport.Object,
+            packFileService.Object,
+            skeletonLookup.Object,
+            Mock.Of<IStandardDialogs>(),
+            new ApplicationSettingsService(GameTypeEnum.Warhammer3));
+
+        viewModel.LoadFile(animation);
+
+        NUnitAssert.Multiple(() =>
+        {
+            NUnitAssert.That(viewModel.IsWorkbenchEnabled, Is.True);
+            NUnitAssert.That(viewModel.CanEdit, Is.True);
+            NUnitAssert.That(viewModel.Diagnostics, Is.Empty);
+        });
+        viewModel.Close();
+    }
+
+    [Test]
     public void Xaml_UsesFourZoneWorkspaceAndSharedSplitterStyles()
     {
         var root = FindSolutionRoot();
@@ -379,6 +419,21 @@ public class AnimationWorkbenchShellTests
             new AnimationFile.AnimationBoneMapping(0));
         part.DynamicFrames.Add(frame);
         file.AnimationParts.Add(part);
+        return file;
+    }
+
+    private static AnimationFile CreateVersionEightStaticAnimationFile()
+    {
+        var file = CreateAnimationFile();
+        file.Header.Version = 8;
+        file.Header.UnknownValue_v8 = 6;
+        var part = file.AnimationParts.Single();
+        part.TranslationMappings[0] =
+            new AnimationFile.AnimationBoneMapping(10000);
+        part.RotationMappings[0] =
+            new AnimationFile.AnimationBoneMapping(10000);
+        part.StaticFrame = part.DynamicFrames.Single();
+        part.DynamicFrames.Clear();
         return file;
     }
 }

--- a/Testing/GameWorld.Core.Test/Animation/AnimationFileV8WriterTests.cs
+++ b/Testing/GameWorld.Core.Test/Animation/AnimationFileV8WriterTests.cs
@@ -1,4 +1,4 @@
-using GameWorld.Core.Animation;
+﻿using GameWorld.Core.Animation;
 using Microsoft.Xna.Framework;
 using Shared.ByteParsing;
 using Shared.GameFormats.Animation;
@@ -79,6 +79,17 @@ internal class AnimationFileV8WriterTests
             17,
             18,
             19);
+    }
+
+    [Test]
+    public void ConvertToBytes_VersionEightWithDynamicMappingAndNoFrames_Throws()
+    {
+        var source = CreateAnimation();
+        source.AnimationParts.Single().DynamicFrames.Clear();
+
+        Assert.That(
+            () => AnimationFile.ConvertToBytes(source),
+            Throws.TypeOf<InvalidDataException>());
     }
 
     [Test]

--- a/Testing/GameWorld.Core.Test/Animation/AnimationFileV8WriterTests.cs
+++ b/Testing/GameWorld.Core.Test/Animation/AnimationFileV8WriterTests.cs
@@ -1,0 +1,252 @@
+using GameWorld.Core.Animation;
+using Microsoft.Xna.Framework;
+using Shared.ByteParsing;
+using Shared.GameFormats.Animation;
+using Shared.GameFormats.RigidModel.Transforms;
+using Test.TestingUtility.TestUtility;
+
+namespace Testing.GameWorld.Core.Animation;
+
+[TestFixture]
+internal class AnimationFileV8WriterTests
+{
+    [Test]
+    public void ConvertToBytes_VersionEightWithStaticAndDynamicTracks_RoundTrips()
+    {
+        var source = CreateAnimation();
+
+        var bytes = AnimationFile.ConvertToBytes(source);
+        var actual = AnimationFile.Create(new ByteChunk(bytes));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.Header.Version, Is.EqualTo(8));
+            Assert.That(actual.Header.UnknownValue_v8, Is.EqualTo(6));
+            Assert.That(actual.Header.FlagVariables, Is.EqualTo(new[] { "flag_a" }));
+            Assert.That(actual.Bones.Select(bone => bone.Name),
+                Is.EqualTo(new[] { "root", "child" }));
+            Assert.That(actual.AnimationParts, Has.Count.EqualTo(1));
+        });
+
+        var part = actual.AnimationParts.Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(part.TranslationMappings.Select(mapping => mapping.FileWriteValue),
+                Is.EqualTo(new[] { 10000, 0 }));
+            Assert.That(part.RotationMappings.Select(mapping => mapping.FileWriteValue),
+                Is.EqualTo(new[] { 0, 10000 }));
+            Assert.That(part.StaticFrame, Is.Not.Null);
+            Assert.That(part.StaticFrame!.Transforms, Has.Count.EqualTo(1));
+            Assert.That(part.StaticFrame.Quaternion, Has.Count.EqualTo(1));
+            Assert.That(part.DynamicFrames, Has.Count.EqualTo(2));
+        });
+
+        AssertVector(part.StaticFrame!.Transforms.Single(), 1, 2, 3);
+        AssertQuaternion(part.StaticFrame.Quaternion.Single(), 0, 0, 0, 1);
+        AssertVector(part.DynamicFrames[0].Transforms.Single(), 4, 5, 6);
+        AssertVector(part.DynamicFrames[1].Transforms.Single(), 7, 8, 9);
+        AssertQuaternion(
+            part.DynamicFrames[0].Quaternion.Single(),
+            0,
+            0.70710677f,
+            0,
+            0.70710677f);
+        AssertQuaternion(
+            part.DynamicFrames[1].Quaternion.Single(),
+            0,
+            -0.70710677f,
+            0,
+            0.70710677f);
+    }
+
+    [Test]
+    public void ConvertToBytes_VersionEightWithMultipleParts_RoundTripsAllParts()
+    {
+        var source = CreateAnimation();
+        source.AnimationParts.Add(CreatePart(10));
+
+        var bytes = AnimationFile.ConvertToBytes(source);
+        var actual = AnimationFile.Create(new ByteChunk(bytes));
+
+        Assert.That(actual.AnimationParts, Has.Count.EqualTo(2));
+        AssertVector(
+            actual.AnimationParts[1].StaticFrame!.Transforms.Single(),
+            11,
+            12,
+            13);
+        AssertVector(
+            actual.AnimationParts[1].DynamicFrames[1].Transforms.Single(),
+            17,
+            18,
+            19);
+    }
+
+    [Test]
+    public void ConvertToBytes_RealWarhammerThreeVersionEightAnimation_PreservesPose()
+    {
+        var dataRoot = PathHelper.GetDataFolder(
+            @"Data\Karl_and_celestialgeneral_Pack");
+        var animationPath = Path.Combine(
+            dataRoot,
+            @"animations\battle\humanoid01\2handed_hammer\stand\hu1_2hh_stand_idle_01.anim");
+        var skeletonPath = Path.Combine(
+            dataRoot,
+            @"animations\skeletons\humanoid01.anim");
+        var original = AnimationFile.Create(new ByteChunk(
+            File.ReadAllBytes(animationPath)));
+        var skeletonFile = AnimationFile.Create(new ByteChunk(
+            File.ReadAllBytes(skeletonPath)));
+        var skeleton = new GameSkeleton(
+            skeletonFile,
+            new AnimationPlayer());
+
+        var bytes = AnimationFile.ConvertToBytes(original);
+        var actual = AnimationFile.Create(new ByteChunk(bytes));
+        var expectedClip = new AnimationClip(original, skeleton);
+        var actualClip = new AnimationClip(actual, skeleton);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(original.Header.Version, Is.EqualTo(8));
+            Assert.That(actual.Header.Version, Is.EqualTo(8));
+            Assert.That(actual.Header.UnknownValue_v8,
+                Is.EqualTo(original.Header.UnknownValue_v8));
+            Assert.That(actual.Header.FlagVariables,
+                Is.EqualTo(original.Header.FlagVariables));
+            Assert.That(actual.AnimationParts,
+                Has.Count.EqualTo(original.AnimationParts.Count));
+            Assert.That(actualClip.DynamicFrames,
+                Has.Count.EqualTo(expectedClip.DynamicFrames.Count));
+            Assert.That(actualClip.Duration,
+                Is.EqualTo(expectedClip.Duration));
+        });
+
+        for (var frameIndex = 0;
+             frameIndex < expectedClip.DynamicFrames.Count;
+             frameIndex++)
+        {
+            for (var boneIndex = 0;
+                 boneIndex < expectedClip.AnimationBoneCount;
+                 boneIndex++)
+            {
+                var expectedPosition =
+                    expectedClip.DynamicFrames[frameIndex].Position[boneIndex];
+                var actualPosition =
+                    actualClip.DynamicFrames[frameIndex].Position[boneIndex];
+                Assert.That(
+                    Vector3.Distance(expectedPosition, actualPosition),
+                    Is.LessThanOrEqualTo(0.0001f),
+                    $"Position mismatch at frame {frameIndex}, bone {boneIndex}.");
+
+                var expectedRotation =
+                    expectedClip.DynamicFrames[frameIndex].Rotation[boneIndex];
+                var actualRotation =
+                    actualClip.DynamicFrames[frameIndex].Rotation[boneIndex];
+                expectedRotation.Normalize();
+                actualRotation.Normalize();
+                Assert.That(
+                    MathF.Abs(Quaternion.Dot(expectedRotation, actualRotation)),
+                    Is.GreaterThanOrEqualTo(0.9999f),
+                    $"Rotation mismatch at frame {frameIndex}, bone {boneIndex}.");
+            }
+        }
+    }
+
+    private static AnimationFile CreateAnimation()
+    {
+        var animation = new AnimationFile
+        {
+            Header = new AnimationFile.AnimationHeader
+            {
+                Version = 8,
+                Unknown0_alwaysOne = 1,
+                FrameRate = 20,
+                SkeletonName = "test_skeleton",
+                FlagCount = 1,
+                FlagVariables = ["flag_a"],
+                AnimationTotalPlayTimeInSec = 0.1f,
+                UnknownValue_v8 = 6,
+            },
+            Bones =
+            [
+                new AnimationFile.BoneInfo
+                {
+                    Id = 0,
+                    Name = "root",
+                    ParentId = AnimationFile.BoneIndexNoParent,
+                },
+                new AnimationFile.BoneInfo
+                {
+                    Id = 1,
+                    Name = "child",
+                    ParentId = 0,
+                },
+            ],
+        };
+        animation.AnimationParts.Add(CreatePart(0));
+        return animation;
+    }
+
+    private static AnimationFile.AnimationPart CreatePart(float offset)
+    {
+        var part = new AnimationFile.AnimationPart
+        {
+            TranslationMappings =
+            [
+                new AnimationFile.AnimationBoneMapping(10000),
+                new AnimationFile.AnimationBoneMapping(0),
+            ],
+            RotationMappings =
+            [
+                new AnimationFile.AnimationBoneMapping(0),
+                new AnimationFile.AnimationBoneMapping(10000),
+            ],
+            StaticFrame = new AnimationFile.Frame
+            {
+                Transforms = [new RmvVector3(1 + offset, 2 + offset, 3 + offset)],
+                Quaternion = [new RmvVector4(0, 0, 0, 1)],
+            },
+        };
+        part.DynamicFrames.Add(new AnimationFile.Frame
+        {
+            Transforms = [new RmvVector3(4 + offset, 5 + offset, 6 + offset)],
+            Quaternion = [new RmvVector4(0, 0.70710677f, 0, 0.70710677f)],
+        });
+        part.DynamicFrames.Add(new AnimationFile.Frame
+        {
+            Transforms = [new RmvVector3(7 + offset, 8 + offset, 9 + offset)],
+            Quaternion = [new RmvVector4(0, -0.70710677f, 0, 0.70710677f)],
+        });
+        return part;
+    }
+
+    private static void AssertVector(
+        RmvVector3 actual,
+        float x,
+        float y,
+        float z)
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.X, Is.EqualTo(x).Within(0.0001f));
+            Assert.That(actual.Y, Is.EqualTo(y).Within(0.0001f));
+            Assert.That(actual.Z, Is.EqualTo(z).Within(0.0001f));
+        });
+    }
+
+    private static void AssertQuaternion(
+        RmvVector4 actual,
+        float x,
+        float y,
+        float z,
+        float w)
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(actual.X, Is.EqualTo(x).Within(0.0001f));
+            Assert.That(actual.Y, Is.EqualTo(y).Within(0.0001f));
+            Assert.That(actual.Z, Is.EqualTo(z).Within(0.0001f));
+            Assert.That(actual.W, Is.EqualTo(w).Within(0.0001f));
+        });
+    }
+}

--- a/Testing/GameWorld.Core.Test/Animation/AnimationFormatCapabilitiesTests.cs
+++ b/Testing/GameWorld.Core.Test/Animation/AnimationFormatCapabilitiesTests.cs
@@ -9,6 +9,7 @@ internal class AnimationFormatCapabilitiesTests
     [TestCase(5u)]
     [TestCase(6u)]
     [TestCase(7u)]
+    [TestCase(8u)]
     public void Evaluate_SupportedSinglePartFormat_AllowsReadEditAndSave(uint version)
     {
         var capabilities = AnimationFormatCapabilities.Evaluate(version, partCount: 1);
@@ -19,22 +20,6 @@ internal class AnimationFormatCapabilitiesTests
             Assert.That(capabilities.CanEdit, Is.True);
             Assert.That(capabilities.CanSave, Is.True);
             Assert.That(capabilities.BlockingReasons, Is.Empty);
-        });
-    }
-
-    [Test]
-    public void Evaluate_VersionEight_IsReadableButReadOnly()
-    {
-        var capabilities = AnimationFormatCapabilities.Evaluate(version: 8, partCount: 1);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(capabilities.CanRead, Is.True);
-            Assert.That(capabilities.CanEdit, Is.False);
-            Assert.That(capabilities.CanSave, Is.False);
-            Assert.That(
-                capabilities.BlockingReasons,
-                Is.EqualTo(new[] { AnimationFormatBlockReason.VersionEightIsReadOnly }));
         });
     }
 
@@ -71,7 +56,7 @@ internal class AnimationFormatCapabilitiesTests
     }
 
     [Test]
-    public void Evaluate_VersionEightWithMultipleParts_ReportsBothReadOnlyReasons()
+    public void Evaluate_VersionEightWithMultipleParts_ReportsPartReason()
     {
         var capabilities = AnimationFormatCapabilities.Evaluate(version: 8, partCount: 2);
 
@@ -79,7 +64,6 @@ internal class AnimationFormatCapabilitiesTests
             capabilities.BlockingReasons,
             Is.EqualTo(new[]
             {
-                AnimationFormatBlockReason.VersionEightIsReadOnly,
                 AnimationFormatBlockReason.MultiplePartsAreReadOnly,
             }));
     }


### PR DESCRIPTION
## 变更

- 为 Animation v8 增加原生二进制写出，不再强制降为 v7
- 保留 v8 UnknownValue、flags、Static/Dynamic 轨道语义，并支持底层多 Part round-trip
- 动画工作台允许单 Part v8 编辑、融合和另存为；输出版本由动画 A 决定
- 多 Part 工作台仍保持只读，三国写出仍保持禁用
- 增加真实战锤 3 v8 动画与骨架的逐帧姿态 round-trip 验证
- 拒绝动态映射存在但动态帧为空的不完整 v8 文件

## 验证

- dotnet restore AssetEditor.CN.sln
- dotnet build AssetEditor.CN.sln --configuration Release --no-restore
- dotnet test AssetEditor.CN.sln --configuration Release --no-build --no-restore --verbosity normal
- 结果：完整测试 1381/1381 通过；动画核心 91/91、动画工作台 158/158 通过

## 边界

- v8 使用已验证的完整平移与四元数编码模式，输出通常比 CA 的 ranged 压缩更大，但保存后姿态等价
- 三国真实样本和游戏验收按用户指示暂时跳过
- 合并后仍需用户完成战锤 3 真实窗口、编辑观感、重开与进游戏验收

Follow-up to #164 and #137.