### PR TITLE
重做动画工作台平面布局与基础动画列表

### DIFF
--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchBaseAnimationView.xaml
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchBaseAnimationView.xaml
@@ -42,12 +42,12 @@
 
         <Grid Grid.Row="1" Margin="0,16">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="300" />
-                <ColumnDefinition Width="16" />
-                <ColumnDefinition Width="*" MinWidth="720" />
+                <ColumnDefinition Width="240" />
+                <ColumnDefinition Width="12" />
+                <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
 
-            <Border Padding="16" Style="{StaticResource AeSurface.Panel}">
+            <Border Background="Transparent">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <StackPanel>
                         <TextBlock Style="{StaticResource AeText.SectionTitle}" Text="{loc:Loc AnimationWorkbench.BaseAnimation.DonorTitle}" />
@@ -115,7 +115,6 @@
                                 <TextBlock Style="{StaticResource AeText.SectionTitle}" Text="{loc:Loc AnimationWorkbench.BaseAnimation.OutputTitle}" />
                                 <Grid Margin="0,8,0,0">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="104" />
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
@@ -124,23 +123,34 @@
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
-                                    <Label HorizontalContentAlignment="Right" Content="{loc:Loc AnimationWorkbench.BaseAnimation.OutputFolder}" Style="{StaticResource AeForm.Label}" />
-                                    <TextBox Grid.Column="1" AutomationProperties.Name="{loc:Loc AnimationWorkbench.BaseAnimation.OutputFolder}" Style="{StaticResource AeInput.TextBox}" Text="{Binding OutputFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    <TextBlock Grid.ColumnSpan="2" Style="{StaticResource AeText.Label}" Text="{loc:Loc AnimationWorkbench.BaseAnimation.OutputFolder}" />
+                                    <TextBox Grid.Row="1" Margin="0,4,0,0" AutomationProperties.Name="{loc:Loc AnimationWorkbench.BaseAnimation.OutputFolder}" Style="{StaticResource AeInput.TextBox}" Text="{Binding OutputFolder, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTip="{Binding OutputFolder}" />
                                     <Button
-                                        Grid.Column="2"
-                                        Margin="8,0,0,0"
+                                        Grid.Row="1"
+                                        Grid.Column="1"
+                                        Margin="8,4,0,0"
                                         AutomationProperties.Name="{loc:Loc AnimationWorkbench.BaseAnimation.BrowseOutputFolder}"
                                         Command="{Binding BrowseOutputFolderCommand}"
                                         Content="{loc:Loc AnimationWorkbench.BaseAnimation.BrowseOutputFolder}"
                                         Style="{StaticResource AeButton.Secondary}" />
-                                    <Label Grid.Row="1" Margin="0,8,0,0" HorizontalContentAlignment="Right" Content="{loc:Loc AnimationWorkbench.BaseAnimation.OutputPrefix}" Style="{StaticResource AeForm.Label}" />
-                                    <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,8,0,0" AutomationProperties.Name="{loc:Loc AnimationWorkbench.BaseAnimation.OutputPrefix}" Style="{StaticResource AeInput.TextBox}" Text="{Binding OutputPrefix, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                                    <Label Grid.Row="2" Margin="0,8,0,0" HorizontalContentAlignment="Right" Content="{loc:Loc AnimationWorkbench.BaseAnimation.AnimationSetOutput}" Style="{StaticResource AeForm.Label}" />
-                                    <TextBlock Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Margin="0,8,0,0" VerticalAlignment="Center" Style="{StaticResource AeText.Technical}" Text="{Binding AnimationSetOutputPath}" TextWrapping="Wrap" ToolTip="{loc:Loc AnimationWorkbench.BaseAnimation.AnimationSetHint}" />
+                                    <TextBlock Grid.Row="2" Grid.ColumnSpan="2" Margin="0,8,0,0" Style="{StaticResource AeText.Label}" Text="{loc:Loc AnimationWorkbench.BaseAnimation.OutputPrefix}" />
+                                    <TextBox Grid.Row="3" Grid.ColumnSpan="2" Margin="0,4,0,0" AutomationProperties.Name="{loc:Loc AnimationWorkbench.BaseAnimation.OutputPrefix}" Style="{StaticResource AeInput.TextBox}" Text="{Binding OutputPrefix, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    <TextBlock Grid.Row="4" Grid.ColumnSpan="2" Margin="0,8,0,0" Style="{StaticResource AeText.Label}" Text="{loc:Loc AnimationWorkbench.BaseAnimation.AnimationSetOutput}" />
+                                    <TextBlock
+                                        Grid.Row="5"
+                                        Grid.ColumnSpan="2"
+                                        Margin="0,4,0,0"
+                                        AutomationProperties.HelpText="{loc:Loc AnimationWorkbench.BaseAnimation.AnimationSetHint}"
+                                        Style="{StaticResource AeText.Technical}"
+                                        Text="{Binding AnimationSetOutputPath}"
+                                        TextTrimming="CharacterEllipsis"
+                                        ToolTip="{Binding AnimationSetOutputPath}" />
                                     <CheckBox
-                                        Grid.Row="3"
-                                        Grid.Column="1"
+                                        Grid.Row="6"
                                         Grid.ColumnSpan="2"
                                         Margin="0,8,0,0"
                                         AutomationProperties.Name="{loc:Loc AnimationWorkbench.BaseAnimation.OverwriteExisting}"
@@ -154,7 +164,12 @@
                 </ScrollViewer>
             </Border>
 
-            <Border Grid.Column="2" Padding="16" Style="{StaticResource AeSurface.Panel}">
+            <Border
+                Grid.Column="2"
+                Padding="12,0,0,0"
+                Background="Transparent"
+                BorderBrush="{DynamicResource AeBrush.Border}"
+                BorderThickness="1,0,0,0">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -170,11 +185,12 @@
                         CanUserDeleteRows="False"
                         IsReadOnly="False"
                         ItemsSource="{Binding Items}"
+                        ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                         SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
                         SelectionMode="Single"
                         Style="{StaticResource AeTable.Grid}">
                         <DataGrid.Columns>
-                            <DataGridTemplateColumn Width="56" Header="{loc:Loc AnimationWorkbench.BaseAnimation.Selected}">
+                            <DataGridTemplateColumn Width="44" Header="{loc:Loc AnimationWorkbench.BaseAnimation.Selected}">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <CheckBox
@@ -185,7 +201,7 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTemplateColumn Width="120" Header="{loc:Loc AnimationWorkbench.BaseAnimation.Role}">
+                            <DataGridTemplateColumn Width="112" Header="{loc:Loc AnimationWorkbench.BaseAnimation.Role}">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <ComboBox
@@ -198,13 +214,46 @@
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
-                            <DataGridTextColumn Width="2*" Binding="{Binding SourcePath}" Header="{loc:Loc AnimationWorkbench.BaseAnimation.SourcePath}" IsReadOnly="True" />
-                            <DataGridTextColumn Width="2*" Binding="{Binding OutputPath}" Header="{loc:Loc AnimationWorkbench.BaseAnimation.OutputPath}" IsReadOnly="True" />
-                            <DataGridTextColumn Width="100" Binding="{Binding StatusText}" Header="{loc:Loc AnimationWorkbench.BaseAnimation.Status}" IsReadOnly="True" />
-                            <DataGridTextColumn Width="2*" Binding="{Binding DetailText}" Header="{loc:Loc AnimationWorkbench.BaseAnimation.Details}" IsReadOnly="True" />
+                            <DataGridTemplateColumn Width="*" Header="{loc:Loc AnimationWorkbench.BaseAnimation.SourcePath}" IsReadOnly="True">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <TextBlock
+                                            VerticalAlignment="Center"
+                                            Style="{StaticResource AeText.Technical}"
+                                            Text="{Binding SourcePath}"
+                                            TextTrimming="CharacterEllipsis"
+                                            ToolTip="{Binding SourcePath}" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                            <DataGridTextColumn Width="88" Binding="{Binding StatusText}" Header="{loc:Loc AnimationWorkbench.BaseAnimation.Status}" IsReadOnly="True" />
                         </DataGrid.Columns>
                     </DataGrid>
-                    <TextBlock Grid.Row="2" Margin="0,12,0,0" Style="{StaticResource AeText.Caption}" Text="{Binding StatusText}" TextWrapping="Wrap" />
+                    <Border
+                        Grid.Row="2"
+                        Margin="0,8,0,0"
+                        Padding="0,8,0,0"
+                        Background="Transparent"
+                        BorderBrush="{DynamicResource AeBrush.Border}"
+                        BorderThickness="0,1,0,0">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="56" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <TextBlock Style="{StaticResource AeText.Label}" Text="{loc:Loc AnimationWorkbench.BaseAnimation.SourcePath}" />
+                            <TextBlock Grid.Column="1" Style="{StaticResource AeText.Technical}" Text="{Binding SelectedItem.SourcePath}" TextTrimming="CharacterEllipsis" ToolTip="{Binding SelectedItem.SourcePath}" />
+                            <TextBlock Grid.Row="1" Margin="0,4,0,0" Style="{StaticResource AeText.Label}" Text="{loc:Loc AnimationWorkbench.BaseAnimation.OutputPath}" />
+                            <TextBlock Grid.Row="1" Grid.Column="1" Margin="0,4,0,0" Style="{StaticResource AeText.Technical}" Text="{Binding SelectedItem.OutputPath}" TextTrimming="CharacterEllipsis" ToolTip="{Binding SelectedItem.OutputPath}" />
+                            <TextBlock Grid.Row="2" Margin="0,4,0,0" Style="{StaticResource AeText.Label}" Text="{loc:Loc AnimationWorkbench.BaseAnimation.Details}" />
+                            <TextBlock Grid.Row="2" Grid.Column="1" Margin="0,4,0,0" Style="{StaticResource AeText.Caption}" Text="{Binding SelectedItem.DetailText}" TextWrapping="Wrap" />
+                        </Grid>
+                    </Border>
                 </Grid>
             </Border>
         </Grid>

--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchBlendView.xaml
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchBlendView.xaml
@@ -29,7 +29,7 @@
     <Border
         Margin="12"
         Padding="16"
-        Style="{StaticResource AeSurface.Panel}">
+        Background="Transparent">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -52,19 +52,13 @@
                         Text="{loc:Loc AnimationWorkbench.Blend.Subtitle}"
                         TextWrapping="Wrap" />
                 </StackPanel>
-                <Border
+                <TextBlock
+                    x:Name="HeaderStateText"
                     Grid.Column="1"
-                    Padding="12,4"
                     VerticalAlignment="Center"
-                    Background="{DynamicResource AeBrush.AccentSoft}"
-                    BorderBrush="{DynamicResource AeBrush.Accent}"
-                    BorderThickness="1"
-                    CornerRadius="{StaticResource AeRadius.Control}">
-                    <TextBlock
-                        x:Name="HeaderStateText"
-                        Style="{StaticResource AeText.Label}"
-                        Text="{loc:Loc AnimationWorkbench.Blend.LivePreview}" />
-                </Border>
+                    Foreground="{DynamicResource AeBrush.Accent}"
+                    Style="{StaticResource AeText.Label}"
+                    Text="{loc:Loc AnimationWorkbench.Blend.LivePreview}" />
             </Grid>
 
             <Grid Grid.Row="1" Margin="0,16,0,16">
@@ -74,7 +68,7 @@
                     <ColumnDefinition Width="0.95*" />
                 </Grid.ColumnDefinitions>
 
-                <Border Padding="16" Style="{StaticResource AeSurface.Control}">
+                <Border Padding="16" Background="Transparent">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -213,7 +207,7 @@
                             Grid.Row="5"
                             Margin="0,16,0,0"
                             Padding="12"
-                            Style="{StaticResource AeSurface.Control}">
+                            Background="Transparent">
                             <StackPanel>
                                 <TextBlock
                                     Style="{StaticResource AeText.SectionTitle}"
@@ -254,7 +248,7 @@
                 <Border
                     Grid.Column="2"
                     Padding="16"
-                    Style="{StaticResource AeSurface.Control}">
+                    Background="Transparent">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -268,25 +262,25 @@
                             Text="{loc:Loc AnimationWorkbench.Blend.OutputImpact}" />
 
                         <UniformGrid Grid.Row="1" Margin="0,16,0,0" Columns="2">
-                            <Border Margin="0,0,4,4" Padding="12" Style="{StaticResource AeSurface.Control}">
+                            <Border Margin="0,0,4,4" Padding="12" Background="Transparent">
                                 <StackPanel>
                                     <TextBlock Style="{StaticResource AeText.Caption}" Text="{loc:Loc AnimationWorkbench.Blend.SourceRates}" />
                                     <TextBlock x:Name="SourceRatesText" Margin="0,4,0,0" Style="{StaticResource AeText.Technical}" />
                                 </StackPanel>
                             </Border>
-                            <Border Margin="4,0,0,4" Padding="12" Style="{StaticResource AeSurface.Control}">
+                            <Border Margin="4,0,0,4" Padding="12" Background="Transparent">
                                 <StackPanel>
                                     <TextBlock Style="{StaticResource AeText.Caption}" Text="{loc:Loc AnimationWorkbench.Blend.OutputRate}" />
                                     <TextBlock x:Name="OutputRateText" Margin="0,4,0,0" Style="{StaticResource AeText.Technical}" />
                                 </StackPanel>
                             </Border>
-                            <Border Margin="0,4,4,0" Padding="12" Style="{StaticResource AeSurface.Control}">
+                            <Border Margin="0,4,4,0" Padding="12" Background="Transparent">
                                 <StackPanel>
                                     <TextBlock Style="{StaticResource AeText.Caption}" Text="{loc:Loc AnimationWorkbench.Blend.OutputFrames}" />
                                     <TextBlock x:Name="OutputFramesText" Margin="0,4,0,0" Style="{StaticResource AeText.Technical}" />
                                 </StackPanel>
                             </Border>
-                            <Border Margin="4,4,0,0" Padding="12" Style="{StaticResource AeSurface.Control}">
+                            <Border Margin="4,4,0,0" Padding="12" Background="Transparent">
                                 <StackPanel>
                                     <TextBlock Style="{StaticResource AeText.Caption}" Text="{loc:Loc AnimationWorkbench.Blend.OutputDuration}" />
                                     <TextBlock x:Name="OutputDurationText" Margin="0,4,0,0" Style="{StaticResource AeText.Technical}" />
@@ -297,11 +291,10 @@
                         <Border
                             Grid.Row="2"
                             Margin="0,16,0,0"
-                            Padding="12"
-                            Background="{DynamicResource AeBrush.AccentSoft}"
-                            BorderBrush="{DynamicResource AeBrush.Accent}"
-                            BorderThickness="1"
-                            CornerRadius="{StaticResource AeRadius.Control}">
+                            Padding="0,12,0,0"
+                            Background="Transparent"
+                            BorderBrush="{DynamicResource AeBrush.Border}"
+                            BorderThickness="0,1,0,0">
                             <TextBlock
                                 x:Name="ResampleText"
                                 Style="{StaticResource AeText.Caption}"
@@ -312,7 +305,7 @@
                             Grid.Row="3"
                             Margin="0,12,0,0"
                             Padding="12"
-                            Style="{StaticResource AeSurface.Control}">
+                            Background="Transparent">
                             <StackPanel>
                                 <TextBlock
                                     Style="{StaticResource AeText.Label}"
@@ -329,7 +322,7 @@
                             Grid.Row="4"
                             Margin="0,12,0,0"
                             Padding="12"
-                            Style="{StaticResource AeSurface.Control}">
+                            Background="Transparent">
                             <StackPanel>
                                 <TextBlock
                                     Style="{StaticResource AeText.Label}"

--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchLayerView.xaml
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchLayerView.xaml
@@ -31,7 +31,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Border Margin="12" Padding="16" Style="{StaticResource AeSurface.Panel}">
+    <Border Margin="12" Padding="16" Background="Transparent">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -48,19 +48,23 @@
                     <TextBlock Style="{StaticResource AeText.PageTitle}" Text="{loc:Loc AnimationWorkbench.Layer.Title}" />
                     <TextBlock Margin="0,4,0,0" Style="{StaticResource AeText.Caption}" Text="{loc:Loc AnimationWorkbench.Layer.Subtitle}" TextWrapping="Wrap" />
                 </StackPanel>
-                <Border Grid.Column="1" Padding="12,4" VerticalAlignment="Center" Background="{DynamicResource AeBrush.AccentSoft}" BorderBrush="{DynamicResource AeBrush.Accent}" BorderThickness="1" CornerRadius="{StaticResource AeRadius.Control}">
-                    <TextBlock x:Name="HeaderStateText" Style="{StaticResource AeText.Label}" Text="{loc:Loc AnimationWorkbench.Layer.LivePreview}" />
-                </Border>
+                <TextBlock
+                    x:Name="HeaderStateText"
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Foreground="{DynamicResource AeBrush.Accent}"
+                    Style="{StaticResource AeText.Label}"
+                    Text="{loc:Loc AnimationWorkbench.Layer.LivePreview}" />
             </Grid>
 
             <Grid Grid.Row="1" Margin="0,16">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="1.1*" MinWidth="360" />
+                    <ColumnDefinition Width="1.1*" />
                     <ColumnDefinition Width="16" />
-                    <ColumnDefinition Width="0.9*" MinWidth="340" />
+                    <ColumnDefinition Width="0.9*" />
                 </Grid.ColumnDefinitions>
 
-                <Border Padding="16" Style="{StaticResource AeSurface.Control}">
+                <Border Padding="16" Background="Transparent">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -84,7 +88,7 @@
                             AutomationProperties.Name="{loc:Loc AnimationWorkbench.Layer.SearchBones}"
                             Style="{StaticResource AeInput.TextBox}"
                             TextChanged="SearchTextBox_TextChanged" />
-                        <Border Grid.Row="2" Padding="4" BorderBrush="{DynamicResource AeBrush.Border}" BorderThickness="1" CornerRadius="{StaticResource AeRadius.Control}">
+                        <Border Grid.Row="2" Padding="4" BorderBrush="{DynamicResource AeBrush.Border}" BorderThickness="1">
                             <TreeView
                                 x:Name="BoneTree"
                                 AutomationProperties.Name="{loc:Loc AnimationWorkbench.Layer.BoneTree}"
@@ -124,7 +128,7 @@
                     </Grid>
                 </Border>
 
-                <Border Grid.Column="2" Padding="16" Style="{StaticResource AeSurface.Control}">
+                <Border Grid.Column="2" Padding="16" Background="Transparent">
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                         <StackPanel>
                             <TextBlock Style="{StaticResource AeText.SectionTitle}" Text="{loc:Loc AnimationWorkbench.Layer.LayerParameters}" />

--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchMetaDataView.xaml
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchMetaDataView.xaml
@@ -25,7 +25,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Border Margin="12" Padding="16" Style="{StaticResource AeSurface.Panel}">
+    <Border Margin="12" Padding="16" Background="Transparent">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -54,7 +54,7 @@
                 </StackPanel>
             </Grid>
 
-            <Border Grid.Row="1" Margin="0,16,0,12" Padding="12" Style="{StaticResource AeSurface.Control}">
+            <Border Grid.Row="1" Margin="0,16,0,12" Padding="12" Background="Transparent">
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -64,13 +64,16 @@
                         <TextBlock Style="{StaticResource AeText.SectionTitle}" Text="{loc:Loc AnimationWorkbench.MetaData.Summary}" />
                         <TextBlock Margin="0,4,0,0" Style="{StaticResource AeText.Caption}" Text="{Binding SummaryText}" />
                     </StackPanel>
-                    <Border Grid.Column="1" Padding="8,4" VerticalAlignment="Center" Background="{DynamicResource AeBrush.Surface2}" BorderBrush="{DynamicResource AeBrush.Border}" BorderThickness="1" CornerRadius="{StaticResource AeRadius.Control}">
-                        <TextBlock Style="{StaticResource AeText.Label}" Text="{Binding DirtyStateText}" />
-                    </Border>
+                    <TextBlock
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Foreground="{DynamicResource AeBrush.TextSecondary}"
+                        Style="{StaticResource AeText.Label}"
+                        Text="{Binding DirtyStateText}" />
                 </Grid>
             </Border>
 
-            <Border Grid.Row="2" Padding="12" Style="{StaticResource AeSurface.Control}">
+            <Border Grid.Row="2" Padding="12" Background="Transparent">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />

--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchRetargetView.xaml
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchRetargetView.xaml
@@ -28,7 +28,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Border Margin="12" Padding="16" Style="{StaticResource AeSurface.Panel}">
+    <Border Margin="12" Padding="16" Background="Transparent">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -45,19 +45,23 @@
                     <TextBlock Style="{StaticResource AeText.PageTitle}" Text="{loc:Loc AnimationWorkbench.Retarget.Title}" />
                     <TextBlock Margin="0,4,0,0" Style="{StaticResource AeText.Caption}" Text="{loc:Loc AnimationWorkbench.Retarget.Subtitle}" TextWrapping="Wrap" />
                 </StackPanel>
-                <Border Grid.Column="1" Padding="12,4" VerticalAlignment="Center" Background="{DynamicResource AeBrush.AccentSoft}" BorderBrush="{DynamicResource AeBrush.Accent}" BorderThickness="1" CornerRadius="{StaticResource AeRadius.Control}">
-                    <TextBlock x:Name="HeaderStateText" Style="{StaticResource AeText.Label}" Text="{loc:Loc AnimationWorkbench.Retarget.LivePreview}" />
-                </Border>
+                <TextBlock
+                    x:Name="HeaderStateText"
+                    Grid.Column="1"
+                    VerticalAlignment="Center"
+                    Foreground="{DynamicResource AeBrush.Accent}"
+                    Style="{StaticResource AeText.Label}"
+                    Text="{loc:Loc AnimationWorkbench.Retarget.LivePreview}" />
             </Grid>
 
             <Grid Grid.Row="1" Margin="0,16">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="1.6*" MinWidth="560" />
+                    <ColumnDefinition Width="1.6*" />
                     <ColumnDefinition Width="16" />
-                    <ColumnDefinition Width="0.7*" MinWidth="280" />
+                    <ColumnDefinition Width="0.7*" />
                 </Grid.ColumnDefinitions>
 
-                <Border Padding="16" Style="{StaticResource AeSurface.Control}">
+                <Border Padding="16" Background="Transparent">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -104,7 +108,7 @@
                             <TextBlock Grid.Column="1" Style="{StaticResource AeText.Caption}" Text="{loc:Loc AnimationWorkbench.Retarget.SourceBone}" />
                             <TextBlock Grid.Column="2" Style="{StaticResource AeText.Caption}" Text="{loc:Loc AnimationWorkbench.Retarget.Confidence}" />
                         </Grid>
-                        <Border Grid.Row="3" BorderBrush="{DynamicResource AeBrush.Border}" BorderThickness="1" CornerRadius="{StaticResource AeRadius.Control}">
+                        <Border Grid.Row="3" BorderBrush="{DynamicResource AeBrush.Border}" BorderThickness="1">
                             <ListBox
                                 x:Name="MappingList"
                                 ScrollViewer.CanContentScroll="True"
@@ -122,9 +126,12 @@
                                                     </Grid.ColumnDefinitions>
                                                     <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                                                         <TextBlock Style="{StaticResource AeText.Label}" Text="{Binding TargetBoneName}" />
-                                                        <Border Margin="8,0,0,0" Padding="4,1" Background="{DynamicResource AeBrush.Surface2}" BorderBrush="{DynamicResource AeBrush.Warning}" BorderThickness="1" CornerRadius="{StaticResource AeRadius.Control}" Visibility="{Binding IsCoreBone, Converter={StaticResource BooleanToVisibility}}">
-                                                            <TextBlock Foreground="{DynamicResource AeBrush.Warning}" Style="{StaticResource AeText.Caption}" Text="{loc:Loc AnimationWorkbench.Retarget.CoreBone}" />
-                                                        </Border>
+                                                        <TextBlock
+                                                            Margin="8,0,0,0"
+                                                            Foreground="{DynamicResource AeBrush.Warning}"
+                                                            Style="{StaticResource AeText.Caption}"
+                                                            Text="{loc:Loc AnimationWorkbench.Retarget.CoreBone}"
+                                                            Visibility="{Binding IsCoreBone, Converter={StaticResource BooleanToVisibility}}" />
                                                     </StackPanel>
                                                     <ComboBox
                                                         Grid.Column="1"
@@ -166,7 +173,7 @@
                     </Grid>
                 </Border>
 
-                <Border Grid.Column="2" Padding="16" Style="{StaticResource AeSurface.Control}">
+                <Border Grid.Column="2" Padding="16" Background="Transparent">
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
                         <StackPanel>
                             <TextBlock Style="{StaticResource AeText.SectionTitle}" Text="{loc:Loc AnimationWorkbench.Retarget.Summary}" />

--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchTimelineView.xaml
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchTimelineView.xaml
@@ -31,7 +31,7 @@
     <Border
         Margin="12"
         Padding="12"
-        Style="{StaticResource AeSurface.Panel}">
+        Background="Transparent">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
@@ -109,7 +109,7 @@
                 Grid.Row="1"
                 Margin="0,10,0,0"
                 Padding="8"
-                Style="{StaticResource AeSurface.Control}">
+                Background="Transparent">
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -214,11 +214,10 @@
             <Border
                 Grid.Row="2"
                 Margin="0,8,0,0"
-                Padding="8,6"
-                Background="{DynamicResource AeBrush.AccentSoft}"
-                BorderBrush="{DynamicResource AeBrush.Accent}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource AeRadius.Control}">
+                Padding="0,8,0,0"
+                Background="Transparent"
+                BorderBrush="{DynamicResource AeBrush.Border}"
+                BorderThickness="0,1,0,0">
                 <TextBlock
                     x:Name="StatusText"
                     Style="{StaticResource AeText.Caption}"
@@ -231,8 +230,7 @@
                 Margin="0,8,0,0"
                 Background="{DynamicResource AeBrush.Surface2}"
                 BorderBrush="{DynamicResource AeBrush.Border}"
-                BorderThickness="1"
-                CornerRadius="{StaticResource AeRadius.Control}">
+                BorderThickness="1">
                 <Grid ClipToBounds="True">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="32" />

--- a/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchView.xaml
+++ b/Editors/AnimationEditor/AnimationWorkbench/AnimationWorkbenchView.xaml
@@ -28,6 +28,9 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
+    <Border
+        Margin="8"
+        Style="{StaticResource AeSurface.Panel}">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -40,7 +43,9 @@
         <Border
             Grid.Row="0"
             Padding="12,8"
-            Style="{StaticResource AeSurface.Panel}">
+            Background="Transparent"
+            BorderBrush="{DynamicResource AeBrush.Border}"
+            BorderThickness="0,0,0,1">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -100,17 +105,12 @@
                     Grid.Column="8"
                     HorizontalAlignment="Right"
                     Orientation="Horizontal">
-                    <Border
+                    <TextBlock
                         Margin="0,0,8,0"
-                        Padding="8,4"
-                        Background="{DynamicResource AeBrush.AccentSoft}"
-                        BorderBrush="{DynamicResource AeBrush.Accent}"
-                        BorderThickness="1"
-                        CornerRadius="{StaticResource AeRadius.Control}">
-                        <TextBlock
-                            Style="{StaticResource AeText.Label}"
-                            Text="{loc:Loc AnimationWorkbench.Shell.Warhammer3Badge}" />
-                    </Border>
+                        VerticalAlignment="Center"
+                        Foreground="{DynamicResource AeBrush.Accent}"
+                        Style="{StaticResource AeText.Label}"
+                        Text="{loc:Loc AnimationWorkbench.Shell.Warhammer3Badge}" />
                     <Button
                         AutomationProperties.HelpText="{Binding SaveUnavailableReason}"
                         AutomationProperties.Name="{loc:Loc AnimationWorkbench.Shell.SaveAsNewResource}"
@@ -125,18 +125,17 @@
 
         <Grid Grid.Row="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="260" MinWidth="210" />
+                <ColumnDefinition Width="240" MinWidth="190" />
                 <ColumnDefinition Width="5" />
                 <ColumnDefinition Width="*" MinWidth="360" />
                 <ColumnDefinition Width="5" />
-                <ColumnDefinition Width="520" MinWidth="340" />
+                <ColumnDefinition Width="720" MinWidth="600" />
             </Grid.ColumnDefinitions>
 
             <Border
                 Grid.Column="0"
-                Margin="8,8,0,8"
                 Padding="12"
-                Style="{StaticResource AeSurface.Panel}">
+                Background="Transparent">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -152,9 +151,10 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate DataType="{x:Type local:AnimationWorkbenchSourceItem}">
                                 <Border
-                                    Margin="0,0,0,8"
-                                    Padding="12,8"
-                                    Style="{StaticResource AeSurface.Control}">
+                                    Padding="0,8"
+                                    Background="Transparent"
+                                    BorderBrush="{DynamicResource AeBrush.Border}"
+                                    BorderThickness="0,0,0,1">
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="28" />
@@ -190,7 +190,7 @@
                         Margin="0,8,0,0"
                         AutomationProperties.Name="{loc:Loc AnimationWorkbench.Shell.TargetBones}"
                         ItemsSource="{Binding BoneNames}"
-                        ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                        ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                         VirtualizingPanel.IsVirtualizing="True"
                         VirtualizingPanel.VirtualizationMode="Recycling" />
                 </Grid>
@@ -203,8 +203,7 @@
 
             <Border
                 Grid.Column="2"
-                Margin="0,8"
-                Style="{StaticResource AeSurface.Panel}">
+                Background="{DynamicResource AeBrush.Canvas}">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*" />
@@ -216,10 +215,9 @@
                     <Border
                         HorizontalAlignment="Left"
                         Margin="12"
-                        Padding="12,8"
+                        Padding="8,4"
                         VerticalAlignment="Top"
-                        Background="{DynamicResource AeBrush.Surface2}"
-                        CornerRadius="{StaticResource AeRadius.Control}">
+                        Background="{DynamicResource AeBrush.Surface2}">
                         <TextBlock
                             MaxWidth="520"
                             Style="{StaticResource AeText.Caption}"
@@ -239,8 +237,7 @@
 
             <Border
                 Grid.Column="4"
-                Margin="0,8,8,8"
-                Style="{StaticResource AeSurface.Panel}">
+                Background="Transparent">
                 <TabControl
                     x:Name="ToolTabs"
                     AutomationProperties.Name="{loc:Loc AnimationWorkbench.Shell.ToolsAndIssues}"
@@ -272,42 +269,32 @@
                         </Grid>
                     </TabItem>
                     <TabItem Header="{loc:Loc AnimationWorkbench.Shell.Blend}" Tag="Blend">
-                        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                        <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                             <local:AnimationWorkbenchBlendView
-                                MinHeight="640"
-                                MinWidth="1060"
                                 Controller="{Binding BlendController}" />
                         </ScrollViewer>
                     </TabItem>
                     <TabItem Header="{loc:Loc AnimationWorkbench.Shell.Layer}" Tag="Layer">
-                        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                        <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                             <local:AnimationWorkbenchLayerView
-                                MinHeight="640"
-                                MinWidth="1060"
                                 Controller="{Binding LayerController}" />
                         </ScrollViewer>
                     </TabItem>
                     <TabItem Header="{loc:Loc AnimationWorkbench.Shell.Retarget}" Tag="Retarget">
-                        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                        <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                             <local:AnimationWorkbenchRetargetView
-                                MinHeight="640"
-                                MinWidth="1060"
                                 Controller="{Binding RetargetController}" />
                         </ScrollViewer>
                     </TabItem>
                     <TabItem Header="{loc:Loc AnimationWorkbench.Shell.BaseAnimation}" Tag="BaseAnimation">
-                        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                        <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                             <local:AnimationWorkbenchBaseAnimationView
-                                MinHeight="640"
-                                MinWidth="1120"
                                 Controller="{Binding DataContext.BaseAnimationController, ElementName=Root}" />
                         </ScrollViewer>
                     </TabItem>
                     <TabItem Header="{loc:Loc AnimationWorkbench.Shell.MetaData}" Tag="MetaData">
-                        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                        <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
                             <local:AnimationWorkbenchMetaDataView
-                                MinHeight="480"
-                                MinWidth="720"
                                 Controller="{Binding DataContext.MetaDataController, ElementName=Root}" />
                         </ScrollViewer>
                     </TabItem>
@@ -322,9 +309,8 @@
 
         <Border
             Grid.Row="3"
-            Margin="8,0,8,4"
             IsEnabled="{Binding CanEdit}"
-            Style="{StaticResource AeSurface.Panel}">
+            Background="Transparent">
             <local:AnimationWorkbenchTimelineView
                 AutomationProperties.Name="{loc:Loc AnimationWorkbench.Timeline.Title}"
                 Controller="{Binding TimelineController}" />
@@ -342,4 +328,5 @@
                 TextWrapping="Wrap" />
         </Border>
     </Grid>
+    </Border>
 </UserControl>

--- a/Testing/AssetEditorTests/AnimationWorkbenchBlendViewTests.cs
+++ b/Testing/AssetEditorTests/AnimationWorkbenchBlendViewTests.cs
@@ -85,8 +85,8 @@ public class AnimationWorkbenchBlendViewTests
 
         NUnitAssert.Multiple(() =>
         {
-            NUnitAssert.That(source, Does.Contain("AeSurface.Panel"));
-            NUnitAssert.That(source, Does.Contain("AeSurface.Control"));
+            NUnitAssert.That(source, Does.Not.Contain("AeSurface.Panel"));
+            NUnitAssert.That(source, Does.Not.Contain("AeSurface.Control"));
             NUnitAssert.That(source, Does.Contain("AeEditor.PlaybackSlider"));
             NUnitAssert.That(source, Does.Contain("AeInput.ComboBox"));
             NUnitAssert.That(source, Does.Contain("AeInput.CheckBox"));

--- a/Testing/AssetEditorTests/AnimationWorkbenchLayerViewTests.cs
+++ b/Testing/AssetEditorTests/AnimationWorkbenchLayerViewTests.cs
@@ -76,8 +76,8 @@ public class AnimationWorkbenchLayerViewTests
 
         NUnitAssert.Multiple(() =>
         {
-            NUnitAssert.That(source, Does.Contain("AeSurface.Panel"));
-            NUnitAssert.That(source, Does.Contain("AeSurface.Control"));
+            NUnitAssert.That(source, Does.Not.Contain("AeSurface.Panel"));
+            NUnitAssert.That(source, Does.Not.Contain("AeSurface.Control"));
             NUnitAssert.That(source, Does.Contain("AeEditor.PlaybackSlider"));
             NUnitAssert.That(source, Does.Contain("AeInput.TextBox"));
             NUnitAssert.That(source, Does.Contain("AeInput.ComboBox"));

--- a/Testing/AssetEditorTests/AnimationWorkbenchMetaDataViewTests.cs
+++ b/Testing/AssetEditorTests/AnimationWorkbenchMetaDataViewTests.cs
@@ -101,8 +101,8 @@ public sealed class AnimationWorkbenchMetaDataViewTests
 
         NUnitAssert.Multiple(() =>
         {
-            NUnitAssert.That(source, Does.Contain("AeSurface.Panel"));
-            NUnitAssert.That(source, Does.Contain("AeSurface.Control"));
+            NUnitAssert.That(source, Does.Not.Contain("AeSurface.Panel"));
+            NUnitAssert.That(source, Does.Not.Contain("AeSurface.Control"));
             NUnitAssert.That(source, Does.Contain("AeInput.Switch"));
             NUnitAssert.That(source, Does.Contain("AeList.View"));
             NUnitAssert.That(source, Does.Contain("AeList.Item"));

--- a/Testing/AssetEditorTests/AnimationWorkbenchRetargetViewTests.cs
+++ b/Testing/AssetEditorTests/AnimationWorkbenchRetargetViewTests.cs
@@ -78,8 +78,8 @@ public sealed class AnimationWorkbenchRetargetViewTests
 
         NUnitAssert.Multiple(() =>
         {
-            NUnitAssert.That(source, Does.Contain("AeSurface.Panel"));
-            NUnitAssert.That(source, Does.Contain("AeSurface.Control"));
+            NUnitAssert.That(source, Does.Not.Contain("AeSurface.Panel"));
+            NUnitAssert.That(source, Does.Not.Contain("AeSurface.Control"));
             NUnitAssert.That(source, Does.Contain("AeInput.TextBox"));
             NUnitAssert.That(source, Does.Contain("AeInput.ComboBox"));
             NUnitAssert.That(source, Does.Contain("AeInput.CheckBox"));

--- a/Testing/AssetEditorTests/AnimationWorkbenchShellTests.cs
+++ b/Testing/AssetEditorTests/AnimationWorkbenchShellTests.cs
@@ -276,6 +276,7 @@ public class AnimationWorkbenchShellTests
                         () => { },
                         DispatcherPriority.ApplicationIdle);
                     window.UpdateLayout();
+                    SaveWindowForVisualReview(window, "shell-base");
 
                     var baseView = FindDescendants<
                             AnimationWorkbenchBaseAnimationView>(view)
@@ -418,6 +419,11 @@ public class AnimationWorkbenchShellTests
             "AnimationWorkbenchView.xaml");
         var source = File.ReadAllText(xamlPath);
         var document = XDocument.Load(xamlPath);
+        var workbenchViews = Directory.GetFiles(
+                Path.GetDirectoryName(xamlPath)!,
+                "*View.xaml")
+            .Select(File.ReadAllText)
+            .ToArray();
 
         NUnitAssert.Multiple(() =>
         {
@@ -425,6 +431,23 @@ public class AnimationWorkbenchShellTests
                 Does.Contain("AeVerticalGridSplitterStyle"));
             NUnitAssert.That(source,
                 Does.Contain("AeHorizontalGridSplitterStyle"));
+            NUnitAssert.That(
+                workbenchViews.Sum(view =>
+                    Regex.Matches(view, "AeSurface\\.Panel").Count),
+                Is.EqualTo(1));
+            NUnitAssert.That(
+                workbenchViews.All(view =>
+                    !view.Contains(
+                        "AeSurface.Control",
+                        StringComparison.Ordinal)),
+                Is.True);
+            NUnitAssert.That(source,
+                Does.Not.Contain(
+                    "HorizontalScrollBarVisibility=\"Auto\""));
+            NUnitAssert.That(source,
+                Does.Not.Contain("MinWidth=\"1060\""));
+            NUnitAssert.That(source,
+                Does.Not.Contain("MinWidth=\"1120\""));
             NUnitAssert.That(source,
                 Does.Contain("AnimationWorkbenchTimelineView"));
             NUnitAssert.That(source,
@@ -559,10 +582,15 @@ public class AnimationWorkbenchShellTests
             "AnimationWorkbench",
             "AnimationWorkbenchBaseAnimationView.xaml");
         var source = File.ReadAllText(xamlPath);
+        var document = XDocument.Load(xamlPath);
         NUnitAssert.Multiple(() =>
         {
-            NUnitAssert.That(source, Does.Contain("AeSurface.Panel"));
+            NUnitAssert.That(source, Does.Not.Contain("AeSurface.Panel"));
+            NUnitAssert.That(source, Does.Not.Contain("AeSurface.Control"));
             NUnitAssert.That(source, Does.Contain("AeTable.Grid"));
+            NUnitAssert.That(source,
+                Does.Contain(
+                    "ScrollViewer.HorizontalScrollBarVisibility=\"Disabled\""));
             NUnitAssert.That(source,
                 Does.Contain("OperationProgressWindowHost"));
             NUnitAssert.That(source,
@@ -574,6 +602,11 @@ public class AnimationWorkbenchShellTests
             NUnitAssert.That(
                 Regex.IsMatch(source, "#[0-9a-fA-F]{3,8}"),
                 Is.False);
+            NUnitAssert.That(
+                document.Descendants().Count(element =>
+                    element.Name.LocalName is nameof(DataGridTextColumn)
+                        or nameof(DataGridTemplateColumn)),
+                Is.EqualTo(4));
         });
 
         WpfTestApplicationHost.InvokeWithThemeResources(
@@ -594,7 +627,7 @@ public class AnimationWorkbenchShellTests
                         ThemesController.SetTheme(theme);
                         var window = new Window
                         {
-                            Width = 1280,
+                            Width = 720,
                             Height = 820,
                             Content =
                                 new AnimationWorkbenchBaseAnimationView(),
@@ -669,6 +702,13 @@ public class AnimationWorkbenchShellTests
                         NUnitAssert.Multiple(() =>
                         {
                             NUnitAssert.That(grid.SelectedItem, Is.SameAs(row));
+                            NUnitAssert.That(
+                                ScrollViewer.GetHorizontalScrollBarVisibility(
+                                    grid),
+                                Is.EqualTo(ScrollBarVisibility.Disabled));
+                            NUnitAssert.That(
+                                grid.Columns.Sum(column => column.ActualWidth),
+                                Is.LessThanOrEqualTo(grid.ActualWidth + 1));
                             NUnitAssert.That(selectedCheckBox.IsChecked, Is.True);
                             NUnitAssert.That(progress.IsOperationActive, Is.True);
                             NUnitAssert.That(
@@ -711,9 +751,89 @@ public class AnimationWorkbenchShellTests
             });
     }
 
+    [Test]
+    public void BaseAnimationView_RendersDenseRecipeWithoutHorizontalScroll()
+    {
+        WpfTestApplicationHost.InvokeWithThemeResources(
+            WpfTestApplicationHost.EmptyServices,
+            () =>
+            {
+                var rows = Enumerable.Range(1, 24)
+                    .Select(index => new BaseAnimationRowState
+                    {
+                        IsSelected = index % 4 == 0,
+                        Role = AnimationWorkbenchBaseAnimationRole.Death,
+                        SourcePath =
+                            $@"animations\battle\humanoid01\2handed_sword\candidate_{index:00}.anim",
+                        OutputPath =
+                            $@"animations\battle\external\base\candidate_{index:00}.anim",
+                        StatusText = index % 3 == 0 ? "候选" : "待生成",
+                        DetailText = "已匹配目标骨架，等待生成预览。",
+                    })
+                    .ToArray();
+                var selected = rows[7];
+                var state = new BaseAnimationViewState
+                {
+                    Items = rows,
+                    SelectedItem = selected,
+                    StatusText = "已选择 24 个候选动作",
+                    CanGenerate = true,
+                    CanPreview = true,
+                };
+
+                var previousTheme = ThemesController.CurrentTheme;
+                try
+                {
+                    foreach (var theme in new[]
+                             {
+                                 ThemeType.DarkTheme,
+                                 ThemeType.LightTheme,
+                                 ThemeType.HighContrastDark,
+                                 ThemeType.HighContrastLight,
+                             })
+                    {
+                        ThemesController.SetTheme(theme);
+                        RenderAndAssertBaseAnimationState(
+                            state,
+                            view =>
+                            {
+                                var grid = FindDescendants<DataGrid>(view)
+                                    .Single();
+                                NUnitAssert.Multiple(() =>
+                                {
+                                    NUnitAssert.That(
+                                        grid.Items.Count,
+                                        Is.EqualTo(24));
+                                    NUnitAssert.That(
+                                        grid.Columns,
+                                        Has.Count.EqualTo(4));
+                                    NUnitAssert.That(
+                                        ScrollViewer
+                                            .GetHorizontalScrollBarVisibility(
+                                                grid),
+                                        Is.EqualTo(
+                                            ScrollBarVisibility.Disabled));
+                                    NUnitAssert.That(
+                                        grid.Columns.Sum(column =>
+                                            column.ActualWidth),
+                                        Is.LessThanOrEqualTo(
+                                            grid.ActualWidth + 1));
+                                });
+                            },
+                            $"dense-{theme}");
+                    }
+                }
+                finally
+                {
+                    ThemesController.SetTheme(previousTheme);
+                }
+            });
+    }
+
     private static void RenderAndAssertBaseAnimationState(
         BaseAnimationViewState state,
-        Action<AnimationWorkbenchBaseAnimationView> assert)
+        Action<AnimationWorkbenchBaseAnimationView> assert,
+        string? captureName = null)
     {
         var view = new AnimationWorkbenchBaseAnimationView
         {
@@ -721,7 +841,7 @@ public class AnimationWorkbenchShellTests
         };
         var window = new Window
         {
-            Width = 1280,
+            Width = 720,
             Height = 820,
             Content = view,
             ShowActivated = false,
@@ -737,11 +857,44 @@ public class AnimationWorkbenchShellTests
                 DispatcherPriority.ApplicationIdle);
             window.UpdateLayout();
             assert(view);
+            SaveWindowForVisualReview(window, captureName);
         }
         finally
         {
             window.Close();
         }
+    }
+
+    private static void SaveWindowForVisualReview(
+        Window window,
+        string? captureName)
+    {
+        var outputDirectory = Environment.GetEnvironmentVariable(
+            "AE_UI_QA_OUTPUT");
+        if (string.IsNullOrWhiteSpace(outputDirectory) ||
+            string.IsNullOrWhiteSpace(captureName))
+        {
+            return;
+        }
+
+        var dpi = VisualTreeHelper.GetDpi(window);
+        var bitmap = new RenderTargetBitmap(
+            Math.Max(1, (int)Math.Ceiling(
+                window.ActualWidth * dpi.DpiScaleX)),
+            Math.Max(1, (int)Math.Ceiling(
+                window.ActualHeight * dpi.DpiScaleY)),
+            dpi.PixelsPerInchX,
+            dpi.PixelsPerInchY,
+            PixelFormats.Pbgra32);
+        bitmap.Render(window);
+
+        Directory.CreateDirectory(outputDirectory);
+        using var stream = File.Create(Path.Combine(
+            outputDirectory,
+            $"animation-workbench-{captureName}.png"));
+        var encoder = new PngBitmapEncoder();
+        encoder.Frames.Add(BitmapFrame.Create(bitmap));
+        encoder.Save(stream);
     }
 
     private static IEnumerable<T> FindDescendants<T>(DependencyObject root)


### PR DESCRIPTION
## 修改内容
- 整个动画工作台只保留一个外层主面板，移除来源区、视口、工具页、时间线及各功能页的嵌套卡片。
- 移除工具页的强制横向滚动和硬最小宽度，改为随右侧工作区自适应。
- 基础动作配方压缩为使用、基础类型、游戏来源、状态四列；完整来源、输出和详情在选中项下方显示。
- 输出目录改为纵向表单，避免标签和路径被按钮挤碎。
- 保留原有命令、数据绑定、快捷键与保存语义。

## 验证
- Release 模块构建：0 个错误。
- AnimationWorkbench 相关测试：179/179 通过。
- 720x820、24 条候选动作，在深色、浅色和两种高对比主题下实际渲染，无横向滚动。
- 1600x940 整体工作台实际渲染检查：仅一个外层面板。

Related #137