### PR TITLE
修复 Blender 动画高级导入时的剪切误报

### DIFF
--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/AnimationBuilder.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Importers/GltfToRmv/Helper/AnimationBuilder.cs
@@ -664,7 +664,9 @@ public class AnimationBuilder
             for (var boneIndex = 0; boneIndex < _skeleton.Bones.Length; boneIndex++)
             {
                 var gameTranslation = bindFrame.Transforms[boneIndex].ToVector3();
-                var gameRotation = bindFrame.Quaternion[boneIndex].ToQuaternion();
+                // Quantized game rotations must not introduce scale or shear into retargeting.
+                var gameRotation = Xna.Quaternion.Normalize(
+                    bindFrame.Quaternion[boneIndex].ToQuaternion());
                 _targetBindLocal[boneIndex] =
                     Matrix4x4.CreateFromQuaternion(new Quaternion(
                         gameRotation.X,

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/AnimationBuilderTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/AnimationBuilderTests.cs
@@ -292,8 +292,14 @@ public class AnimationBuilderTests
         });
     }
 
-    [Test]
-    public void Build_UnitScaleKeysWithRetargetMatrixDrift_DoesNotRejectScale()
+    [TestCase(0, 0, 1, 1.000078f)]
+    [TestCase(1, 2, 3, 1.000078f)]
+    [TestCase(1, 2, 3, 0.99995f)]
+    public void Build_UnitScaleKeysWithRetargetMatrixDrift_PreservesRotation(
+        float axisX,
+        float axisY,
+        float axisZ,
+        float storedQuaternionLength)
     {
         var modelRoot = ModelRoot.CreateModel();
         var scene = modelRoot.UseScene("default");
@@ -324,9 +330,8 @@ public class AnimationBuilderTests
         });
         var skeleton = CreateSingleBoneSkeleton();
         var targetBindRotation = Numerics.Quaternion.CreateFromAxisAngle(
-            Numerics.Vector3.UnitZ,
+            Numerics.Vector3.Normalize(new Numerics.Vector3(axisX, axisY, axisZ)),
             MathF.PI / 2.0f);
-        const float storedQuaternionLength = 1.000078f;
         skeleton.AnimationParts[0].DynamicFrames[0].Quaternion[0] =
             new Shared.GameFormats.RigidModel.Transforms.RmvVector4(
                 targetBindRotation.X * storedQuaternionLength,
@@ -351,7 +356,15 @@ public class AnimationBuilderTests
             rotation.Y * rotation.Y +
             rotation.Z * rotation.Z +
             rotation.W * rotation.W);
-        Assert.That(rotationLength, Is.EqualTo(1.0f).Within(0.000001f));
+        Assert.Multiple(() =>
+        {
+            Assert.That(rotationLength, Is.EqualTo(1.0f).Within(0.000001f));
+            Assert.That(
+                MathF.Abs(Numerics.Quaternion.Dot(
+                    targetBindRotation,
+                    new Numerics.Quaternion(rotation.X, rotation.Y, rotation.Z, rotation.W))),
+                Is.EqualTo(1.0f).Within(0.000001f));
+        });
     }
 
     [Test]

--- a/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfExternalAnimationImportTests.cs
+++ b/Editors/ImportExportEditor/Test.ImportExport/Importing/Importers/GltfToRmvImporter/GltfExternalAnimationImportTests.cs
@@ -184,12 +184,15 @@ public class GltfExternalAnimationImportTests
         }
     }
 
-    [TestCase(".gltf")]
-    [TestCase(".glb")]
+    [TestCase(".gltf", false)]
+    [TestCase(".glb", false)]
+    [TestCase(".gltf", true)]
+    [TestCase(".glb", true)]
     public void Import_BlenderRoundTripWithUnitScaleKeys_CreatesAnimation(
-        string extension)
+        string extension,
+        bool diagonalBindRotation)
     {
-        var fixture = CreateExistingGameSkeletonRoundTrip(extension);
+        var fixture = CreateExistingGameSkeletonRoundTrip(extension, diagonalBindRotation);
 
         try
         {
@@ -411,7 +414,7 @@ public class GltfExternalAnimationImportTests
     }
 
     private static (string Directory, string Path, AnimationFile Skeleton)
-        CreateExistingGameSkeletonRoundTrip(string extension)
+        CreateExistingGameSkeletonRoundTrip(string extension, bool diagonalBindRotation)
     {
         var geometry = new MeshBuilder<
             VertexPositionNormalTangent,
@@ -452,13 +455,13 @@ public class GltfExternalAnimationImportTests
         else
             modelRoot.SaveGLB(path);
 
-        return (directory, path, CreateStoredGameSkeleton());
+        return (directory, path, CreateStoredGameSkeleton(diagonalBindRotation));
     }
 
-    private static AnimationFile CreateStoredGameSkeleton()
+    private static AnimationFile CreateStoredGameSkeleton(bool diagonalBindRotation)
     {
         var targetBindRotation = Quaternion.CreateFromAxisAngle(
-            Vector3.UnitZ,
+            diagonalBindRotation ? Vector3.Normalize(new Vector3(1, 2, 3)) : Vector3.UnitZ,
             MathF.PI / 2.0f);
         const float storedQuaternionLength = 1.000078f;
         var frame = new AnimationFile.Frame


### PR DESCRIPTION
高级导出原版模型和骨架、不包含动画，再在 Blender 制作动画并高级导入时，原版骨架旋转数值的精度偏差会进入目标绑定矩阵，导致合法动画被误判为剪切。用户提供的嗜血狂魔文件会在第 0 秒的 `wing_left_0` 骨骼处失败。

在构造目标绑定矩阵前归一化旋转，消除由旋转数值长度误差引入的缩放和剪切。保留原有的真实缩放、剪切校验，并扩展不同旋转轴和 `.gltf` / `.glb` 文件导入的回归测试。

验证（复用本次修复已完成的本地结果）：

- 新增覆盖在修复前有 3 项触发同类剪切误报，修复后通过。
- `dotnet test Editors/ImportExportEditor/Test.ImportExport/Test.ImportExport.csproj --configuration Release --no-restore`：Release 构建成功，137 项通过、0 失败、0 跳过，退出码 0。
- 用户提供的原版文件和 Blender 编辑文件均完成模型、材质导入；编辑文件生成 141 根骨骼、31 帧动画，ANIM 保存回读及逐帧数值比较通过，输入附件保持不变。
- `git diff --check` 通过；用户已反馈测试无误。未执行游戏内验证。
