### PR TITLE
修复弹窗关闭确认、显示顺序与主题布局

### DIFF
--- a/AssetEditor/Views/Settings/SettingsWindow.xaml
+++ b/AssetEditor/Views/Settings/SettingsWindow.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="AssetEditor.Views.Settings.SettingsWindow"
+﻿<Window Style="{DynamicResource CustomWindowStyle}"
+    x:Class="AssetEditor.Views.Settings.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/AssetEditor/Views/Updater/UpdaterWindow.xaml
+++ b/AssetEditor/Views/Updater/UpdaterWindow.xaml
@@ -1,4 +1,5 @@
 ﻿<Window
+    Style="{DynamicResource CustomWindowStyle}"
     x:Class="AssetEditor.Views.Updater.UpdaterWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationKeyframeEditorViewModel.cs
+++ b/Editors/AnimationEditor/AnimationKeyframeEditor/AnimationKeyframeEditorViewModel.cs
@@ -356,7 +356,7 @@ namespace Editors.AnimationVisualEditors.AnimationKeyframeEditor
             var currentFrame = _rider.Player.CurrentFrame;
 
             var result = MessageBox.Show(LocalizationManager.Instance.GetFormat("Msg.RemoveFrameConfirm", currentFrame), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-            if (result == DialogResult.No) return;
+            if (result != DialogResult.Yes) return;
 
             _commandFactory.Create<DeleteFrameBoneCommand>().Configure(x => x.Configure(_rider.AnimationClip, currentFrame)).BuildAndExecute();
             _selectionComponent.SetBoneSelectionMode();

--- a/Editors/AnimationEditor/AnimationKeyframeEditor/CopyPasteFromClipboardPose.cs
+++ b/Editors/AnimationEditor/AnimationKeyframeEditor/CopyPasteFromClipboardPose.cs
@@ -86,7 +86,7 @@ namespace AnimationEditor.AnimationKeyframeEditor
                 if ((parsedClipboardFrame.SkeletonName != skeleton.SkeletonName) && !_parent.DontWarnDifferentSkeletons.Value)
                 {
                     var result = MessageBox.Show(LocalizationManager.Instance.GetFormat("Msg.SkeletonMismatch", parsedClipboardFrame.SkeletonName, skeleton.SkeletonName), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-                    if (result == DialogResult.No) return;
+                    if (result != DialogResult.Yes) return;
                 }
 
                 _parent.CommandFactory.Create<PasteWholeInRangeTransformFromClipboardBoneCommand>().Configure(x => x.Configure(
@@ -129,7 +129,7 @@ namespace AnimationEditor.AnimationKeyframeEditor
                 if ((parsedClipboardFrame.SkeletonName != skeleton.SkeletonName) && !_parent.DontWarnDifferentSkeletons.Value)
                 {
                     var result = MessageBox.Show(LocalizationManager.Instance.GetFormat("Msg.SkeletonMismatch", parsedClipboardFrame.SkeletonName, skeleton.SkeletonName), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-                    if (result == DialogResult.No) return;
+                    if (result != DialogResult.Yes) return;
                 }
 
                 var framesCount = parsedClipboardFrame.Frames.Keys.Count;
@@ -184,7 +184,7 @@ namespace AnimationEditor.AnimationKeyframeEditor
                 if ((parsedClipboardFrame.SkeletonName != skeleton.SkeletonName) && !_parent.DontWarnDifferentSkeletons.Value)
                 {
                     var result = MessageBox.Show(LocalizationManager.Instance.GetFormat("Msg.SkeletonMismatch", parsedClipboardFrame.SkeletonName, skeleton.SkeletonName), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-                    if (result == DialogResult.No) return;
+                    if (result != DialogResult.Yes) return;
                 }
 
                 var pastedFramesLength = parsedClipboardFrame.Frames.Count;
@@ -246,7 +246,7 @@ namespace AnimationEditor.AnimationKeyframeEditor
                 if ((parsedClipboardFrame.SkeletonName != skeleton.SkeletonName) && !_parent.DontWarnDifferentSkeletons.Value)
                 {
                     var result = MessageBox.Show(LocalizationManager.Instance.GetFormat("Msg.SkeletonMismatch", parsedClipboardFrame.SkeletonName, skeleton.SkeletonName), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-                    if (result == DialogResult.No) return;
+                    if (result != DialogResult.Yes) return;
                 }
 
 
@@ -305,7 +305,7 @@ namespace AnimationEditor.AnimationKeyframeEditor
                 if ((parsedClipboardFrame.SkeletonName != skeleton.SkeletonName) && !_parent.DontWarnDifferentSkeletons.Value)
                 {
                     var result = MessageBox.Show(LocalizationManager.Instance.GetFormat("Msg.SkeletonMismatch", parsedClipboardFrame.SkeletonName, skeleton.SkeletonName), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-                    if (result == DialogResult.No) return;
+                    if (result != DialogResult.Yes) return;
                 }
 
                 var framesCount = parsedClipboardFrame.Frames.Keys.Count;
@@ -367,7 +367,7 @@ namespace AnimationEditor.AnimationKeyframeEditor
                 if ((parsedClipboardFrame.SkeletonName != skeleton.SkeletonName) && !_parent.DontWarnDifferentSkeletons.Value)
                 {
                     var result = MessageBox.Show(LocalizationManager.Instance.GetFormat("Msg.SkeletonMismatch", parsedClipboardFrame.SkeletonName, skeleton.SkeletonName), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-                    if (result == DialogResult.No) return;
+                    if (result != DialogResult.Yes) return;
                 }
 
                 _parent.CommandFactory.Create<PasteIntoSelectedBonesInRangeTransformFromClipboardBoneCommand>().Configure(x => x.Configure(

--- a/Editors/AnimationEditor/MountAnimationCreator/Views/BatchProcessOptionsWindow.xaml
+++ b/Editors/AnimationEditor/MountAnimationCreator/Views/BatchProcessOptionsWindow.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="AnimationEditor.MountAnimationCreator.BatchProcessOptionsWindow"
+﻿<Window Style="{DynamicResource CustomWindowStyle}"
+    x:Class="AnimationEditor.MountAnimationCreator.BatchProcessOptionsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Editors/AnimationReTarget/Editors.AnimatioReTarget/Editor/Saving/SaveWindow.xaml.cs
+++ b/Editors/AnimationReTarget/Editors.AnimatioReTarget/Editor/Saving/SaveWindow.xaml.cs
@@ -143,6 +143,7 @@ namespace Editors.AnimatioReTarget.Editor.Saving
                 _settings.BatchTargetFolder,
                 _settings.BatchOverwriteExisting);
             BatchAnimationRetargetResult? result = null;
+            Exception? batchException = null;
             SetBatchOperationState(true);
             ResetProgress();
             _batchCancellation = new CancellationTokenSource();
@@ -160,17 +161,23 @@ namespace Editors.AnimatioReTarget.Editor.Saving
             }
             catch (Exception exception)
             {
-                _standardDialogs.ShowExceptionWindow(
-                    exception,
-                    LocalizationManager.Instance.Get(
-                        "AnimReTarget.Batch.Error.ExecutionFailed"));
+                batchException = exception;
             }
             finally
             {
                 _batchCancellation.Dispose();
                 _batchCancellation = null;
+                _batchProgress.CancelCommand = null;
                 await _batchProgress.CompleteAsync();
                 SetBatchOperationState(false);
+            }
+
+            if (batchException != null)
+            {
+                _standardDialogs.ShowExceptionWindow(
+                    batchException,
+                    LocalizationManager.Instance.Get(
+                        "AnimReTarget.Batch.Error.ExecutionFailed"));
             }
 
             if (result != null)

--- a/Editors/Audio/AudioProjectConverter/AudioProjectConverterViewModel.cs
+++ b/Editors/Audio/AudioProjectConverter/AudioProjectConverterViewModel.cs
@@ -41,6 +41,7 @@ namespace Editors.Audio.AudioProjectConverter
 
         private readonly ILogger _logger = Logging.Create<AudioProjectConverterViewModel>();
         private System.Action _closeAction;
+        private Func<Task> _completeProgressAction = () => Task.CompletedTask;
 
         [ObservableProperty] private string _audioProjectName;
         [ObservableProperty] private string _outputDirectoryPath;
@@ -111,6 +112,7 @@ namespace Editors.Audio.AudioProjectConverter
             ProgressMaximum = 0;
             ProgressIsIndeterminate = true;
             UpdateOkButtonIsEnabled();
+            Exception? loadException = null;
             try
             {
                 var progress = new Progress<AudioLoadProgress>(value =>
@@ -139,18 +141,24 @@ namespace Editors.Audio.AudioProjectConverter
             }
             catch (Exception exception)
             {
+                loadException = exception;
                 Status = LocalizationManager.Instance.Get(
                     "AudioProjectConverter.LoadFailed");
-                _standardDialogs.ShowDialogBox(
-                    LocalizationManager.Instance.GetFormat(
-                        "AudioProjectConverter.LoadFailed.Detail",
-                        exception.Message),
-                    LocalizationManager.Instance.Get("Msg.GeneralError"));
             }
             finally
             {
+                await _completeProgressAction();
                 IsLoading = false;
                 UpdateOkButtonIsEnabled();
+            }
+
+            if (loadException != null && !cancellationToken.IsCancellationRequested)
+            {
+                _standardDialogs.ShowDialogBox(
+                    LocalizationManager.Instance.GetFormat(
+                        "AudioProjectConverter.LoadFailed.Detail",
+                        loadException.Message),
+                    LocalizationManager.Instance.Get("Msg.GeneralError"));
             }
         }
 
@@ -267,6 +275,8 @@ namespace Editors.Audio.AudioProjectConverter
                     cancellationToken,
                     _lifetimeCancellationToken);
             IsProcessing = true;
+            Exception? conversionException = null;
+            var saved = false;
             Status = LocalizationManager.Instance.Get(
                 "AudioProjectConverter.Processing");
             ProgressDetail = Status;
@@ -308,7 +318,7 @@ namespace Editors.Audio.AudioProjectConverter
                         outputs.Count,
                         outputs.Count));
                     Status = string.Empty;
-                    CloseWindowAction();
+                    saved = true;
                 }
             }
             catch (OperationCanceledException)
@@ -318,22 +328,30 @@ namespace Editors.Audio.AudioProjectConverter
             }
             catch (Exception exception)
             {
+                conversionException = exception;
                 _logger.Here().Error(
                     exception,
                     "Audio Project conversion failed");
                 Status = LocalizationManager.Instance.Get(
                     "AudioProjectConverter.Failed");
-                _standardDialogs.ShowDialogBox(
-                    LocalizationManager.Instance.GetFormat(
-                        "AudioProjectConverter.Failed.Detail",
-                        exception.Message),
-                    LocalizationManager.Instance.Get("Msg.GeneralError"));
             }
             finally
             {
                 TryDeleteWorkspace(workspacePath);
+                await _completeProgressAction();
                 IsProcessing = false;
             }
+
+            if (conversionException != null && !linkedCancellation.IsCancellationRequested)
+            {
+                _standardDialogs.ShowDialogBox(
+                    LocalizationManager.Instance.GetFormat(
+                        "AudioProjectConverter.Failed.Detail",
+                        conversionException.Message),
+                    LocalizationManager.Instance.Get("Msg.GeneralError"));
+            }
+            else if (saved)
+                CloseWindowAction();
         }
 
         private List<AudioPackOutput> CreateConversionOutputs(
@@ -1287,5 +1305,8 @@ namespace Editors.Audio.AudioProjectConverter
         [RelayCommand] public void CloseWindowAction() => _closeAction?.Invoke();
 
         public void SetCloseAction(System.Action closeAction) =>_closeAction = closeAction;
+
+        public void SetProgressCompletionAction(Func<Task> completeProgressAction) =>
+            _completeProgressAction = completeProgressAction;
     }
 }

--- a/Editors/Audio/AudioProjectConverter/AudioProjectConverterWindow.xaml
+++ b/Editors/Audio/AudioProjectConverter/AudioProjectConverterWindow.xaml
@@ -229,6 +229,7 @@
         </Grid>
 
         <Grid
+            x:Name="ProgressSurface"
             Grid.Row="2"
             Margin="16,0,16,12">
             <progress:OperationProgressWindowHost

--- a/Editors/Audio/AudioProjectConverter/AudioProjectConverterWindow.xaml.cs
+++ b/Editors/Audio/AudioProjectConverter/AudioProjectConverterWindow.xaml.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Threading;
+using System.Linq;
 using System.ComponentModel;
 using System.Windows;
 using CommonControls;
+using Shared.Ui.Common.OperationProgress;
 
 namespace Editors.Audio.AudioProjectConverter
 {
@@ -11,10 +13,14 @@ namespace Editors.Audio.AudioProjectConverter
         private readonly CancellationTokenSource _initializationCancellation =
             new();
         private bool _closeWhenIdle;
+        private readonly OperationProgressWindowHost _operationProgressHost;
 
         public AudioProjectConverterWindow()
         {
             InitializeComponent();
+            _operationProgressHost = ProgressSurface.Children
+                .OfType<OperationProgressWindowHost>()
+                .Single();
             DarkTitleBarHelper.Enable(this);
             Loaded += AudioProjectConverterWindowLoaded;
         }
@@ -26,6 +32,7 @@ namespace Editors.Audio.AudioProjectConverter
             if (DataContext is AudioProjectConverterViewModel viewModel)
             {
                 viewModel.SetCloseAction(Close);
+                viewModel.SetProgressCompletionAction(_operationProgressHost.CompleteAsync);
                 viewModel.PropertyChanged += OnViewModelPropertyChanged;
                 await viewModel.InitializeAsync(
                     _initializationCancellation.Token);

--- a/Editors/Audio/AudioProjectMerger/AudioProjectMergerWindow.xaml
+++ b/Editors/Audio/AudioProjectMerger/AudioProjectMergerWindow.xaml
@@ -1,4 +1,5 @@
 ﻿<Window
+    Style="{DynamicResource CustomWindowStyle}"
     x:Class="Editors.Audio.AudioProjectMerger.AudioProjectMergerWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Presentation/ExportWindow.xaml
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Presentation/ExportWindow.xaml
@@ -26,7 +26,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid>
+        <Grid IsEnabled="{Binding IsEnabled, ElementName=ExportButton}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="120" />
                 <ColumnDefinition Width="*" />
@@ -71,6 +71,7 @@
 
         <Border
             Grid.Row="1"
+            IsEnabled="{Binding IsEnabled, ElementName=ExportButton}"
             Margin="0,14,0,0"
             Padding="12"
             Background="{DynamicResource AeBrush.Surface}"
@@ -90,6 +91,7 @@
             <Button
                 Margin="0,0,8,0"
                 Content="{loc:Loc General.Cancel}"
+                IsEnabled="{Binding IsEnabled, ElementName=ExportButton}"
                 IsCancel="True" />
             <Button
                 x:Name="ExportButton"

--- a/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Presentation/ExportWindow.xaml.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Exporting/Presentation/ExportWindow.xaml.cs
@@ -1,8 +1,11 @@
 using System.IO;
 using System.Windows;
+using System.ComponentModel;
+using System.Windows.Controls;
 using Editors.ImportExport.Common;
 using Shared.Core.PackFiles.Models;
 using Shared.Core.Services;
+using Shared.Ui.Common.OperationProgress;
 using WindowHandling;
 
 namespace Editors.ImportExport.Exporting.Presentation;
@@ -11,12 +14,16 @@ public partial class ExportWindow : AssetEditorWindow
 {
     private readonly ExporterCoreViewModel _viewModel;
     private readonly IStandardDialogs _standardDialogs;
+    private readonly OperationProgressWindowHost _exportOperationProgress;
 
     public ExportWindow(
         ExporterCoreViewModel viewModel,
         IStandardDialogs standardDialogs)
     {
         InitializeComponent();
+        _exportOperationProgress = ((Grid)Content).Children
+            .OfType<OperationProgressWindowHost>()
+            .Single();
         _viewModel = viewModel;
         _standardDialogs = standardDialogs;
         DataContext = _viewModel;
@@ -29,6 +36,9 @@ public partial class ExportWindow : AssetEditorWindow
 
     private async void ExportButton_Click(object sender, RoutedEventArgs e)
     {
+        if (_viewModel.IsOperationActive)
+            return;
+
         if (!PathValidator.IsValid(_viewModel.SystemPath))
         {
             _standardDialogs.ShowDialogBox(
@@ -40,22 +50,37 @@ public partial class ExportWindow : AssetEditorWindow
         ExportButton.IsEnabled = false;
         _viewModel.IsOperationActive = true;
         var succeeded = false;
+        Exception? exportException = null;
         try
         {
             succeeded = await _viewModel.ExportAsync();
         }
         catch (Exception ex)
         {
-            _standardDialogs.ShowExceptionWindow(ex, "高级 glTF 导出失败。");
+            exportException = ex;
         }
         finally
         {
+            await _exportOperationProgress.CompleteAsync();
             _viewModel.IsOperationActive = false;
             ExportButton.IsEnabled = true;
         }
 
+        if (exportException != null)
+        {
+            _standardDialogs.ShowExceptionWindow(exportException, "高级 glTF 导出失败。");
+            return;
+        }
+
         if (succeeded)
             Close();
+    }
+
+    protected override void OnClosing(CancelEventArgs e)
+    {
+        if (_viewModel.IsOperationActive)
+            e.Cancel = true;
+        base.OnClosing(e);
     }
 }
 

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml
@@ -27,7 +27,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid>
+        <Grid IsEnabled="{Binding IsEnabled, ElementName=ImportButton}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="120" />
                 <ColumnDefinition Width="*" />
@@ -64,6 +64,7 @@
 
         <Border
             Grid.Row="1"
+            IsEnabled="{Binding IsEnabled, ElementName=ImportButton}"
             Margin="0,14,0,0"
             Padding="12"
             Background="{DynamicResource AeBrush.Surface}"
@@ -96,6 +97,7 @@
             <Button
                 Margin="0,0,8,0"
                 Content="{loc:Loc General.Cancel}"
+                IsEnabled="{Binding IsEnabled, ElementName=ImportButton}"
                 IsCancel="True" />
             <Button
                 x:Name="ImportButton"

--- a/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml.cs
+++ b/Editors/ImportExportEditor/Editors.ImportExport/Importing/Presentation/ImportWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using CommunityToolkit.Mvvm.Input;
+using System.ComponentModel;
 using Editors.ImportExport.Common;
 using System.Windows.Controls;
 using Editors.ImportExport.Exporting.Presentation;
@@ -41,6 +42,9 @@ public partial class ImportWindow : AssetEditorWindow
 
     private async void ImportButton_Click(object sender, RoutedEventArgs e)
     {
+        if (_viewModel.IsOperationActive)
+            return;
+
         if (!PathValidator.IsValid(_viewModel.SystemPath))
         {
             _standardDialogs.ShowDialogBox(
@@ -53,6 +57,7 @@ public partial class ImportWindow : AssetEditorWindow
         ResetProgress();
         _viewModel.IsOperationActive = true;
         ImportResult? result = null;
+        Exception? importException = null;
         try
         {
             var progress = new Progress<OperationProgressUpdate>(ApplyProgress);
@@ -71,16 +76,22 @@ public partial class ImportWindow : AssetEditorWindow
         }
         catch (Exception ex)
         {
-            _standardDialogs.ShowExceptionWindow(ex, "高级 glTF/GLB 导入失败。");
+            importException = ex;
         }
         finally
         {
             _importCancellation?.Dispose();
             _importCancellation = null;
             _importOperationProgress.CancelCommand = null;
-            _viewModel.IsOperationActive = false;
             await _importOperationProgress.CompleteAsync();
+            _viewModel.IsOperationActive = false;
             ImportButton.IsEnabled = true;
+        }
+
+        if (importException != null)
+        {
+            _standardDialogs.ShowExceptionWindow(importException, "高级 glTF/GLB 导入失败。");
+            return;
         }
 
         if (result == null)
@@ -109,6 +120,13 @@ public partial class ImportWindow : AssetEditorWindow
             resultMessage,
             LocalizationManager.Instance.Get("ImportWindow.FailureTitle"),
             UiMessageBoxIcon.Error);
+    }
+
+    protected override void OnClosing(CancelEventArgs e)
+    {
+        if (_viewModel.IsOperationActive)
+            e.Cancel = true;
+        base.OnClosing(e);
     }
 
     private void ResetProgress()

--- a/Editors/Kitbashing/KitbasherEditor/ChildEditors/SaveDialog/SaveDialogWindow.xaml
+++ b/Editors/Kitbashing/KitbasherEditor/ChildEditors/SaveDialog/SaveDialogWindow.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="Editors.KitbasherEditor.ViewModels.SaveDialog.SaveDialogWindow"
+﻿<Window Style="{DynamicResource CustomWindowStyle}"
+    x:Class="Editors.KitbasherEditor.ViewModels.SaveDialog.SaveDialogWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Editors/Shared/Editors.Shared.Core/Editors/BoneMapping/View/BoneMappingWindow.xaml
+++ b/Editors/Shared/Editors.Shared.Core/Editors/BoneMapping/View/BoneMappingWindow.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="CommonControls.Editors.BoneMapping.View.BoneMappingWindow"
+﻿<Window Style="{DynamicResource CustomWindowStyle}"
+    x:Class="CommonControls.Editors.BoneMapping.View.BoneMappingWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Editors/Shared/Editors.Shared.Core/Editors/TextEditor/TextEditorViewModel.cs
+++ b/Editors/Shared/Editors.Shared.Core/Editors/TextEditor/TextEditorViewModel.cs
@@ -105,7 +105,7 @@ namespace Shared.Ui.Editors.TextEditor
 
                 if (_converter.CanSaveOnError())
                 {
-                    if (MessageBox.Show(LocalizationManager.Instance.GetFormat("Msg.SaveWithErrors", error.Text), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButton.YesNo) == MessageBoxResult.No)
+                    if (MessageBox.Show(LocalizationManager.Instance.GetFormat("Msg.SaveWithErrors", error.Text), LocalizationManager.Instance.Get("Msg.GeneralError"), MessageBoxButton.YesNo) != MessageBoxResult.Yes)
                         return false;
                 }
                 else

--- a/Shared/SharedUI/BaseDialogs/ColourPickerButton/ColourPickerButtonView.xaml
+++ b/Shared/SharedUI/BaseDialogs/ColourPickerButton/ColourPickerButtonView.xaml
@@ -18,6 +18,7 @@
     </UserControl.Resources>
     <Grid>
         <ToggleButton x:Name="PickerButton" Style="{StaticResource AeEditor.ToggleIcon}"
+                      Width="Auto" Height="Auto" Padding="2"
                       ToolTip="{loc:Loc Shared.ColourPicker.Choose}" AutomationProperties.Name="{loc:Loc Shared.ColourPicker.Choose}">
             <Border Width="18" Height="18" BorderBrush="{DynamicResource AeBrush.BorderStrong}" BorderThickness="1">
                 <Border.Background><SolidColorBrush Color="{Binding PickedColor}"/></Border.Background>

--- a/Shared/SharedUI/BaseDialogs/ControllerHostWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/ControllerHostWindow.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="CommonControls.BaseDialogs.ControllerHostWindow"
+﻿<Window Style="{DynamicResource CustomWindowStyle}"
+    x:Class="CommonControls.BaseDialogs.ControllerHostWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Shared/SharedUI/BaseDialogs/SelectionListDialog/SelectionListWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/SelectionListDialog/SelectionListWindow.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="CommonControls.SelectionListDialog.SelectionListWindow"
+﻿<Window Style="{DynamicResource CustomWindowStyle}"
+    x:Class="CommonControls.SelectionListDialog.SelectionListWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/ErrorDialog/ErrorListWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/ErrorDialog/ErrorListWindow.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="CommonControls.BaseDialogs.ErrorListDialog.ErrorListWindow"
+﻿<Window Style="{DynamicResource CustomWindowStyle}"
+    x:Class="CommonControls.BaseDialogs.ErrorListDialog.ErrorListWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/ErrorDialog/ErrorListWindow.xaml.cs
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/ErrorDialog/ErrorListWindow.xaml.cs
@@ -11,6 +11,7 @@ using Microsoft.Win32;
 using Shared.Core.ErrorHandling;
 using Shared.Core.Services;
 using Shared.Ui.BaseDialogs.ErrorListDialog;
+using WindowHandling;
 using static Shared.Ui.BaseDialogs.ErrorListDialog.ErrorListViewModel;
 
 namespace CommonControls.BaseDialogs.ErrorListDialog
@@ -22,7 +23,7 @@ namespace CommonControls.BaseDialogs.ErrorListDialog
     {
         public ErrorListWindow()
         {
-            Owner = System.Windows.Application.Current.MainWindow;
+            AssetEditorWindow.SetOwnerToActiveWindow(this);
             InitializeComponent();
             DarkTitleBarHelper.Enable(this);
         }

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/ExceptionHandling/CustomExceptionWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/ExceptionHandling/CustomExceptionWindow.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="Shared.Ui.Common.Exceptions.CustomExceptionWindow"
+﻿<Window Style="{DynamicResource CustomWindowStyle}"
+    x:Class="Shared.Ui.Common.Exceptions.CustomExceptionWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/MessageDialogWindow.xaml.cs
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/MessageDialogWindow.xaml.cs
@@ -24,6 +24,13 @@ public partial class MessageDialogWindow : AssetEditorWindow
         MessageBoxImage image = MessageBoxImage.None)
     {
         InitializeComponent();
+        Result = buttonSet switch
+        {
+            MessageDialogButtonSet.Ok => MessageBoxResult.OK,
+            MessageDialogButtonSet.YesNo => MessageBoxResult.No,
+            _ => MessageBoxResult.Cancel,
+        };
+        NoButton.IsCancel = buttonSet == MessageDialogButtonSet.YesNo;
         Title = title;
         MessageText.Text = message;
         MessageImage = image;

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/PackFile/SavePackFileWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/PackFile/SavePackFileWindow.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="Shared.Ui.BaseDialogs.StandardDialog.PackFile.SavePackFileWindow"
+﻿<Window Style="{DynamicResource CustomWindowStyle}"
+    x:Class="Shared.Ui.BaseDialogs.StandardDialog.PackFile.SavePackFileWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/PackFile/SavePackFileWindow.xaml.cs
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/PackFile/SavePackFileWindow.xaml.cs
@@ -63,7 +63,7 @@ namespace Shared.Ui.BaseDialogs.StandardDialog.PackFile
 
             if (SelectedFile != null)
             {
-                if (MessageBox.Show(LocalizationManager.Instance.Get("Msg.ReplaceFile"), "", System.Windows.MessageBoxButton.YesNo) == System.Windows.MessageBoxResult.No)
+                if (MessageBox.Show(LocalizationManager.Instance.Get("Msg.ReplaceFile"), "", System.Windows.MessageBoxButton.YesNo) != System.Windows.MessageBoxResult.Yes)
                     return;
             }
 

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/StandardDialogs.cs
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/StandardDialogs.cs
@@ -13,6 +13,7 @@ using Shared.Core.Services;
 using Shared.Ui.BaseDialogs.PackFileTree;
 using Shared.Ui.BaseDialogs.StandardDialog.PackFile;
 using Shared.Ui.Common.Exceptions;
+using WindowHandling;
 
 namespace Shared.Ui.BaseDialogs.StandardDialog
 {
@@ -161,14 +162,7 @@ namespace Shared.Ui.BaseDialogs.StandardDialog
 
         private static void ApplyOwner(Window window)
         {
-            var owner = Application.Current?.MainWindow;
-            if (owner != null &&
-                owner.IsLoaded &&
-                !ReferenceEquals(owner, window) &&
-                window.Owner == null)
-            {
-                window.Owner = owner;
-            }
+            AssetEditorWindow.SetOwnerToActiveWindow(window);
         }
 
         private static bool? ShowOwnedDialog(Window window)

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/Text/TextInputWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/Text/TextInputWindow.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="CommonControls.BaseDialogs.TextInputWindow"
+﻿<Window Style="{DynamicResource CustomWindowStyle}"
+    x:Class="CommonControls.BaseDialogs.TextInputWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/Text/TextInputWindow.xaml.cs
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/Text/TextInputWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows;
 using System.Windows.Input;
 using CommonControls;
+using WindowHandling;
 
 namespace CommonControls.BaseDialogs
 {
@@ -21,7 +22,7 @@ namespace CommonControls.BaseDialogs
             DarkTitleBarHelper.Enable(this);
             Title = title;
             TextValue = initialValue;
-            Owner = Application.Current.MainWindow;
+            AssetEditorWindow.SetOwnerToActiveWindow(this);
 
             if (focusTextInput)
             {

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/Text/TitleDescriptionInputWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/Text/TitleDescriptionInputWindow.xaml
@@ -1,4 +1,5 @@
 <Window
+    Style="{DynamicResource CustomWindowStyle}"
     x:Class="CommonControls.BaseDialogs.TitleDescriptionInputWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/Shared/SharedUI/BaseDialogs/StandardDialog/UnifiedMessageBox.cs
+++ b/Shared/SharedUI/BaseDialogs/StandardDialog/UnifiedMessageBox.cs
@@ -1,6 +1,6 @@
-using System.Linq;
 using System.Windows;
 using Shared.Core.Services;
+using WindowHandling;
 
 using DialogResult = System.Windows.Forms.DialogResult;
 using MessageBoxButtons = System.Windows.Forms.MessageBoxButtons;
@@ -71,12 +71,7 @@ public static class UnifiedMessageBox
             message,
             ToButtonSet(buttons),
             image);
-        var owner = application.Windows
-            .OfType<Window>()
-            .FirstOrDefault(window => window.IsActive) ??
-            application.MainWindow;
-        if (owner is { IsLoaded: true } && owner != dialog)
-            dialog.Owner = owner;
+        AssetEditorWindow.SetOwnerToActiveWindow(dialog);
         dialog.ShowDialog();
         return dialog.Result;
     }

--- a/Shared/SharedUI/BaseDialogs/ToolSelector/ToolSelectorUiProvider.cs
+++ b/Shared/SharedUI/BaseDialogs/ToolSelector/ToolSelectorUiProvider.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
-using System.Windows;
 using CommonControls.BaseDialogs.ToolSelector;
 using Shared.Core.ToolCreation;
+using WindowHandling;
 
 namespace Shared.Ui.BaseDialogs.ToolSelector
 {
@@ -9,7 +9,8 @@ namespace Shared.Ui.BaseDialogs.ToolSelector
     {
         public EditorEnums CreateAndShow(IEnumerable<EditorEnums> editors)
         {
-            var window = new ToolSelectorWindow() { Owner = Application.Current.MainWindow };
+            var window = new ToolSelectorWindow();
+            AssetEditorWindow.SetOwnerToActiveWindow(window);
 
             foreach (var tool in editors)
                 window.PossibleTools.Items.Add(tool);

--- a/Shared/SharedUI/BaseDialogs/ToolSelector/ToolSelectorWindow.xaml
+++ b/Shared/SharedUI/BaseDialogs/ToolSelector/ToolSelectorWindow.xaml
@@ -1,4 +1,5 @@
-﻿<Window x:Class="CommonControls.BaseDialogs.ToolSelector.ToolSelectorWindow"
+﻿<Window Style="{DynamicResource CustomWindowStyle}"
+    x:Class="CommonControls.BaseDialogs.ToolSelector.ToolSelectorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/Shared/SharedUI/Common/AssetEditorWindow.cs
+++ b/Shared/SharedUI/Common/AssetEditorWindow.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Windows;
 using System.Windows.Media;
 using CommonControls;
@@ -15,9 +16,7 @@ namespace WindowHandling
 
         public AssetEditorWindow()
         {
-            var mainWindow = Application.Current?.MainWindow;
-            if (mainWindow != null && mainWindow != this && mainWindow.IsLoaded)
-                Owner = mainWindow;
+            SetOwnerToActiveWindow(this);
             Deactivated += AssetEdWindow_Deactivated;
             SetResourceReference(StyleProperty, "CustomWindowStyle");
             SetResourceReference(BackgroundProperty, "AeBrush.Canvas");
@@ -25,6 +24,16 @@ namespace WindowHandling
             SetResourceReference(FontFamilyProperty, "AppFontFamily");
             SetResourceReference(FontWeightProperty, "AppFontWeight");
             DarkTitleBarHelper.Enable(this);
+        }
+
+        public static void SetOwnerToActiveWindow(Window window)
+        {
+            var application = Application.Current;
+            var owner = application?.Windows.OfType<Window>()
+                .FirstOrDefault(candidate => candidate != window && candidate.IsActive) ??
+                window.Owner ?? application?.MainWindow;
+            if (owner is { IsLoaded: true } && owner != window)
+                window.Owner = owner;
         }
 
         private void AssetEdWindow_Deactivated(object? sender, EventArgs e)

--- a/Testing/AssetEditorTests/AudioEditorReliabilityTests.cs
+++ b/Testing/AssetEditorTests/AudioEditorReliabilityTests.cs
@@ -1252,6 +1252,8 @@ namespace AssetEditorTests
         [TestMethod]
         public async Task AudioProjectConverter_WhenRepositoryLoadFails_RemainsDisabled()
         {
+            var dialogs = new Mock<IStandardDialogs>();
+            var progressCompleted = false;
             var repository = new Mock<IAudioRepository>();
             repository
                 .Setup(x => x.Load(
@@ -1260,7 +1262,7 @@ namespace AssetEditorTests
                     It.IsAny<CancellationToken>()))
                 .Throws(new InvalidOperationException("load failed"));
             var viewModel = new AudioProjectConverterViewModel(
-                Mock.Of<IStandardDialogs>(),
+                dialogs.Object,
                 Mock.Of<IAudioPackOutputService>(),
                 repository.Object,
                 Mock.Of<IAudioEditorFileService>(),
@@ -1276,9 +1278,22 @@ namespace AssetEditorTests
                 IsUsingWwiseProject = false
             };
 
+            viewModel.SetProgressCompletionAction(() =>
+            {
+                progressCompleted = true;
+                return Task.CompletedTask;
+            });
+            dialogs.Setup(service => service.ShowDialogBox(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback(() =>
+                {
+                    Assert.IsTrue(progressCompleted);
+                    Assert.IsFalse(viewModel.IsBusy);
+                });
+
             await viewModel.InitializeAsync(CancellationToken.None);
 
             Assert.IsFalse(viewModel.IsOkButtonEnabled);
+            dialogs.Verify(service => service.ShowDialogBox(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
 
         [TestMethod]

--- a/Testing/AssetEditorTests/DialogWorkflowRegressionTests.cs
+++ b/Testing/AssetEditorTests/DialogWorkflowRegressionTests.cs
@@ -1,0 +1,341 @@
+﻿using System.Diagnostics;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using Editors.ImportExport.Exporting.Exporters;
+using Editors.ImportExport.Exporting.Presentation;
+using Editors.ImportExport.Importing;
+using Editors.ImportExport.Importing.Presentation;
+using Editors.ImportExport.Misc;
+using Moq;
+using NUnit.Framework;
+using Shared.Core.Events;
+using Shared.Core.PackFiles;
+using Shared.Core.PackFiles.Models;
+using Shared.Core.Services;
+using Shared.Core.Settings;
+using Shared.Ui.BaseDialogs.PackFileTree;
+using Shared.Ui.BaseDialogs.PackFileTree.ContextMenu;
+using Shared.Ui.BaseDialogs.StandardDialog;
+using Shared.Ui.BaseDialogs.StandardDialog.PackFile;
+using Shared.Ui.Common.OperationProgress;
+using WindowHandling;
+using NUnitAssert = NUnit.Framework.Assert;
+
+namespace AssetEditorTests;
+
+[NonParallelizable]
+public class DialogWorkflowRegressionTests
+{
+    [TestCase(MessageBoxButton.OK, MessageBoxResult.OK)]
+    [TestCase(MessageBoxButton.OKCancel, MessageBoxResult.Cancel)]
+    [TestCase(MessageBoxButton.YesNo, MessageBoxResult.No)]
+    [TestCase(MessageBoxButton.YesNoCancel, MessageBoxResult.Cancel)]
+    public void Confirmation_TitleBarCloseReturnsSafeResult(
+        MessageBoxButton buttons,
+        MessageBoxResult expected)
+    {
+        WithWindows(() =>
+        {
+            Later(() => CloseTitleBar(Application.Current.Windows
+                .OfType<MessageDialogWindow>().Single()));
+            var result = UnifiedMessageBox.Show("关闭确认测试", "确认", buttons);
+            NUnitAssert.That(result, Is.EqualTo(expected));
+        });
+    }
+
+    [TestCase("YesButton", true)]
+    [TestCase("NoButton", false)]
+    [TestCase("btnClose", false)]
+    public void OverwriteConfirmation_OnlyYesAcceptsSave(string buttonName, bool expected)
+    {
+        WithWindows(() =>
+        {
+            var files = new Mock<IPackFileService>();
+            files.Setup(service => service.GetAllPackfileContainers()).Returns([]);
+            files.Setup(service => service.GetFullPath(
+                    It.IsAny<PackFile>(), It.IsAny<PackFileContainer>()))
+                .Returns("test\\existing.anim");
+            var contextMenu = new Mock<IContextMenuBuilder>();
+            contextMenu.SetupGet(builder => builder.Type).Returns(ContextMenuType.Simple);
+            var factory = new PackFileTreeViewFactory(
+                new ApplicationSettingsService(GameTypeEnum.Warhammer3),
+                files.Object,
+                Mock.Of<IEventHub>(),
+                new ContextMenuFactory([contextMenu.Object]));
+            using var save = new SavePackFileWindow(files.Object, factory)
+            {
+                CurrentFileName = "existing.anim",
+                SelectedFile = new PackFile("existing.anim", null!),
+            };
+            Later(() =>
+            {
+                Later(() =>
+                {
+                    var confirmation = Application.Current.Windows
+                        .OfType<MessageDialogWindow>().Single();
+                    if (buttonName == "btnClose")
+                        CloseTitleBar(confirmation);
+                    else
+                        Click((Button)confirmation.FindName(buttonName));
+                });
+                Click(FindChildren<Button>(save).Single(button => button.IsDefault));
+                if (save.IsVisible)
+                    save.Close();
+            });
+
+            NUnitAssert.That(save.ShowDialog() == true, Is.EqualTo(expected));
+            NUnitAssert.That(save.FilePath,
+                expected ? Is.EqualTo("test\\existing.anim") : Is.Null.Or.Empty);
+        });
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void StandardDialog_UsesActiveChildAsOwner(bool textInput)
+    {
+        WithWindows(() =>
+        {
+            using var child = new AssetEditorWindow
+            {
+                Title = "子操作窗口", Width = 400, Height = 250,
+                Left = -10000, Top = -10000, ShowInTaskbar = false,
+            };
+            var dialogs = new StandardDialogs(null!, null!, null!, null!, null!, null!);
+            Window? actualOwner = null;
+            Later(() =>
+            {
+                child.Activate();
+                Later(() =>
+                {
+                    var dialog = Application.Current.Windows.OfType<Window>()
+                        .Single(window => window != child && window != Application.Current.MainWindow);
+                    actualOwner = dialog.Owner;
+                    dialog.Close();
+                });
+                if (textInput)
+                    dialogs.ShowTextInputDialog("输入测试");
+                else
+                    dialogs.ShowDialogBox("子窗口发起的提示", "提示");
+                child.Close();
+            });
+            child.ShowDialog();
+            NUnitAssert.That(actualOwner, Is.SameAs(child));
+        });
+    }
+
+    [TestCase(true, false, false)]
+    [TestCase(true, true, false)]
+    [TestCase(false, false, false)]
+    [TestCase(false, true, false)]
+    [TestCase(true, false, true)]
+    public void ImportExport_KeepsWindowUntilWorkAndProgressFinish(
+        bool import, bool fail, bool cancel)
+    {
+        var inputPath = Path.GetTempFileName();
+        try
+        {
+            WithWindows(() =>
+            {
+                using var release = new ManualResetEventSlim();
+                var dialogs = new Mock<IStandardDialogs>();
+                var notifications = 0;
+                var progressAtNotification = -1;
+                var activeAtNotification = true;
+                Func<bool> isActive;
+                Window window;
+                if (import)
+                {
+                    var importer = new Mock<IImporterViewModel>();
+                    importer.SetupGet(item => item.SupportsCancellation).Returns(true);
+                    importer.Setup(item => item.CanImportFile(It.IsAny<PackFile>()))
+                        .Returns(ImportSupportEnum.HighPriority);
+                    importer.Setup(item => item.Execute(
+                            It.IsAny<PackFile>(), It.IsAny<string>(),
+                            It.IsAny<PackFileContainer>(), It.IsAny<GameTypeEnum>(),
+                            It.IsAny<IProgress<OperationProgressUpdate>>(),
+                            It.IsAny<CancellationToken>()))
+                        .Returns((PackFile source, string path, PackFileContainer container,
+                            GameTypeEnum game, IProgress<OperationProgressUpdate> progress,
+                            CancellationToken token) =>
+                        {
+                            WaitForRelease(release, token, fail);
+                            return ImportResult.Success(["test\\result.anim"]);
+                        });
+                    var viewModel = new ImporterCoreViewModel([importer.Object],
+                        new ApplicationSettingsService(GameTypeEnum.Warhammer3));
+                    viewModel.Initialize(new PackFileContainer("test"), "test", inputPath);
+                    isActive = () => viewModel.IsOperationActive;
+                    window = new ImportWindow(viewModel, dialogs.Object);
+                }
+                else
+                {
+                    var exporter = new Mock<IExporterViewModel>();
+                    exporter.Setup(item => item.CanExportFile(It.IsAny<PackFile>()))
+                        .Returns(ExportSupportEnum.HighPriority);
+                    exporter.Setup(item => item.Execute(It.IsAny<PackFile>(), It.IsAny<string>()))
+                        .Returns(() =>
+                        {
+                            WaitForRelease(release, CancellationToken.None, fail);
+                            return true;
+                        });
+                    var viewModel = new ExporterCoreViewModel([exporter.Object]);
+                    viewModel.Initialize(new PackFile("source.anim", null!));
+                    viewModel.SystemPath = inputPath;
+                    isActive = () => viewModel.IsOperationActive;
+                    window = new ExportWindow(viewModel, dialogs.Object);
+                }
+
+                void RecordNotification()
+                {
+                    notifications++;
+                    progressAtNotification = ProgressCount(window);
+                    activeAtNotification = isActive();
+                }
+                dialogs.Setup(item => item.ShowExceptionWindow(It.IsAny<Exception>(), It.IsAny<string>()))
+                    .Callback(RecordNotification);
+                dialogs.Setup(item => item.ShowDialogBox(
+                        It.IsAny<string>(), It.IsAny<string>(), It.IsAny<UiMessageBoxIcon>()))
+                    .Callback(RecordNotification);
+                window.Left = -10000;
+                window.Top = -10000;
+                window.ShowInTaskbar = false;
+                window.Show();
+                var start = (Button)window.FindName(import ? "ImportButton" : "ExportButton");
+                try
+                {
+                    Click(start);
+                    PumpUntil(() => ProgressCount(window) == 1);
+                    CloseTitleBar(window);
+                    NUnitAssert.Multiple(() =>
+                    {
+                        NUnitAssert.That(window.IsVisible, Is.True, "Running work must keep its owner visible.");
+                        NUnitAssert.That(isActive(), Is.True);
+                        NUnitAssert.That(FindChildren<Button>(window)
+                            .Single(button => button.IsCancel).IsEnabled, Is.False);
+                    });
+
+                    if (cancel)
+                    {
+                        var progressHost = ((Grid)window.Content).Children
+                            .OfType<OperationProgressWindowHost>().Single();
+                        progressHost.CancelCommand!.Execute(null);
+                    }
+                    else
+                        release.Set();
+                    PumpUntil(() => !isActive() && start.IsEnabled);
+                    NUnitAssert.Multiple(() =>
+                    {
+                        NUnitAssert.That(ProgressCount(window), Is.Zero);
+                        NUnitAssert.That(window.IsVisible, Is.EqualTo(fail || cancel));
+                        NUnitAssert.That(notifications, Is.EqualTo(cancel ? 0 : import || fail ? 1 : 0));
+                        if (notifications > 0)
+                        {
+                            NUnitAssert.That(progressAtNotification, Is.Zero);
+                            NUnitAssert.That(activeAtNotification, Is.False);
+                        }
+                    });
+                }
+                finally
+                {
+                    release.Set();
+                    PumpUntil(() => !isActive() && start.IsEnabled);
+                    window.Close();
+                }
+            });
+        }
+        finally
+        {
+            File.Delete(inputPath);
+        }
+    }
+
+    private static void WaitForRelease(ManualResetEventSlim release, CancellationToken token, bool fail)
+    {
+        if (!release.Wait(TimeSpan.FromSeconds(10), token))
+            throw new TimeoutException("The test did not release the operation.");
+        token.ThrowIfCancellationRequested();
+        if (fail)
+            throw new InvalidOperationException("测试异常");
+    }
+
+    private static void WithWindows(Action action)
+    {
+        WpfTestApplicationHost.InvokeWithThemeResources(WpfTestApplicationHost.EmptyServices, () =>
+        {
+            var application = Application.Current;
+            var previousMain = application.MainWindow;
+            var previousSelector = application.Resources["ViewTemplateDataSelector"];
+            application.Resources["ViewTemplateDataSelector"] = new DataTemplateSelector();
+            using var root = new AssetEditorWindow
+            {
+                Width = 600, Height = 400, Left = -10000, Top = -10000,
+                ShowInTaskbar = false,
+            };
+            application.MainWindow = root;
+            root.Show();
+            try
+            {
+                action();
+            }
+            finally
+            {
+                foreach (var window in application.Windows.OfType<Window>().Where(item => item != previousMain).ToArray())
+                    window.Close();
+                application.MainWindow = previousMain;
+                if (previousSelector == null)
+                    application.Resources.Remove("ViewTemplateDataSelector");
+                else
+                    application.Resources["ViewTemplateDataSelector"] = previousSelector;
+            }
+        });
+    }
+
+    private static void Later(Action action) =>
+        Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, action);
+
+    private static void CloseTitleBar(Window window)
+    {
+        window.UpdateLayout();
+        Click((Button)window.Template.FindName("btnClose", window));
+    }
+
+    private static void Click(Button button) => button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+    private static int ProgressCount(Window owner) => Application.Current.Windows
+        .OfType<OperationProgressWindow>().Count(window => window.Owner == owner && window.IsVisible);
+
+    private static void PumpUntil(Func<bool> completed)
+    {
+        var timeout = Stopwatch.StartNew();
+        var frame = new DispatcherFrame();
+        var timer = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromMilliseconds(10),
+        };
+        timer.Tick += (_, _) => frame.Continue = !completed() && timeout.Elapsed < TimeSpan.FromSeconds(10);
+        timer.Start();
+        try
+        {
+            Dispatcher.PushFrame(frame);
+        }
+        finally
+        {
+            timer.Stop();
+        }
+        NUnitAssert.That(completed(), Is.True, "The window workflow timed out.");
+    }
+
+    private static IEnumerable<T> FindChildren<T>(DependencyObject parent) where T : DependencyObject
+    {
+        for (var index = 0; index < System.Windows.Media.VisualTreeHelper.GetChildrenCount(parent); index++)
+        {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(parent, index);
+            if (child is T match)
+                yield return match;
+            foreach (var descendant in FindChildren<T>(child))
+                yield return descendant;
+        }
+    }
+}

--- a/Testing/AssetEditorTests/FactionColourSettingsWindowTests.cs
+++ b/Testing/AssetEditorTests/FactionColourSettingsWindowTests.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using GameWorld.Core.Services;
 using GameWorld.Core.WpfWindow.FactionColourSettings;
@@ -35,6 +36,17 @@ public class FactionColourSettingsWindowTests
                 {
                     window.Show();
                     window.UpdateLayout();
+
+                    foreach (var picker in FindVisualChildren<ColourPickerButtonView>(window))
+                    {
+                        var button = FindVisualChildren<ToggleButton>(picker).Single();
+                        var bounds = button.TransformToAncestor(picker)
+                            .TransformBounds(new Rect(button.RenderSize));
+                        NUnitAssert.That(bounds.Left, Is.GreaterThanOrEqualTo(-0.5));
+                        NUnitAssert.That(bounds.Top, Is.GreaterThanOrEqualTo(-0.5));
+                        NUnitAssert.That(bounds.Right, Is.LessThanOrEqualTo(picker.ActualWidth + 0.5));
+                        NUnitAssert.That(bounds.Bottom, Is.LessThanOrEqualTo(picker.ActualHeight + 0.5));
+                    }
 
                     NUnitAssert.Multiple(() =>
                     {

--- a/Testing/AssetEditorTests/OpenSettingsDialogCommandTests.cs
+++ b/Testing/AssetEditorTests/OpenSettingsDialogCommandTests.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using System.Windows.Threading;
 using AssetEditor.Services.Settings;
 using AssetEditor.UiCommands;
 using AssetEditor.ViewModels;
@@ -66,9 +67,12 @@ public class OpenSettingsDialogCommandTests
             _window = new SettingsWindow();
             _window.Loaded += (_, _) =>
             {
-                WasShown = true;
-                _window.DataContext = null;
-                _window.Close();
+                _window.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, () =>
+                {
+                    WasShown = _window.IsLoaded;
+                    _window.DataContext = null;
+                    _window.Close();
+                });
             };
             return _window;
         }

--- a/Testing/AssetEditorTests/ToolSelectorWindowTests.cs
+++ b/Testing/AssetEditorTests/ToolSelectorWindowTests.cs
@@ -7,6 +7,7 @@ using System.Windows.Media;
 using System.Windows.Threading;
 using CommonControls.BaseDialogs.ToolSelector;
 using NUnit.Framework;
+using Shared.Core.Services;
 using Shared.Core.ToolCreation;
 using Shared.Ui.BaseDialogs.ToolSelector;
 using NUnitAssert = NUnit.Framework.Assert;
@@ -171,9 +172,15 @@ public class ToolSelectorWindowTests
                             candidate.IsVisible &&
                             candidate.Owner == owner);
                     window.UpdateLayout();
-                    interaction(window);
-                    if (window.IsVisible)
-                        window.Close();
+                    try
+                    {
+                        interaction(window);
+                    }
+                    finally
+                    {
+                        if (window.IsVisible)
+                            window.Close();
+                    }
                 });
 
             return new ToolSelectorUiProvider().CreateAndShow(
@@ -226,7 +233,8 @@ public class ToolSelectorWindowTests
 
     private static void InvokeOpenButton(ToolSelectorWindow window)
     {
-        var button = FindVisualChildren<Button>(window).Single();
+        var button = FindVisualChildren<Button>(window).Single(candidate =>
+            Equals(candidate.Content, LocalizationManager.Instance.Get("Shared.ToolSelector.Open")));
         var peer = new ButtonAutomationPeer(button);
         var provider = (IInvokeProvider)peer.GetPattern(
             PatternInterface.Invoke);

--- a/Testing/AssetEditorTests/UiCommonWorkflowTests.cs
+++ b/Testing/AssetEditorTests/UiCommonWorkflowTests.cs
@@ -290,29 +290,6 @@ public class UiCommonWorkflowTests
     }
 
     [Test]
-    public void StandardDialogs_AssignMainWindowOwnerBeforeShowingModal()
-    {
-        var source = File.ReadAllText(Path.Combine(
-            FindSolutionRoot(),
-            "Shared",
-            "SharedUI",
-            "BaseDialogs",
-            "StandardDialog",
-            "StandardDialogs.cs"));
-
-        NUnitAssert.Multiple(() =>
-        {
-            NUnitAssert.That(source, Does.Contain("ApplyOwner"));
-            NUnitAssert.That(
-                source,
-                Does.Contain("Application.Current?.MainWindow"));
-            NUnitAssert.That(
-                source,
-                Does.Not.Contain("dialog.ShowDialog()"));
-        });
-    }
-
-    [Test]
     public void CommonDialogs_InheritTheLoadedMainWindowOwner()
     {
         using var services = new ServiceCollection()


### PR DESCRIPTION
修复关闭确认框后仍继续覆盖或删除、进度窗口尚未结束就显示结果，以及子窗口提示层级错误的问题。关闭确认框返回安全的否定结果，覆盖、删除与风险保存只有点击“是”才继续。

- 导入、导出期间阻止重复启动和提前关闭；先结束进度窗口，再恢复操作或显示结果。动画重定向和音频转换同样等待进度结束后提示。
- 标准弹窗归属于当前活动窗口；14 个窗口复用现有窗口主题，颜色选择按钮按实际可用空间布局。
- 新增真实 WPF 窗口回归测试，覆盖关闭确认、覆盖保存、子窗口归属、导入导出成功/失败/取消和进度顺序；适配窗口主题后的现有测试。

验证（复用本轮最终代码对应的本地结果）：

- `dotnet restore AssetEditor.CN.sln` 和 Release 全解决方案构建成功，93 个警告、0 个错误。测试适配后重新构建 AssetEditorTests 成功。
- 弹窗专项回归：16 通过、0 失败、0 跳过；修复前已复现相关失败。
- 最终 AssetEditorTests 排除单独对照的原生鼠标组：1343 通过、0 失败、0 跳过。复用其他未变化项目结果 2183 通过、0 失败、7 跳过；合计 3526 通过、0 失败、7 跳过。
- 本机原生鼠标组：37 通过、29 失败。用修复前程序集在同一环境对照得到完全相同的 29 项失败名单，多项报告测试窗口无法取得前台焦点；该组没有修改。全量本地测试因此不能标记全绿，合并须等待本 PR 的 GitHub 完整构建与测试通过。
- 33 类真实窗口 × 4 个主题 × 3 个 DPI，共 396 次渲染检查通过；抽查代表性中文界面。多显示器与全部真实业务入口尚未逐项人工验收。
- `git diff --cached --check` 通过。

GitHub 验证：本 PR 的 [Run-Unit-Test](https://github.com/Szy-Cathay/TheAssetEditor-CN/actions/runs/34488473834) 已通过，验证提交为 `2c5b646d4dc55a40d8b9b98b1d2d4b4743ad8c0f`。Release 构建成功；全量测试 3597 通过、0 失败、1 跳过，另 1 项需显式启用的 Gitee 在线安装测试未运行。原生鼠标组所在的 AssetEditorTests 全部 1409 项通过。